### PR TITLE
feat: add build.Version / build.Date ldflags wiring

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   label-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/co.yml
+++ b/.github/workflows/co.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   check-skip:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   build-and-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -3,7 +3,7 @@ name: Update Release PR
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   update-pr:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle/
-build/
+/build/
 .idea/
 .kotlin/
 *.jar
@@ -12,6 +12,8 @@ bin/
 .bin/
 .intellijPlatform/
 .DS_Store
+.cursor/
+.claude/
 .kiro/
 .trae/
 .qodo/

--- a/api-collector-go/collector.go
+++ b/api-collector-go/collector.go
@@ -2,7 +2,7 @@
 // Supported frameworks: Gin, Echo, Fiber.
 package gocollector
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // GoCollector parses Go source trees for API route registrations.
 type GoCollector struct{}

--- a/api-collector-go/echo/parser.go
+++ b/api-collector-go/echo/parser.go
@@ -1,7 +1,7 @@
 // Package echo parses Echo route registrations using Go's standard go/ast package.
 package echo
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Echo route registrations in the given source directory.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -1,7 +1,7 @@
 // Package fiber parses Fiber route registrations using Go's standard go/ast package.
 package fiber
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Fiber route registrations in the given source directory.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-go/gin/parser.go
+++ b/api-collector-go/gin/parser.go
@@ -1,7 +1,7 @@
 // Package gin parses Gin route registrations using Go's standard go/ast package.
 package gin
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Gin route registrations in the given source directory.
 // It walks the AST for gin.RouterGroup.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS calls.

--- a/api-collector-go/go.mod
+++ b/api-collector-go/go.mod
@@ -3,3 +3,5 @@ module github.com/tangcent/apilot/api-collector-go
 go 1.22
 
 require github.com/tangcent/apilot/api-collector v0.0.0
+
+replace github.com/tangcent/apilot/api-collector => ../api-collector

--- a/api-collector-java/collector.go
+++ b/api-collector-java/collector.go
@@ -2,7 +2,7 @@
 // Supported frameworks: Spring MVC, JAX-RS, Feign.
 package javacollector
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // JavaCollector parses Java/Kotlin source trees for API endpoints.
 type JavaCollector struct{}

--- a/api-collector-java/feign/parser.go
+++ b/api-collector-java/feign/parser.go
@@ -1,7 +1,7 @@
 // Package feign parses Feign client interfaces for API endpoints.
 package feign
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from @FeignClient annotated interfaces under sourceDir.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-java/go.mod
+++ b/api-collector-java/go.mod
@@ -3,3 +3,5 @@ module github.com/tangcent/apilot/api-collector-java
 go 1.22
 
 require github.com/tangcent/apilot/api-collector v0.0.0
+
+replace github.com/tangcent/apilot/api-collector => ../api-collector

--- a/api-collector-java/jaxrs/parser.go
+++ b/api-collector-java/jaxrs/parser.go
@@ -1,7 +1,7 @@
 // Package jaxrs parses JAX-RS annotated classes for API endpoints.
 package jaxrs
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from JAX-RS annotated source files under sourceDir.
 // It looks for @Path, @GET, @POST, @PUT, @DELETE, @Produces, @Consumes.

--- a/api-collector-java/springmvc/parser.go
+++ b/api-collector-java/springmvc/parser.go
@@ -1,7 +1,7 @@
 // Package springmvc parses Spring MVC controller classes for API endpoints.
 package springmvc
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Spring MVC annotated source files under sourceDir.
 // It looks for @RestController, @RequestMapping, @GetMapping, @PostMapping, etc.

--- a/api-collector-node/collector.go
+++ b/api-collector-node/collector.go
@@ -2,7 +2,7 @@
 // Supported frameworks: Express, Fastify, NestJS.
 package nodecollector
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // NodeCollector parses TypeScript/JavaScript source trees for API route definitions.
 type NodeCollector struct{}

--- a/api-collector-node/express/parser.go
+++ b/api-collector-node/express/parser.go
@@ -1,7 +1,7 @@
 // Package express parses Express route registrations.
 package express
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Express route registrations (app.get, router.use, etc.).
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-node/fastify/parser.go
+++ b/api-collector-node/fastify/parser.go
@@ -1,7 +1,7 @@
 // Package fastify parses Fastify route registrations.
 package fastify
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Fastify route registrations (fastify.get, fastify.post, etc.).
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-node/go.mod
+++ b/api-collector-node/go.mod
@@ -3,3 +3,5 @@ module github.com/tangcent/apilot/api-collector-node
 go 1.22
 
 require github.com/tangcent/apilot/api-collector v0.0.0
+
+replace github.com/tangcent/apilot/api-collector => ../api-collector

--- a/api-collector-node/nestjs/parser.go
+++ b/api-collector-node/nestjs/parser.go
@@ -1,7 +1,7 @@
 // Package nestjs parses NestJS decorated controller classes.
 package nestjs
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from NestJS @Controller, @Get, @Post, etc. decorated classes.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-python/collector.go
+++ b/api-collector-python/collector.go
@@ -2,7 +2,7 @@
 // Supported frameworks: FastAPI, Django REST Framework, Flask.
 package pycollector
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // PythonCollector parses Python source trees for API route definitions.
 type PythonCollector struct{}

--- a/api-collector-python/django/parser.go
+++ b/api-collector-python/django/parser.go
@@ -1,7 +1,7 @@
 // Package django parses Django REST Framework views and URL patterns.
 package django
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Django REST Framework @api_view, APIView, ViewSet classes
 // and urlpatterns definitions.

--- a/api-collector-python/fastapi/parser.go
+++ b/api-collector-python/fastapi/parser.go
@@ -1,7 +1,7 @@
 // Package fastapi parses FastAPI decorated route functions.
 package fastapi
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from FastAPI @app.get, @router.post, etc. decorated functions.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-python/flask/parser.go
+++ b/api-collector-python/flask/parser.go
@@ -1,7 +1,7 @@
 // Package flask parses Flask route decorators.
 package flask
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Parse extracts endpoints from Flask @app.route and @blueprint.route decorated functions.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {

--- a/api-collector-python/go.mod
+++ b/api-collector-python/go.mod
@@ -3,3 +3,5 @@ module github.com/tangcent/apilot/api-collector-python
 go 1.22
 
 require github.com/tangcent/apilot/api-collector v0.0.0
+
+replace github.com/tangcent/apilot/api-collector => ../api-collector

--- a/api-formatter-curl/formatter.go
+++ b/api-formatter-curl/formatter.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 // CurlFormatter formats endpoints as cURL commands.

--- a/api-formatter-curl/go.mod
+++ b/api-formatter-curl/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/tangcent/apilot/api-collector v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-formatter => ../api-formatter
+)

--- a/api-formatter-markdown/formatter.go
+++ b/api-formatter-markdown/formatter.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"text/template"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 //go:embed templates/simple.md.tmpl

--- a/api-formatter-markdown/go.mod
+++ b/api-formatter-markdown/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/tangcent/apilot/api-collector v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-formatter => ../api-formatter
+)

--- a/api-formatter-postman/formatter.go
+++ b/api-formatter-postman/formatter.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 	"github.com/tangcent/apilot/api-formatter-postman/model"
 )
 

--- a/api-formatter-postman/go.mod
+++ b/api-formatter-postman/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/tangcent/apilot/api-collector v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-formatter => ../api-formatter
+)

--- a/api-formatter/formatter.go
+++ b/api-formatter/formatter.go
@@ -2,7 +2,7 @@
 // A Formatter converts []ApiEndpoint into a specific output format (Markdown, cURL, Postman, etc.).
 package formatter
 
-import "github.com/tangcent/apilot/api-collector/collector"
+import "github.com/tangcent/apilot/api-collector"
 
 // Formatter is the interface every output formatter must implement.
 type Formatter interface {

--- a/api-formatter/go.mod
+++ b/api-formatter/go.mod
@@ -3,3 +3,5 @@ module github.com/tangcent/apilot/api-formatter
 go 1.22
 
 require github.com/tangcent/apilot/api-collector v0.0.0
+
+replace github.com/tangcent/apilot/api-collector => ../api-collector

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -2,11 +2,14 @@
 package engine
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
+	"github.com/tangcent/apilot/api-master/config"
+	"github.com/tangcent/apilot/api-master/plugin"
 )
 
 // Config holds the runtime configuration for a single engine run.
@@ -102,7 +105,89 @@ func writeOutput(path string, data []byte) error {
 
 // RunCLI parses os.Args and calls Run. Used by apilot-cli and api-master main.
 func RunCLI() {
-	// TODO: implement flag parsing (--collector, --formatter, --output, --format,
-	//       --plugin-registry, --list-collectors, --list-formatters)
-	panic("RunCLI: not yet implemented")
+	var (
+		collectorName  string
+		formatterName  string
+		formatVariant  string
+		outputPath     string
+		pluginRegistry string
+		listCollectors bool
+		listFormatters bool
+	)
+
+	flag.StringVar(&collectorName, "collector", "", "collector name (auto-detect if omitted)")
+	flag.StringVar(&formatterName, "formatter", "markdown", "formatter name (default: markdown)")
+	flag.StringVar(&formatVariant, "format", "", "format variant passed to formatter")
+	flag.StringVar(&outputPath, "output", "", "output file path (default: stdout)")
+	flag.StringVar(&pluginRegistry, "plugin-registry", "", "path to plugins.json")
+	flag.BoolVar(&listCollectors, "list-collectors", false, "print registered collectors and exit")
+	flag.BoolVar(&listFormatters, "list-formatters", false, "print registered formatters and exit")
+
+	flag.Parse()
+
+	if pluginRegistry == "" {
+		pluginRegistry = config.DefaultPluginRegistryPath()
+	}
+
+	if err := plugin.LoadRegistry(pluginRegistry, RegisterCollector, RegisterFormatter); err != nil {
+		fmt.Fprintf(os.Stderr, "error loading plugin registry: %v\n", err)
+		os.Exit(1)
+	}
+
+	if listCollectors {
+		printCollectors()
+		return
+	}
+
+	if listFormatters {
+		printFormatters()
+		return
+	}
+
+	args := flag.Args()
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "error: source path required\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	sourceDir := args[0]
+
+	cfg := Config{
+		SourceDir:      sourceDir,
+		CollectorName:  collectorName,
+		FormatterName:  formatterName,
+		FormatVariant:  formatVariant,
+		OutputPath:     outputPath,
+		PluginRegistry: pluginRegistry,
+	}
+
+	if err := Run(cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func printCollectors() {
+	collectors := ListCollectors()
+	if len(collectors) == 0 {
+		fmt.Println("No collectors registered.")
+		return
+	}
+	fmt.Println("Registered collectors:")
+	for name, langs := range collectors {
+		fmt.Printf("  %s: %v\n", name, langs)
+	}
+}
+
+func printFormatters() {
+	formatters := ListFormatters()
+	if len(formatters) == 0 {
+		fmt.Println("No formatters registered.")
+		return
+	}
+	fmt.Println("Registered formatters:")
+	for name, formats := range formatters {
+		fmt.Printf("  %s: %v\n", name, formats)
+	}
 }

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -1,0 +1,100 @@
+package engine
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"strings"
+	"testing"
+)
+
+func resetFlags() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(&bytes.Buffer{})
+}
+
+func TestRunCLI_ListCollectors(t *testing.T) {
+	resetFlags()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"api-master", "--list-collectors"}
+
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = originalStdout
+	output.ReadFrom(r)
+
+	result := output.String()
+	if !strings.Contains(result, "No collectors registered") {
+		t.Errorf("Expected 'No collectors registered' in output, got: %s", result)
+	}
+}
+
+func TestRunCLI_ListFormatters(t *testing.T) {
+	resetFlags()
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"api-master", "--list-formatters"}
+
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = originalStdout
+	output.ReadFrom(r)
+
+	result := output.String()
+	if !strings.Contains(result, "No formatters registered") {
+		t.Errorf("Expected 'No formatters registered' in output, got: %s", result)
+	}
+}
+
+func TestPrintCollectors_NoCollectors(t *testing.T) {
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printCollectors()
+
+	w.Close()
+	os.Stdout = originalStdout
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	result := buf.String()
+
+	if !strings.Contains(result, "No collectors registered") {
+		t.Errorf("Expected 'No collectors registered' in output, got: %s", result)
+	}
+}
+
+func TestPrintFormatters_NoFormatters(t *testing.T) {
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printFormatters()
+
+	w.Close()
+	os.Stdout = originalStdout
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	result := buf.String()
+
+	if !strings.Contains(result, "No formatters registered") {
+		t.Errorf("Expected 'No formatters registered' in output, got: %s", result)
+	}
+}

--- a/api-master/engine/registry.go
+++ b/api-master/engine/registry.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 var (

--- a/api-master/go.mod
+++ b/api-master/go.mod
@@ -6,3 +6,8 @@ require (
 	github.com/tangcent/apilot/api-collector v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-formatter => ../api-formatter
+)

--- a/api-master/plugin/registry.go
+++ b/api-master/plugin/registry.go
@@ -6,12 +6,13 @@ import (
 	"log"
 	"os"
 
-	"github.com/tangcent/apilot/api-master/engine"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 // LoadRegistry reads the plugin registry file at path and registers all valid entries.
 // Invalid or missing plugin paths are logged as warnings and skipped.
-func LoadRegistry(path string) error {
+func LoadRegistry(path string, registerCollector func(collector.Collector), registerFormatter func(formatter.Formatter)) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -26,27 +27,27 @@ func LoadRegistry(path string) error {
 	}
 
 	for _, m := range reg.Plugins {
-		if err := registerManifest(m); err != nil {
+		if err := registerManifest(m, registerCollector, registerFormatter); err != nil {
 			log.Printf("warning: skipping plugin %q: %v", m.Name, err)
 		}
 	}
 	return nil
 }
 
-func registerManifest(m PluginManifest) error {
+func registerManifest(m PluginManifest, registerCollector func(collector.Collector), registerFormatter func(formatter.Formatter)) error {
 	switch m.Type {
 	case "collector":
 		c, err := newSubprocessCollector(m)
 		if err != nil {
 			return err
 		}
-		engine.RegisterCollector(c)
+		registerCollector(c)
 	case "formatter":
 		f, err := newSubprocessFormatter(m)
 		if err != nil {
 			return err
 		}
-		engine.RegisterFormatter(f)
+		registerFormatter(f)
 	default:
 		return fmt.Errorf("unknown plugin type %q", m.Type)
 	}

--- a/api-master/plugin/registry_test.go
+++ b/api-master/plugin/registry_test.go
@@ -1,0 +1,283 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
+)
+
+type mockCollector struct {
+	name              string
+	supportedLangs    []string
+	collectCalled     bool
+	collectContext    collector.CollectContext
+	collectEndpoints  []collector.ApiEndpoint
+	collectError      error
+}
+
+func (m *mockCollector) Name() string {
+	return m.name
+}
+
+func (m *mockCollector) SupportedLanguages() []string {
+	return m.supportedLangs
+}
+
+func (m *mockCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	m.collectCalled = true
+	m.collectContext = ctx
+	return m.collectEndpoints, m.collectError
+}
+
+type mockFormatter struct {
+	name             string
+	supportedFormats []string
+	formatCalled     bool
+	formatEndpoints  []collector.ApiEndpoint
+	formatOpts       formatter.FormatOptions
+	formatOutput     []byte
+	formatError      error
+}
+
+func (m *mockFormatter) Name() string {
+	return m.name
+}
+
+func (m *mockFormatter) SupportedFormats() []string {
+	return m.supportedFormats
+}
+
+func (m *mockFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	m.formatCalled = true
+	m.formatEndpoints = endpoints
+	m.formatOpts = opts
+	return m.formatOutput, m.formatError
+}
+
+func TestLoadRegistry_NonExistentFile(t *testing.T) {
+	registeredCollectors := make(map[string]collector.Collector)
+	registeredFormatters := make(map[string]formatter.Formatter)
+
+	registerCollector := func(c collector.Collector) {
+		registeredCollectors[c.Name()] = c
+	}
+	registerFormatter := func(f formatter.Formatter) {
+		registeredFormatters[f.Name()] = f
+	}
+
+	err := LoadRegistry("/nonexistent/plugins.json", registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error for non-existent file, got: %v", err)
+	}
+
+	if len(registeredCollectors) != 0 {
+		t.Errorf("Expected 0 collectors, got: %d", len(registeredCollectors))
+	}
+
+	if len(registeredFormatters) != 0 {
+		t.Errorf("Expected 0 formatters, got: %d", len(registeredFormatters))
+	}
+}
+
+func TestLoadRegistry_ValidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "test-collector",
+      "type": "collector",
+      "command": "echo"
+    },
+    {
+      "name": "test-formatter",
+      "type": "formatter",
+      "command": "echo"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registeredCollectors := make(map[string]collector.Collector)
+	registeredFormatters := make(map[string]formatter.Formatter)
+
+	registerCollector := func(c collector.Collector) {
+		registeredCollectors[c.Name()] = c
+	}
+	registerFormatter := func(f formatter.Formatter) {
+		registeredFormatters[f.Name()] = f
+	}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if _, ok := registeredCollectors["test-collector"]; !ok {
+		t.Error("Expected test-collector to be registered")
+	}
+
+	if _, ok := registeredFormatters["test-formatter"]; !ok {
+		t.Error("Expected test-formatter to be registered")
+	}
+}
+
+func TestLoadRegistry_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `invalid json`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registerCollector := func(c collector.Collector) {}
+	registerFormatter := func(f formatter.Formatter) {}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err == nil {
+		t.Error("Expected error for invalid JSON, got nil")
+	}
+}
+
+func TestLoadRegistry_UnknownPluginType(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "test-plugin",
+      "type": "unknown"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registerCollector := func(c collector.Collector) {}
+	registerFormatter := func(f formatter.Formatter) {}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error (unknown plugins should be skipped), got: %v", err)
+	}
+}
+
+func TestLoadRegistry_MissingCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "test-collector",
+      "type": "collector"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registerCollector := func(c collector.Collector) {}
+	registerFormatter := func(f formatter.Formatter) {}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error (invalid plugins should be skipped), got: %v", err)
+	}
+}
+
+func TestLoadRegistry_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registerCollector := func(c collector.Collector) {}
+	registerFormatter := func(f formatter.Formatter) {}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error for empty plugins, got: %v", err)
+	}
+}
+
+func TestLoadRegistry_MultiplePlugins(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "collector1",
+      "type": "collector",
+      "command": "echo"
+    },
+    {
+      "name": "collector2",
+      "type": "collector",
+      "command": "echo"
+    },
+    {
+      "name": "formatter1",
+      "type": "formatter",
+      "command": "echo"
+    },
+    {
+      "name": "formatter2",
+      "type": "formatter",
+      "command": "echo"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registeredCollectors := make(map[string]collector.Collector)
+	registeredFormatters := make(map[string]formatter.Formatter)
+
+	registerCollector := func(c collector.Collector) {
+		registeredCollectors[c.Name()] = c
+	}
+	registerFormatter := func(f formatter.Formatter) {
+		registeredFormatters[f.Name()] = f
+	}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if len(registeredCollectors) != 2 {
+		t.Errorf("Expected 2 collectors, got: %d", len(registeredCollectors))
+	}
+
+	if len(registeredFormatters) != 2 {
+		t.Errorf("Expected 2 formatters, got: %d", len(registeredFormatters))
+	}
+}

--- a/api-master/plugin/subprocess.go
+++ b/api-master/plugin/subprocess.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/tangcent/apilot/api-collector/collector"
-	"github.com/tangcent/apilot/api-formatter/formatter"
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 // subprocessCollector wraps an external binary as a collector.Collector.

--- a/apilot-cli/build/version.go
+++ b/apilot-cli/build/version.go
@@ -1,0 +1,6 @@
+package build
+
+var (
+	Version = "dev"
+	Date    = "unknown"
+)

--- a/apilot-cli/go.mod
+++ b/apilot-cli/go.mod
@@ -3,12 +3,30 @@ module github.com/tangcent/apilot/apilot-cli
 go 1.22
 
 require (
-	github.com/tangcent/apilot/api-master v0.0.0
-	github.com/tangcent/apilot/api-collector-java v0.0.0
 	github.com/tangcent/apilot/api-collector-go v0.0.0
+	github.com/tangcent/apilot/api-collector-java v0.0.0
 	github.com/tangcent/apilot/api-collector-node v0.0.0
 	github.com/tangcent/apilot/api-collector-python v0.0.0
-	github.com/tangcent/apilot/api-formatter-markdown v0.0.0
 	github.com/tangcent/apilot/api-formatter-curl v0.0.0
+	github.com/tangcent/apilot/api-formatter-markdown v0.0.0
 	github.com/tangcent/apilot/api-formatter-postman v0.0.0
+	github.com/tangcent/apilot/api-master v0.0.0
+)
+
+require (
+	github.com/tangcent/apilot/api-collector v0.0.0 // indirect
+	github.com/tangcent/apilot/api-formatter v0.0.0 // indirect
+)
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-collector-go => ../api-collector-go
+	github.com/tangcent/apilot/api-collector-java => ../api-collector-java
+	github.com/tangcent/apilot/api-collector-node => ../api-collector-node
+	github.com/tangcent/apilot/api-collector-python => ../api-collector-python
+	github.com/tangcent/apilot/api-formatter => ../api-formatter
+	github.com/tangcent/apilot/api-formatter-curl => ../api-formatter-curl
+	github.com/tangcent/apilot/api-formatter-markdown => ../api-formatter-markdown
+	github.com/tangcent/apilot/api-formatter-postman => ../api-formatter-postman
+	github.com/tangcent/apilot/api-master => ../api-master
 )

--- a/apilot-cli/main.go
+++ b/apilot-cli/main.go
@@ -1,18 +1,17 @@
-// apilot-cli is the batteries-included CLI binary.
-// It statically links all built-in collectors and formatters and delegates to the api-master engine.
-// No external plugin registry is required for standard use.
 package main
 
 import (
-	"github.com/tangcent/apilot/api-master/engine"
+	"fmt"
+	"os"
 
-	// Collectors
+	"github.com/tangcent/apilot/api-master/engine"
+	"github.com/tangcent/apilot/apilot-cli/build"
+
 	gocollector   "github.com/tangcent/apilot/api-collector-go"
 	javacollector "github.com/tangcent/apilot/api-collector-java"
 	nodecollector "github.com/tangcent/apilot/api-collector-node"
 	pycollector   "github.com/tangcent/apilot/api-collector-python"
 
-	// Formatters
 	curlfmt    "github.com/tangcent/apilot/api-formatter-curl"
 	mdfmt      "github.com/tangcent/apilot/api-formatter-markdown"
 	postmanfmt "github.com/tangcent/apilot/api-formatter-postman"
@@ -30,5 +29,12 @@ func init() {
 }
 
 func main() {
+	for _, arg := range os.Args[1:] {
+		if arg == "--version" || arg == "-v" {
+			fmt.Printf("apilot %s (built %s)\n", build.Version, build.Date)
+			os.Exit(0)
+		}
+	}
+
 	engine.RunCLI()
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,7 +152,7 @@ For subprocess plugins, `CollectContext` is written as JSON to the subprocess st
 
 Any binary that speaks the stdin/stdout JSON protocol can be registered as a plugin without recompiling `apilot-cli`. See [plugin-protocol.md](plugin-protocol.md).
 
-Register in `~/.config/api-master/plugins.json`:
+Register in `~/.config/apilot/plugins.json`:
 
 ```json
 {
@@ -174,12 +174,12 @@ Register in `~/.config/api-master/plugins.json`:
 ### Go modules
 
 ```bash
-# Build apilot-cli for all platforms
-GOOS=linux   GOARCH=amd64 go build -o bin/apilot-cli-linux-amd64   ./apilot-cli
-GOOS=linux   GOARCH=arm64 go build -o bin/apilot-cli-linux-arm64   ./apilot-cli
-GOOS=darwin  GOARCH=amd64 go build -o bin/apilot-cli-darwin-amd64  ./apilot-cli
-GOOS=darwin  GOARCH=arm64 go build -o bin/apilot-cli-darwin-arm64  ./apilot-cli
-GOOS=windows GOARCH=amd64 go build -o bin/apilot-cli-windows-amd64.exe ./apilot-cli
+# Build apilot for all platforms
+GOOS=linux   GOARCH=amd64 go build -o bin/apilot-linux-amd64   ./apilot-cli
+GOOS=linux   GOARCH=arm64 go build -o bin/apilot-linux-arm64   ./apilot-cli
+GOOS=darwin  GOARCH=amd64 go build -o bin/apilot-darwin-amd64  ./apilot-cli
+GOOS=darwin  GOARCH=arm64 go build -o bin/apilot-darwin-arm64  ./apilot-cli
+GOOS=windows GOARCH=amd64 go build -o bin/apilot-windows-amd64.exe ./apilot-cli
 ```
 
 ### VSCode extension
@@ -206,9 +206,8 @@ cd jetbrains-plugin
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `.github/workflows/ci-go.yml` | push / PR | `go test ./...` + `go vet ./...` for all Go modules |
-| `.github/workflows/ci-jetbrains.yml` | push / PR | `./gradlew test buildPlugin` |
-| `.github/workflows/ci-vscode.yml` | push / PR | `npm ci && npm run compile && npm test` |
+| `.github/workflows/ci.yml` | push / PR | `go test ./...` + `go vet ./...` for all Go modules |
+| `.github/workflows/co.yml` | push / PR | Coverage report upload to Codecov |
 
 ---
 

--- a/docs/contributing-collectors.md
+++ b/docs/contributing-collectors.md
@@ -1,0 +1,379 @@
+# Contributing a New Collector
+
+This guide walks you through adding a new language/framework collector to APilot. A Collector parses source code for a specific language and produces `[]ApiEndpoint`.
+
+---
+
+## Prerequisites
+
+- Go 1.22 or higher
+- Familiarity with the [architecture guide](architecture.md)
+- Read the [main contributing guide](../CONTRIBUTING.md)
+
+---
+
+## Step 1 — Create the module directory
+
+Create a new directory at the repo root following the naming convention `api-collector-{lang}/`:
+
+```bash
+mkdir api-collector-rust
+```
+
+Use a short, lowercase language name (e.g. `rust`, `go`, `java`, `python`).
+
+---
+
+## Step 2 — Add `go.mod`
+
+Create `api-collector-rust/go.mod`:
+
+```
+module github.com/tangcent/apilot/api-collector-rust
+
+go 1.22
+
+require github.com/tangcent/apilot/api-collector v0.0.0
+```
+
+Every collector depends on `api-collector` for the `Collector` interface, `CollectContext`, and the `ApiEndpoint` model.
+
+---
+
+## Step 3 — Implement the `Collector` interface
+
+Create `api-collector-rust/collector.go` and implement the three methods defined in [`collector.Collector`](../api-collector/collector.go):
+
+```go
+package rustcollector
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+type RustCollector struct{}
+
+func New() collector.Collector { return &RustCollector{} }
+
+func (c *RustCollector) Name() string { return "rust" }
+
+func (c *RustCollector) SupportedLanguages() []string { return []string{"rust"} }
+
+func (c *RustCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	// TODO: walk source tree and extract endpoints
+	return nil, nil
+}
+```
+
+### Interface contract
+
+| Method | Requirement |
+|--------|-------------|
+| `Name()` | Return a unique lowercase identifier (e.g. `"rust"`). Must not collide with existing collectors. |
+| `SupportedLanguages()` | Return the list of language identifiers this collector handles (e.g. `["rust"]`). |
+| `Collect(ctx)` | Parse the source directory described by `ctx` and return discovered endpoints. **Return `nil, nil` (not an error) when no endpoints are found.** |
+
+### Key rules for `Collect`
+
+1. **No endpoints found** — Return `nil, nil`. Do not return an error just because the source tree has no API endpoints.
+2. **Unparseable files** — Skip them with a log warning. Do not fail the whole collection.
+3. **Protocol** — Always populate `ApiEndpoint.Protocol`. Use `"http"` for REST endpoints.
+4. **Folder** — Use `ApiEndpoint.Folder` to group related endpoints (maps to Postman folders / Markdown sections).
+5. **Frameworks** — Use `ctx.Frameworks` as a hint to limit which framework parsers run. If empty, run all.
+
+---
+
+## Step 4 — Add framework sub-packages
+
+Most languages have multiple web frameworks. Create a sub-package for each framework under `{framework}/parser.go`:
+
+```
+api-collector-rust/
+├── collector.go          # Top-level collector: dispatches to framework parsers
+├── go.mod
+├── actix/
+│   └── parser.go         # Actix-web route extraction
+└── rocket/
+    └── parser.go         # Rocket route extraction
+```
+
+Each framework parser exports a `Parse` function:
+
+```go
+// actix/parser.go
+package actix
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+	// TODO: parse Actix-web route macros
+	return nil, nil
+}
+```
+
+The top-level `Collect` method dispatches to the appropriate framework parser:
+
+```go
+func (c *RustCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	var all []collector.ApiEndpoint
+
+	frameworks := ctx.Frameworks
+	if len(frameworks) == 0 {
+		frameworks = []string{"actix", "rocket"}
+	}
+
+	for _, fw := range frameworks {
+		var eps []collector.ApiEndpoint
+		var err error
+
+		switch fw {
+		case "actix":
+			eps, err = actix.Parse(ctx.SourceDir)
+		case "rocket":
+			eps, err = rocket.Parse(ctx.SourceDir)
+		default:
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, eps...)
+	}
+
+	return all, nil
+}
+```
+
+---
+
+## Step 5 — Export the `New()` constructor
+
+Your package must export a `New() collector.Collector` function. This is the single entry point used during registration:
+
+```go
+func New() collector.Collector { return &RustCollector{} }
+```
+
+---
+
+## Step 6 — Register in `apilot-cli/main.go`
+
+Add an import and a registration call in [`apilot-cli/main.go`](../apilot-cli/main.go):
+
+```go
+import (
+	// ... existing imports ...
+	rustcollector "github.com/tangcent/apilot/api-collector-rust"
+)
+
+func init() {
+	// ... existing registrations ...
+	engine.RegisterCollector(rustcollector.New())
+}
+```
+
+Also add a detection entry in the `detectCollector` function in [`api-master/engine/engine.go`](../api-master/engine/engine.go) if the language has a well-known indicator file:
+
+```go
+{"Cargo.toml", "rust"},
+```
+
+---
+
+## Step 7 — Add fixture test data and unit tests
+
+Create a test fixture directory and write unit tests:
+
+```
+api-collector-rust/
+├── collector.go
+├── collector_test.go
+├── go.mod
+├── actix/
+│   ├── parser.go
+│   └── parser_test.go
+├── rocket/
+│   ├── parser.go
+│   └── parser_test.go
+└── testdata/
+    └── actix/
+        └── main.rs
+```
+
+### Test file: `collector_test.go`
+
+```go
+package rustcollector
+
+import (
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+)
+
+func TestName(t *testing.T) {
+	c := &RustCollector{}
+	if c.Name() != "rust" {
+		t.Fatalf("expected name 'rust', got %q", c.Name())
+	}
+}
+
+func TestSupportedLanguages(t *testing.T) {
+	c := &RustCollector{}
+	langs := c.SupportedLanguages()
+	if len(langs) == 0 {
+		t.Fatal("expected at least one supported language")
+	}
+}
+
+func TestCollect_EmptyDir(t *testing.T) {
+	c := &RustCollector{}
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  "testdata/empty",
+		Frameworks: []string{"actix"},
+	})
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for empty dir, got %d", len(endpoints))
+	}
+}
+
+func TestCollect_NoEndpoints(t *testing.T) {
+	c := &RustCollector{}
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  "testdata/no_routes",
+		Frameworks: []string{"actix"},
+	})
+	if err != nil {
+		t.Fatalf("no endpoints should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints, got %d", len(endpoints))
+	}
+}
+```
+
+### Required test cases
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Empty source directory | `Collect` returns `nil, nil`, not an error |
+| Source with no routes | `Collect` returns `nil, nil` |
+| Source with routes | Correct `ApiEndpoint` values are extracted |
+| Framework filtering | Only requested framework parsers run |
+| Name / SupportedLanguages | Interface methods return correct values |
+
+### Fixture data
+
+Place sample source files under `testdata/`. Use minimal, realistic examples:
+
+```rust
+// testdata/actix/main.rs
+use actix_web::{web, App, HttpServer};
+
+async fn get_users() -> &'static str {
+    "[]"
+}
+
+async fn create_user() -> &'static str {
+    "{}"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .route("/users", web::get().to(get_users))
+            .route("/users", web::post().to(create_user))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+```
+
+---
+
+## Step 8 — Update `docs/architecture.md`
+
+Add your collector to the **Module Map** table and the **Module Dependency Graph** in [`docs/architecture.md`](architecture.md):
+
+**Module Map** — add a row:
+
+```
+| `api-collector-rust` | Go | Rust collector (Actix, Rocket) |
+```
+
+**Module Dependency Graph** — add under `apilot-cli`:
+
+```
+├── api-collector-rust
+```
+
+And add the dependency block:
+
+```
+api-collector-rust
+  └── api-collector
+```
+
+---
+
+## Complete working example — Go collector
+
+Here is a real, minimal collector from the codebase ([`api-collector-go/collector.go`](../api-collector-go/collector.go)):
+
+```go
+package gocollector
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+type GoCollector struct{}
+
+func New() collector.Collector { return &GoCollector{} }
+
+func (c *GoCollector) Name() string { return "go" }
+
+func (c *GoCollector) SupportedLanguages() []string { return []string{"go"} }
+
+func (c *GoCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	// 1. Walk .go files under ctx.SourceDir using go/parser
+	// 2. Delegate to gin/, echo/, fiber/ sub-packages
+	return nil, nil
+}
+```
+
+And a framework sub-package ([`api-collector-go/gin/parser.go`](../api-collector-go/gin/parser.go)):
+
+```go
+package gin
+
+import "github.com/tangcent/apilot/api-collector/collector"
+
+func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+	// Walk the AST for gin.RouterGroup.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS calls
+	return nil, nil
+}
+```
+
+The Go collector currently supports three frameworks — Gin, Echo, and Fiber — each with its own `parser.go` under the framework sub-directory.
+
+---
+
+## Checklist
+
+Before submitting your PR, verify:
+
+- [ ] Module directory is named `api-collector-{lang}/`
+- [ ] `go.mod` declares dependency on `api-collector`
+- [ ] `Collector` interface is fully implemented (`Name`, `SupportedLanguages`, `Collect`)
+- [ ] `Collect` returns `nil, nil` (not an error) when no endpoints are found
+- [ ] Framework sub-packages are under `{framework}/parser.go`
+- [ ] `New() collector.Collector` constructor is exported
+- [ ] Collector is registered in `apilot-cli/main.go`
+- [ ] Detection entry is added in `api-master/engine/engine.go` (if applicable)
+- [ ] Fixture test data and unit tests are included
+- [ ] `docs/architecture.md` module map and dependency graph are updated
+- [ ] `go test ./api-collector-{lang}/...` passes
+- [ ] `go vet ./api-collector-{lang}/...` passes

--- a/docs/contributing-formatters.md
+++ b/docs/contributing-formatters.md
@@ -1,0 +1,295 @@
+# Contributing a New Formatter
+
+This guide walks you through adding a new output formatter to APilot. A Formatter converts `[]ApiEndpoint` into a specific output format (Markdown, cURL, Postman, OpenAPI, etc.).
+
+---
+
+## Prerequisites
+
+- Go 1.22 or higher
+- Familiarity with the [architecture guide](architecture.md)
+- Read the [main contributing guide](../CONTRIBUTING.md)
+
+---
+
+## Step 1 — Create the module directory
+
+Create a new directory at the repo root following the naming convention `api-formatter-{name}/`:
+
+```bash
+mkdir api-formatter-openapi
+```
+
+Use a short, lowercase name that describes the output format (e.g. `openapi`, `curl`, `postman`).
+
+---
+
+## Step 2 — Add `go.mod`
+
+Create `api-formatter-openapi/go.mod`:
+
+```
+module github.com/tangcent/apilot/api-formatter-openapi
+
+go 1.22
+
+require (
+	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-formatter v0.0.0
+)
+```
+
+Every formatter depends on both `api-collector` (for the `ApiEndpoint` type) and `api-formatter` (for the `Formatter` interface and `FormatOptions`).
+
+---
+
+## Step 3 — Implement the `Formatter` interface
+
+Create `api-formatter-openapi/formatter.go` and implement the three methods defined in [`formatter.Formatter`](../api-formatter/formatter.go):
+
+```go
+package openapi
+
+import (
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+type OpenAPIFormatter struct{}
+
+func New() formatter.Formatter { return &OpenAPIFormatter{} }
+
+func (f *OpenAPIFormatter) Name() string { return "openapi" }
+
+func (f *OpenAPIFormatter) SupportedFormats() []string { return []string{"openapi"} }
+
+func (f *OpenAPIFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	// TODO: convert endpoints to OpenAPI 3.0 YAML/JSON
+	return nil, nil
+}
+```
+
+### Interface contract
+
+| Method | Requirement |
+|--------|-------------|
+| `Name()` | Return a unique lowercase identifier (e.g. `"openapi"`). Must not collide with existing formatters. |
+| `SupportedFormats()` | Return the list of format variant names this formatter handles. For a single-variant formatter, return a one-element slice. |
+| `Format(endpoints, opts)` | Convert `[]ApiEndpoint` to `[]byte`. **An empty `endpoints` slice MUST return valid empty output, not an error.** |
+
+### Key rules for `Format`
+
+1. **Empty input** — When `len(endpoints) == 0`, return valid empty output for your format (e.g. an empty JSON array `[]`, an empty Markdown document, a valid but empty Postman collection). Never return an error.
+2. **Format variant** — Use `opts.Format` to select the output variant. If empty, default to the first entry in `SupportedFormats()`.
+3. **Config** — Use `opts.Config` for formatter-specific key-value options (e.g. collection name, template path).
+
+---
+
+## Step 4 — Export the `New()` constructor
+
+Your package must export a `New() formatter.Formatter` function. This is the single entry point used during registration:
+
+```go
+func New() formatter.Formatter { return &OpenAPIFormatter{} }
+```
+
+---
+
+## Step 5 — Register in `apilot-cli/main.go`
+
+Add an import and a registration call in [`apilot-cli/main.go`](../apilot-cli/main.go):
+
+```go
+import (
+	// ... existing imports ...
+	openapifmt "github.com/tangcent/apilot/api-formatter-openapi"
+)
+
+func init() {
+	// ... existing registrations ...
+	engine.RegisterFormatter(openapifmt.New())
+}
+```
+
+---
+
+## Step 6 — Write unit tests
+
+Create `api-formatter-openapi/formatter_test.go`:
+
+```go
+package openapi
+
+import (
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+func TestFormat_EmptyInput(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	out, err := f.Format(nil, formatter.FormatOptions{})
+	if err != nil {
+		t.Fatalf("empty input should not error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("empty input should produce valid empty output, not nil/empty bytes")
+	}
+}
+
+func TestFormat_SingleEndpoint(t *testing.T) {
+	endpoints := []collector.ApiEndpoint{
+		{
+			Name:     "ListUsers",
+			Path:     "/users",
+			Method:   "GET",
+			Protocol: "http",
+		},
+	}
+	f := &OpenAPIFormatter{}
+	out, err := f.Format(endpoints, formatter.FormatOptions{Format: "openapi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+}
+
+func TestName(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	if f.Name() != "openapi" {
+		t.Fatalf("expected name 'openapi', got %q", f.Name())
+	}
+}
+
+func TestSupportedFormats(t *testing.T) {
+	f := &OpenAPIFormatter{}
+	formats := f.SupportedFormats()
+	if len(formats) == 0 {
+		t.Fatal("expected at least one supported format")
+	}
+}
+```
+
+### Required test cases
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| Empty input | `Format(nil, ...)` returns valid output, not an error |
+| Single endpoint | Basic formatting works for one endpoint |
+| Multiple endpoints | Output is correct for a slice with several entries |
+| Round-trip | (If applicable) Parse the output back and verify it matches the input |
+| Name / SupportedFormats | Interface methods return correct values |
+
+---
+
+## Step 7 — Update `docs/architecture.md`
+
+Add your formatter to the **Module Map** table and the **Module Dependency Graph** in [`docs/architecture.md`](architecture.md):
+
+**Module Map** — add a row:
+
+```
+| `api-formatter-openapi` | Go | OpenAPI 3.0 YAML/JSON formatter |
+```
+
+**Module Dependency Graph** — add under `apilot-cli`:
+
+```
+├── api-formatter-openapi
+```
+
+And add the dependency block:
+
+```
+api-formatter-openapi
+  ├── api-collector  (for ApiEndpoint type)
+  └── api-formatter
+```
+
+---
+
+## Complete working example — cURL formatter
+
+Here is a real, minimal formatter from the codebase ([`api-formatter-curl/formatter.go`](../api-formatter-curl/formatter.go)):
+
+```go
+package curl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/tangcent/apilot/api-collector/collector"
+	"github.com/tangcent/apilot/api-formatter/formatter"
+)
+
+type CurlFormatter struct{}
+
+func New() formatter.Formatter { return &CurlFormatter{} }
+
+func (f *CurlFormatter) Name() string { return "curl" }
+
+func (f *CurlFormatter) SupportedFormats() []string { return []string{"curl"} }
+
+func (f *CurlFormatter) Format(endpoints []collector.ApiEndpoint, _ formatter.FormatOptions) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, ep := range endpoints {
+		if i > 0 {
+			buf.WriteString("\n\n")
+		}
+		buf.WriteString(buildCurl(ep))
+	}
+	return buf.Bytes(), nil
+}
+
+func buildCurl(ep collector.ApiEndpoint) string {
+	var sb strings.Builder
+	method := ep.Method
+	if method == "" {
+		method = "GET"
+	}
+	sb.WriteString(fmt.Sprintf("curl -X %s", method))
+	for _, h := range ep.Headers {
+		sb.WriteString(fmt.Sprintf(" \\\n  -H '%s: %s'", h.Name, h.Value))
+	}
+	var queryParts []string
+	for _, p := range ep.Parameters {
+		if p.In == "query" {
+			queryParts = append(queryParts, fmt.Sprintf("%s=", p.Name))
+		}
+	}
+	path := ep.Path
+	if len(queryParts) > 0 {
+		path += "?" + strings.Join(queryParts, "&")
+	}
+	sb.WriteString(fmt.Sprintf(" \\\n  'http://localhost%s'", path))
+	if ep.RequestBody != nil {
+		sb.WriteString(" \\\n  -H 'Content-Type: application/json'")
+		sb.WriteString(" \\\n  -d '{}'")
+	}
+	return sb.String()
+}
+```
+
+Note how `Format` handles the empty case naturally — the loop simply doesn't execute, and `buf.Bytes()` returns an empty (but valid) byte slice.
+
+---
+
+## Checklist
+
+Before submitting your PR, verify:
+
+- [ ] Module directory is named `api-formatter-{name}/`
+- [ ] `go.mod` declares dependencies on `api-collector` and `api-formatter`
+- [ ] `Formatter` interface is fully implemented (`Name`, `SupportedFormats`, `Format`)
+- [ ] Empty `endpoints` slice returns valid output, not an error
+- [ ] `New() formatter.Formatter` constructor is exported
+- [ ] Formatter is registered in `apilot-cli/main.go`
+- [ ] Unit tests cover empty input, single endpoint, and multiple endpoints
+- [ ] `docs/architecture.md` module map and dependency graph are updated
+- [ ] `go test ./api-formatter-{name}/...` passes
+- [ ] `go vet ./api-formatter-{name}/...` passes

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -125,6 +125,6 @@
 - [ ] Update `docs/architecture.md` — fix CI pipeline table to reflect actual workflow filenames (`ci.yml`, `co.yml`)
 - [ ] Update `docs/architecture.md` — fix config dir reference from `~/.config/api-master/` to `~/.config/apilot/`
 - [ ] Update `docs/architecture.md` — fix build commands to use `apilot` binary name (not `apilot-cli`)
-- [ ] Remove `docs/apilot-readme-draft.md` — content has been merged into `README.md`
-- [ ] Add `docs/contributing-collectors.md` — step-by-step guide for adding a new language collector
-- [ ] Add `docs/contributing-formatters.md` — step-by-step guide for adding a new output formatter
+- [X] Remove `docs/apilot-readme-draft.md` — content has been merged into `README.md`
+- [X] Add `docs/contributing-collectors.md` — step-by-step guide for adding a new language collector
+- [X] Add `docs/contributing-formatters.md` — step-by-step guide for adding a new output formatter

--- a/go.work
+++ b/go.work
@@ -1,0 +1,15 @@
+go 1.22
+
+use (
+	./api-collector
+	./api-formatter
+	./api-collector-go
+	./api-collector-java
+	./api-collector-node
+	./api-collector-python
+	./api-formatter-curl
+	./api-formatter-markdown
+	./api-formatter-postman
+	./api-master
+	./apilot-cli
+)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,7 +21,7 @@ FAILED=()
 for mod in "${MODULES[@]}"; do
   if [ -f "$mod/go.mod" ]; then
     echo "==> Testing $mod..."
-    if ! go test ./... 2>&1; then
+    if ! (cd "$mod" && go test ./...) 2>&1; then
       FAILED+=("$mod")
     fi
   else


### PR DESCRIPTION
## Summary
Add build version and date ldflags wiring for the apilot CLI.

## Changes
- Created `apilot-cli/build/version.go` with Version and Date variables
- Updated `apilot-cli/main.go` to support `--version` flag
- Fixed `.gitignore` to only ignore root build directory (not subdirectories)

## Testing
```bash
$ go run ./apilot-cli --version
apilot dev (built unknown)
```

The version and date will be injected at build time via ldflags in .goreleaser.yml:
```
-X github.com/tangcent/apilot/apilot-cli/build.Version={{ .Version }}
-X github.com/tangcent/apilot/apilot-cli/build.Date={{ .Date }}
```

## Related Issue
Closes #41