### PR TITLE
chore(npm): add .npmignore to keep published package lean

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,61 @@
+# Go source files and modules
+api-collector/
+api-collector-go/
+api-collector-java/
+api-collector-node/
+api-collector-python/
+api-formatter/
+api-formatter-curl/
+api-formatter-markdown/
+api-formatter-postman/
+api-master/
+apilot-cli/
+*.go
+go.mod
+go.sum
+go.work
+
+# Documentation
+docs/
+
+# GitHub
+.github/
+
+# IDE and editor
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Build artifacts
+bin/
+dist/
+
+# Development files
+.agent/
+.claude/
+.cursor/
+.kiro/
+.qodo/
+.trae/
+*.log
+
+# Test and CI
+scripts/test.sh
+scripts/package.sh
+scripts/init.sh
+
+# JetBrains plugin
+jetbrains-plugin/
+
+# VSCode plugin source (published separately)
+vscode-plugin/
+
+# Misc
+.DS_Store
+.gitignore
+.goreleaser.yml
+.codecov.yml
+CONTRIBUTING.md
+LICENSE
+README.md


### PR DESCRIPTION
## Summary
Add .npmignore to keep the published npm package lean by excluding unnecessary files.

## Changes
- Added .npmignore file that excludes:
  - All Go source files and modules
  - Documentation (docs/)
  - GitHub workflows (.github/)
  - Build artifacts (bin/, dist/)
  - IDE/editor files
  - Development files
  - Test and CI scripts

## Package Contents
After this change, the npm package only includes:
```
CHANGELOG.md
LICENSE
README.md
package.json
scripts/install.js
scripts/run.js
```

Package size: 15.4 kB (6 files)

## Testing
```bash
$ npm pack --dry-run
npm notice 📦  @tangcent/apilot@0.1.0
npm notice Tarball Contents
npm notice 475B CHANGELOG.md
npm notice 34.5kB LICENSE
npm notice 4.4kB README.md
npm notice 610B package.json
npm notice 2.5kB scripts/install.js
npm notice 793B scripts/run.js
```

## Related Issue
Closes #40