### PR TITLE
doc: add contributing-formatters and contributing-collectors guides

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   label-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/co.yml
+++ b/.github/workflows/co.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   check-skip:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   build-and-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -3,7 +3,7 @@ name: Update Release PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   update-pr:

--- a/docs/contributing-collectors.md
+++ b/docs/contributing-collectors.md
@@ -1,0 +1,379 @@
+# Contributing a New Collector
+
+This guide walks you through adding a new language/framework collector to APilot. A Collector parses source code for a specific language and produces `[]ApiEndpoint`.
+
+---
+
+## Prerequisites
+
+- Go 1.22 or higher
+- Familiarity with the [architecture guide](architecture.md)
+- Read the [main contributing guide](../CONTRIBUTING.md)
+
+---
+
+## Step 1 — Create the module directory
+
+Create a new directory at the repo root following the naming convention `api-collector-{lang}/`:
+
+```bash
+mkdir api-collector-rust
+```
+
+Use a short, lowercase language name (e.g. `rust`, `go`, `java`, `python`).
+
+---
+
+## Step 2 — Add `go.mod`
+
+Create `api-collector-rust/go.mod`:
+
+```
+module github.com/tangcent/apilot/api-collector-rust
+
+go 1.22
+
+require github.com/tangcent/apilot/api-collector v0.0.0
+```
+
+Every collector depends on `api-collector` for the `Collector` interface, `CollectContext`, and the `ApiEndpoint` model.
+
+---
+
+## Step 3 — Implement the `Collector` interface
+
+Create `api-collector-rust/collector.go` and implement the three methods defined in [`collector.Collector`](../api-collector/collector.go):
+
+```go
+package rustcollector
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+type RustCollector struct{}
+
+func New() collector.Collector { return &RustCollector{} }
+
+func (c *RustCollector) Name() string { return "rust" }
+
+func (c *RustCollector) SupportedLanguages() []string { return []string{"rust"} }
+
+func (c *RustCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	// TODO: walk source tree and extract endpoints
+	return nil, nil
+}
+```
+
+### Interface contract
+
+| Method | Requirement |
+|--------|-------------|
+| `Name()` | Return a unique lowercase identifier (e.g. `"rust"`). Must not collide with existing collectors. |
+| `SupportedLanguages()` | Return the list of language identifiers this collector handles (e.g. `["rust"]`). |
+| `Collect(ctx)` | Parse the source directory described by `ctx` and return discovered endpoints. **Return `nil, nil` (not an error) when no endpoints are found.** |
+
+### Key rules for `Collect`
+
+1. **No endpoints found** — Return `nil, nil`. Do not return an error just because the source tree has no API endpoints.
+2. **Unparseable files** — Skip them with a log warning. Do not fail the whole collection.
+3. **Protocol** — Always populate `ApiEndpoint.Protocol`. Use `"http"` for REST endpoints.
+4. **Folder** — Use `ApiEndpoint.Folder` to group related endpoints (maps to Postman folders / Markdown sections).
+5. **Frameworks** — Use `ctx.Frameworks` as a hint to limit which framework parsers run. If empty, run all.
+
+---
+
+## Step 4 — Add framework sub-packages
+
+Most languages have multiple web frameworks. Create a sub-package for each framework under `{framework}/parser.go`:
+
+```
+api-collector-rust/
+├── collector.go          # Top-level collector: dispatches to framework parsers
+├── go.mod
+├── actix/
+│   └── parser.go         # Actix-web route extraction
+└── rocket/
+    └── parser.go         # Rocket route extraction
+```
+
+Each framework parser exports a `Parse` function:
+
+```go
+// actix/parser.go
+package actix
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+	// TODO: parse Actix-web route macros
+	return nil, nil
+}
+```
+
+The top-level `Collect` method dispatches to the appropriate framework parser:
+
+```go
+func (c *RustCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	var all []collector.ApiEndpoint
+
+	frameworks := ctx.Frameworks
+	if len(frameworks) == 0 {
+		frameworks = []string{"actix", "rocket"}
+	}
+
+	for _, fw := range frameworks {
+		var eps []collector.ApiEndpoint
+		var err error
+
+		switch fw {
+		case "actix":
+			eps, err = actix.Parse(ctx.SourceDir)
+		case "rocket":
+			eps, err = rocket.Parse(ctx.SourceDir)
+		default:
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, eps...)
+	}
+
+	return all, nil
+}
+```
+
+---
+
+## Step 5 — Export the `New()` constructor
+
+Your package must export a `New() collector.Collector` function. This is the single entry point used during registration:
+
+```go
+func New() collector.Collector { return &RustCollector{} }
+```
+
+---
+
+## Step 6 — Register in `apilot-cli/main.go`
+
+Add an import and a registration call in [`apilot-cli/main.go`](../apilot-cli/main.go):
+
+```go
+import (
+	// ... existing imports ...
+	rustcollector "github.com/tangcent/apilot/api-collector-rust"
+)
+
+func init() {
+	// ... existing registrations ...
+	engine.RegisterCollector(rustcollector.New())
+}
+```
+
+Also add a detection entry in the `detectCollector` function in [`api-master/engine/engine.go`](../api-master/engine/engine.go) if the language has a well-known indicator file:
+
+```go
+{"Cargo.toml", "rust"},
+```
+
+---
+
+## Step 7 — Add fixture test data and unit tests
+
+Create a test fixture directory and write unit tests:
+
+```
+api-collector-rust/
+├── collector.go
+├── collector_test.go
+├── go.mod
+├── actix/
+│   ├── parser.go
+│   └── parser_test.go
+├── rocket/
+│   ├── parser.go
+│   └── parser_test.go
+└── testdata/
+    └── actix/
+        └── main.rs
+```
+
+### Test file: `collector_test.go`
+
+```go
+package rustcollector
+
+import (
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+)
+
+func TestName(t *testing.T) {
+	c := &RustCollector{}
+	if c.Name() != "rust" {
+		t.Fatalf("expected name 'rust', got %q", c.Name())
+	}
+}
+
+func TestSupportedLanguages(t *testing.T) {
+	c := &RustCollector{}
+	langs := c.SupportedLanguages()
+	if len(langs) == 0 {
+		t.Fatal("expected at least one supported language")
+	}
+}
+
+func TestCollect_EmptyDir(t *testing.T) {
+	c := &RustCollector{}
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  "testdata/empty",
+		Frameworks: []string{"actix"},
+	})
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for empty dir, got %d", len(endpoints))
+	}
+}
+
+func TestCollect_NoEndpoints(t *testing.T) {
+	c := &RustCollector{}
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  "testdata/no_routes",
+		Frameworks: []string{"actix"},
+	})
+	if err != nil {
+		t.Fatalf("no endpoints should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints, got %d", len(endpoints))
+	}
+}
+```
+
+### Required test cases
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Empty source directory | `Collect` returns `nil, nil`, not an error |
+| Source with no routes | `Collect` returns `nil, nil` |
+| Source with routes | Correct `ApiEndpoint` values are extracted |
+| Framework filtering | Only requested framework parsers run |
+| Name / SupportedLanguages | Interface methods return correct values |
+
+### Fixture data
+
+Place sample source files under `testdata/`. Use minimal, realistic examples:
+
+```rust
+// testdata/actix/main.rs
+use actix_web::{web, App, HttpServer};
+
+async fn get_users() -> &'static str {
+    "[]"
+}
+
+async fn create_user() -> &'static str {
+    "{}"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .route("/users", web::get().to(get_users))
+            .route("/users", web::post().to(create_user))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+```
+
+---
+
+## Step 8 — Update `docs/architecture.md`
+
+Add your collector to the **Module Map** table and the **Module Dependency Graph** in [`docs/architecture.md`](architecture.md):
+
+**Module Map** — add a row:
+
+```
+| `api-collector-rust` | Go | Rust collector (Actix, Rocket) |
+```
+
+**Module Dependency Graph** — add under `apilot-cli`:
+
+```
+├── api-collector-rust
+```
+
+And add the dependency block:
+
+```
+api-collector-rust
+  └── api-collector
+```
+
+---
+
+## Complete working example — Go collector
+
+Here is a real, minimal collector from the codebase ([`api-collector-go/collector.go`](../api-collector-go/collector.go)):
+
+```go
+package gocollector
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+type GoCollector struct{}
+
+func New() collector.Collector { return &GoCollector{} }
+
+func (c *GoCollector) Name() string { return "go" }
+
+func (c *GoCollector) SupportedLanguages() []string { return []string{"go"} }
+
+func (c *GoCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	// 1. Walk .go files under ctx.SourceDir using go/parser
+	// 2. Delegate to gin/, echo/, fiber/ sub-packages
+	return nil, nil
+}
+```
+
+And a framework sub-package ([`api-collector-go/gin/parser.go`](../api-collector-go/gin/parser.go)):
+
+```go
+package gin
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+	// Walk the AST for gin.RouterGroup.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS calls
+	return nil, nil
+}
+```
+
+The Go collector currently supports three frameworks — Gin, Echo, and Fiber — each with its own `parser.go` under the framework sub-directory.
+
+---
+
+## Checklist
+
+Before submitting your PR, verify:
+
+- [ ] Module directory is named `api-collector-{lang}/`
+- [ ] `go.mod` declares dependency on `api-collector`
+- [ ] `Collector` interface is fully implemented (`Name`, `SupportedLanguages`, `Collect`)
+- [ ] `Collect` returns `nil, nil` (not an error) when no endpoints are found
+- [ ] Framework sub-packages are under `{framework}/parser.go`
+- [ ] `New() collector.Collector` constructor is exported
+- [ ] Collector is registered in `apilot-cli/main.go`
+- [ ] Detection entry is added in `api-master/engine/engine.go` (if applicable)
+- [ ] Fixture test data and unit tests are included
+- [ ] `docs/architecture.md` module map and dependency graph are updated
+- [ ] `go test ./api-collector-{lang}/...` passes
+- [ ] `go vet ./api-collector-{lang}/...` passes

--- a/docs/contributing-formatters.md
+++ b/docs/contributing-formatters.md
@@ -1,0 +1,295 @@
+# Contributing a New Formatter
+
+This guide walks you through adding a new output formatter to APilot. A Formatter converts `[]ApiEndpoint` into a specific output format (Markdown, cURL, Postman, OpenAPI, etc.).
+
+---
+
+## Prerequisites
+
+- Go 1.22 or higher
+- Familiarity with the [architecture guide](architecture.md)
+- Read the [main contributing guide](../CONTRIBUTING.md)
+
+---
+
+## Step 1 — Create the module directory
+
+Create a new directory at the repo root following the naming convention `api-formatter-{name}/`:
+
+```bash
+mkdir api-formatter-openapi
+```
+
+Use a short, lowercase name that describes the output format (e.g. `openapi`, `curl`, `postman`).
+
+---
+
+## Step 2 — Add `go.mod`
+
+Create `api-formatter-openapi/go.mod`:
+
+```
+module github.com/tangcent/apilot/api-formatter-openapi
+
+go 1.22
+
+require (
+	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-formatter v0.0.0
+)
+```
+
+Every formatter depends on both `api-collector` (for the `ApiEndpoint` type) and `api-formatter` (for the `Formatter` interface and `FormatOptions`).
+
+---
+
+## Step 3 — Implement the `Formatter` interface
+
+Create `api-formatter-openapi/formatter.go` and implement the three methods defined in [`formatter.Formatter`](../api-formatter/formatter.go):
+
+```go
+package openapi
+
+import (
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+type OpenAPIFormatter struct{}
+
+func New() formatter.Formatter { return &OpenAPIFormatter{} }
+
+func (f *OpenAPIFormatter) Name() string { return "openapi" }
+
+func (f *OpenAPIFormatter) SupportedFormats() []string { return []string{"openapi"} }
+
+func (f *OpenAPIFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	// TODO: convert endpoints to OpenAPI 3.0 YAML/JSON
+	return nil, nil
+}
+```
+
+### Interface contract
+
+| Method | Requirement |
+|--------|-------------|
+| `Name()` | Return a unique lowercase identifier (e.g. `"openapi"`). Must not collide with existing formatters. |
+| `SupportedFormats()` | Return the list of format variant names this formatter handles. For a single-variant formatter, return a one-element slice. |
+| `Format(endpoints, opts)` | Convert `[]ApiEndpoint` to `[]byte`. **An empty `endpoints` slice MUST return valid empty output, not an error.** |
+
+### Key rules for `Format`
+
+1. **Empty input** — When `len(endpoints) == 0`, return valid empty output for your format (e.g. an empty JSON array `[]`, an empty Markdown document, a valid but empty Postman collection). Never return an error.
+2. **Format variant** — Use `opts.Format` to select the output variant. If empty, default to the first entry in `SupportedFormats()`.
+3. **Config** — Use `opts.Config` for formatter-specific key-value options (e.g. collection name, template path).
+
+---
+
+## Step 4 — Export the `New()` constructor
+
+Your package must export a `New() formatter.Formatter` function. This is the single entry point used during registration:
+
+```go
+func New() formatter.Formatter { return &OpenAPIFormatter{} }
+```
+
+---
+
+## Step 5 — Register in `apilot-cli/main.go`
+
+Add an import and a registration call in [`apilot-cli/main.go`](../apilot-cli/main.go):
+
+```go
+import (
+	// ... existing imports ...
+	openapifmt "github.com/tangcent/apilot/api-formatter-openapi"
+)
+
+func init() {
+	// ... existing registrations ...
+	engine.RegisterFormatter(openapifmt.New())
+}
+```
+
+---
+
+## Step 6 — Write unit tests
+
+Create `api-formatter-openapi/formatter_test.go`:
+
+```go
+package openapi
+
+import (
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+func TestFormat_EmptyInput(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	out, err := f.Format(nil, formatter.FormatOptions{})
+	if err != nil {
+		t.Fatalf("empty input should not error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("empty input should produce valid empty output, not nil/empty bytes")
+	}
+}
+
+func TestFormat_SingleEndpoint(t *testing.T) {
+	endpoints := []collector.ApiEndpoint{
+		{
+			Name:     "ListUsers",
+			Path:     "/users",
+			Method:   "GET",
+			Protocol: "http",
+		},
+	}
+	f := &OpenAPIFormatter{}
+	out, err := f.Format(endpoints, formatter.FormatOptions{Format: "openapi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+}
+
+func TestName(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	if f.Name() != "openapi" {
+		t.Fatalf("expected name 'openapi', got %q", f.Name())
+	}
+}
+
+func TestSupportedFormats(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	formats := f.SupportedFormats()
+	if len(formats) == 0 {
+		t.Fatal("expected at least one supported format")
+	}
+}
+```
+
+### Required test cases
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Empty input | `Format(nil, ...)` returns valid output, not an error |
+| Single endpoint | Basic formatting works for one endpoint |
+| Multiple endpoints | Output is correct for a slice with several entries |
+| Round-trip | (If applicable) Parse the output back and verify it matches the input |
+| Name / SupportedFormats | Interface methods return correct values |
+
+---
+
+## Step 7 — Update `docs/architecture.md`
+
+Add your formatter to the **Module Map** table and the **Module Dependency Graph** in [`docs/architecture.md`](architecture.md):
+
+**Module Map** — add a row:
+
+```
+| `api-formatter-openapi` | Go | OpenAPI 3.0 YAML/JSON formatter |
+```
+
+**Module Dependency Graph** — add under `apilot-cli`:
+
+```
+├── api-formatter-openapi
+```
+
+And add the dependency block:
+
+```
+api-formatter-openapi
+  ├── api-collector  (for ApiEndpoint type)
+  └── api-formatter
+```
+
+---
+
+## Complete working example — cURL formatter
+
+Here is a real, minimal formatter from the codebase ([`api-formatter-curl/formatter.go`](../api-formatter-curl/formatter.go)):
+
+```go
+package curl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+type CurlFormatter struct{}
+
+func New() formatter.Formatter { return &CurlFormatter{} }
+
+func (f *CurlFormatter) Name() string { return "curl" }
+
+func (f *CurlFormatter) SupportedFormats() []string { return []string{"curl"} }
+
+func (f *CurlFormatter) Format(endpoints []collector.ApiEndpoint, _ formatter.FormatOptions) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, ep := range endpoints {
+		if i > 0 {
+			buf.WriteString("\n\n")
+		}
+		buf.WriteString(buildCurl(ep))
+	}
+	return buf.Bytes(), nil
+}
+
+func buildCurl(ep collector.ApiEndpoint) string {
+	var sb strings.Builder
+	method := ep.Method
+	if method == "" {
+		method = "GET"
+	}
+	sb.WriteString(fmt.Sprintf("curl -X %s", method))
+	for _, h := range ep.Headers {
+		sb.WriteString(fmt.Sprintf(" \\\n  -H '%s: %s'", h.Name, h.Value))
+	}
+	var queryParts []string
+	for _, p := range ep.Parameters {
+		if p.In == "query" {
+			queryParts = append(queryParts, fmt.Sprintf("%s=", p.Name))
+		}
+	}
+	path := ep.Path
+	if len(queryParts) > 0 {
+		path += "?" + strings.Join(queryParts, "&")
+	}
+	sb.WriteString(fmt.Sprintf(" \\\n  'http://localhost%s'", path))
+	if ep.RequestBody != nil {
+		sb.WriteString(" \\\n  -H 'Content-Type: application/json'")
+		sb.WriteString(" \\\n  -d '{}'")
+	}
+	return sb.String()
+}
+```
+
+Note how `Format` handles the empty case naturally — the loop simply doesn't execute, and `buf.Bytes()` returns an empty (but valid) byte slice.
+
+---
+
+## Checklist
+
+Before submitting your PR, verify:
+
+- [ ] Module directory is named `api-formatter-{name}/`
+- [ ] `go.mod` declares dependencies on `api-collector` and `api-formatter`
+- [ ] `Formatter` interface is fully implemented (`Name`, `SupportedFormats`, `Format`)
+- [ ] Empty `endpoints` slice returns valid output, not an error
+- [ ] `New() formatter.Formatter` constructor is exported
+- [ ] Formatter is registered in `apilot-cli/main.go`
+- [ ] Unit tests cover empty input, single endpoint, and multiple endpoints
+- [ ] `docs/architecture.md` module map and dependency graph are updated
+- [ ] `go test ./api-formatter-{name}/...` passes
+- [ ] `go vet ./api-formatter-{name}/...` passes

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -125,6 +125,6 @@
 - [ ] Update `docs/architecture.md` — fix CI pipeline table to reflect actual workflow filenames (`ci.yml`, `co.yml`)
 - [ ] Update `docs/architecture.md` — fix config dir reference from `~/.config/api-master/` to `~/.config/apilot/`
 - [ ] Update `docs/architecture.md` — fix build commands to use `apilot` binary name (not `apilot-cli`)
-- [ ] Remove `docs/apilot-readme-draft.md` — content has been merged into `README.md`
-- [ ] Add `docs/contributing-collectors.md` — step-by-step guide for adding a new language collector
-- [ ] Add `docs/contributing-formatters.md` — step-by-step guide for adding a new output formatter
+- [X] Remove `docs/apilot-readme-draft.md` — content has been merged into `README.md`
+- [X] Add `docs/contributing-collectors.md` — step-by-step guide for adding a new language collector
+- [X] Add `docs/contributing-formatters.md` — step-by-step guide for adding a new output formatter

--- a/go.work
+++ b/go.work
@@ -1,0 +1,15 @@
+go 1.22
+
+use (
+	./api-collector
+	./api-formatter
+	./api-collector-go
+	./api-collector-java
+	./api-collector-node
+	./api-collector-python
+	./api-formatter-curl
+	./api-formatter-markdown
+	./api-formatter-postman
+	./api-master
+	./apilot-cli
+)


### PR DESCRIPTION
## Changes

- Add `docs/contributing-formatters.md` — step-by-step guide for contributors adding a new output formatter
- Add `docs/contributing-collectors.md` — step-by-step guide for contributors adding a new language collector

Both guides cover:
- Creating the module directory with `go.mod`
- Implementing the interface (`Formatter` / `Collector`)
- Handling empty input correctly
- Exporting the `New()` constructor
- Registering in `apilot-cli/main.go`
- Writing unit tests with required test cases
- Updating `docs/architecture.md`
- A complete working example from the codebase
- A pre-submission checklist

Closes #45
Closes #46
Closes #48