### PR TITLE
refactor: extract api-model module and replace FormatOptions with typed Params

### DIFF
--- a/api-collector/endpoint.go
+++ b/api-collector/endpoint.go
@@ -1,46 +1,9 @@
 package collector
 
-// ApiEndpoint is the canonical, language-agnostic model for a single API endpoint.
-type ApiEndpoint struct {
-	Name        string         `json:"name"`
-	Folder      string         `json:"folder,omitempty"`
-	Description string         `json:"description,omitempty"`
-	Tags        []string       `json:"tags,omitempty"`
-	Path        string         `json:"path"`
-	Method      string         `json:"method,omitempty"`  // empty for non-HTTP protocols
-	Protocol    string         `json:"protocol"`          // "http", "grpc", "websocket", etc.
-	Parameters  []ApiParameter `json:"parameters,omitempty"`
-	Headers     []ApiHeader    `json:"headers,omitempty"`
-	RequestBody *ApiBody       `json:"requestBody,omitempty"`
-	Response    *ApiBody       `json:"response,omitempty"`
-	// Metadata holds protocol-specific extensions without polluting the core struct.
-	Metadata map[string]any `json:"metadata,omitempty"`
-}
+import "github.com/tangcent/apilot/api-model"
 
-// ApiParameter describes a single input parameter of an endpoint.
-type ApiParameter struct {
-	Name        string   `json:"name"`
-	Type        string   `json:"type"`              // "text" | "file"
-	Required    bool     `json:"required"`
-	In          string   `json:"in"`                // "query" | "path" | "header" | "cookie" | "body" | "form"
-	Default     string   `json:"default,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Example     string   `json:"example,omitempty"`
-	Enum        []string `json:"enum,omitempty"`
-}
-
-// ApiHeader describes an HTTP header associated with an endpoint.
-type ApiHeader struct {
-	Name        string `json:"name"`
-	Value       string `json:"value,omitempty"`
-	Description string `json:"description,omitempty"`
-	Example     string `json:"example,omitempty"`
-	Required    bool   `json:"required"`
-}
-
-// ApiBody describes the request or response body of an endpoint.
-type ApiBody struct {
-	MediaType string `json:"mediaType,omitempty"` // e.g. "application/json"
-	Schema    any    `json:"schema,omitempty"`    // JSON Schema object
-	Example   any    `json:"example,omitempty"`
-}
+// Re-export model types so existing collector implementations need no import changes.
+type ApiEndpoint = model.ApiEndpoint
+type ApiParameter = model.ApiParameter
+type ApiHeader = model.ApiHeader
+type ApiBody = model.ApiBody

--- a/api-collector/go.mod
+++ b/api-collector/go.mod
@@ -1,3 +1,7 @@
 module github.com/tangcent/apilot/api-collector
 
 go 1.22
+
+require github.com/tangcent/apilot/api-model v0.0.0
+
+replace github.com/tangcent/apilot/api-model => ../api-model

--- a/api-formatter-curl/formatter.go
+++ b/api-formatter-curl/formatter.go
@@ -6,9 +6,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-formatter"
+	"github.com/tangcent/apilot/api-model"
 )
+
+// Params holds curl-specific formatting options.
+type Params struct {
+	// BaseURL is prepended to each endpoint path. Defaults to "http://localhost".
+	BaseURL string `json:"baseURL"`
+}
 
 // CurlFormatter formats endpoints as cURL commands.
 type CurlFormatter struct{}
@@ -18,41 +24,44 @@ func New() formatter.Formatter { return &CurlFormatter{} }
 
 func (f *CurlFormatter) Name() string { return "curl" }
 
-func (f *CurlFormatter) SupportedFormats() []string { return []string{"curl"} }
-
 // Format produces one cURL command per endpoint, separated by blank lines.
 // An empty endpoints slice returns an empty byte slice.
-func (f *CurlFormatter) Format(endpoints []collector.ApiEndpoint, _ formatter.FormatOptions) ([]byte, error) {
+func (f *CurlFormatter) Format(endpoints []model.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	var p Params
+	if err := opts.DecodeParams(&p); err != nil {
+		return nil, err
+	}
+	if p.BaseURL == "" {
+		p.BaseURL = "http://localhost"
+	}
+
 	var buf bytes.Buffer
 	for i, ep := range endpoints {
 		if i > 0 {
 			buf.WriteString("\n\n")
 		}
-		buf.WriteString(buildCurl(ep))
+		buf.WriteString(buildCurl(ep, p))
 	}
 	return buf.Bytes(), nil
 }
 
-func buildCurl(ep collector.ApiEndpoint) string {
+func buildCurl(ep model.ApiEndpoint, p Params) string {
 	var sb strings.Builder
 
-	// Method
 	method := ep.Method
 	if method == "" {
 		method = "GET"
 	}
 	sb.WriteString(fmt.Sprintf("curl -X %s", method))
 
-	// Headers
 	for _, h := range ep.Headers {
 		sb.WriteString(fmt.Sprintf(" \\\n  -H '%s: %s'", h.Name, h.Value))
 	}
 
-	// Query parameters
 	var queryParts []string
-	for _, p := range ep.Parameters {
-		if p.In == "query" {
-			queryParts = append(queryParts, fmt.Sprintf("%s=", p.Name))
+	for _, param := range ep.Parameters {
+		if param.In == "query" {
+			queryParts = append(queryParts, fmt.Sprintf("%s=", param.Name))
 		}
 	}
 
@@ -60,9 +69,8 @@ func buildCurl(ep collector.ApiEndpoint) string {
 	if len(queryParts) > 0 {
 		path += "?" + strings.Join(queryParts, "&")
 	}
-	sb.WriteString(fmt.Sprintf(" \\\n  'http://localhost%s'", path))
+	sb.WriteString(fmt.Sprintf(" \\\n  '%s%s'", p.BaseURL, path))
 
-	// Request body
 	if ep.RequestBody != nil {
 		sb.WriteString(" \\\n  -H 'Content-Type: application/json'")
 		sb.WriteString(" \\\n  -d '{}'")

--- a/api-formatter-curl/go.mod
+++ b/api-formatter-curl/go.mod
@@ -3,11 +3,11 @@ module github.com/tangcent/apilot/api-formatter-curl
 go 1.22
 
 require (
-	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-model v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
 
 replace (
-	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-model => ../api-model
 	github.com/tangcent/apilot/api-formatter => ../api-formatter
 )

--- a/api-formatter-markdown/formatter.go
+++ b/api-formatter-markdown/formatter.go
@@ -1,5 +1,5 @@
 // Package markdown implements the Formatter interface producing Markdown output.
-// Supports two format variants: "simple" (compact) and "detailed" (full schema expansion).
+// Supports two variants via Params: "simple" (default, compact) and "detailed" (full schema expansion).
 package markdown
 
 import (
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"text/template"
 
-	"github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-formatter"
+	"github.com/tangcent/apilot/api-model"
 )
 
 //go:embed templates/simple.md.tmpl
@@ -16,6 +16,12 @@ var simpleTmpl string
 
 //go:embed templates/detailed.md.tmpl
 var detailedTmpl string
+
+// Params holds markdown-specific formatting options.
+type Params struct {
+	// Variant selects the output template: "simple" (default) or "detailed".
+	Variant string `json:"variant"`
+}
 
 // MarkdownFormatter formats endpoints as Markdown documents.
 type MarkdownFormatter struct{}
@@ -25,18 +31,16 @@ func New() formatter.Formatter { return &MarkdownFormatter{} }
 
 func (f *MarkdownFormatter) Name() string { return "markdown" }
 
-func (f *MarkdownFormatter) SupportedFormats() []string { return []string{"simple", "detailed"} }
-
 // Format renders endpoints using the selected template variant.
 // An empty endpoints slice returns an empty Markdown document.
-func (f *MarkdownFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
-	variant := opts.Format
-	if variant == "" {
-		variant = "simple"
+func (f *MarkdownFormatter) Format(endpoints []model.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	var p Params
+	if err := opts.DecodeParams(&p); err != nil {
+		return nil, err
 	}
 
 	var tmplSrc string
-	switch variant {
+	switch p.Variant {
 	case "detailed":
 		tmplSrc = detailedTmpl
 	default:

--- a/api-formatter-markdown/go.mod
+++ b/api-formatter-markdown/go.mod
@@ -3,11 +3,11 @@ module github.com/tangcent/apilot/api-formatter-markdown
 go 1.22
 
 require (
-	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-model v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
 
 replace (
-	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-model => ../api-model
 	github.com/tangcent/apilot/api-formatter => ../api-formatter
 )

--- a/api-formatter-postman/formatter.go
+++ b/api-formatter-postman/formatter.go
@@ -5,12 +5,22 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-formatter"
+	apimodel "github.com/tangcent/apilot/api-model"
 	"github.com/tangcent/apilot/api-formatter-postman/model"
 )
 
 const postmanSchema = "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+
+// Params holds postman-specific formatting options.
+type Params struct {
+	// CollectionName is the name of the exported Postman collection.
+	// Defaults to "APilot Export".
+	CollectionName string `json:"collectionName"`
+
+	// BaseURL is prepended to each endpoint path. Defaults to "http://localhost".
+	BaseURL string `json:"baseURL"`
+}
 
 // PostmanFormatter formats endpoints as a Postman Collection v2.1 JSON document.
 type PostmanFormatter struct{}
@@ -20,19 +30,22 @@ func New() formatter.Formatter { return &PostmanFormatter{} }
 
 func (f *PostmanFormatter) Name() string { return "postman" }
 
-func (f *PostmanFormatter) SupportedFormats() []string { return []string{"postman"} }
-
 // Format converts endpoints into a Postman Collection v2.1 JSON document.
 // Endpoints are grouped by their Folder field into Postman folders.
 // An empty endpoints slice returns a valid empty collection.
-func (f *PostmanFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
-	name := opts.Config["name"]
-	if name == "" {
-		name = "APilot Export"
+func (f *PostmanFormatter) Format(endpoints []apimodel.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	var p Params
+	if err := opts.DecodeParams(&p); err != nil {
+		return nil, err
+	}
+	if p.CollectionName == "" {
+		p.CollectionName = "APilot Export"
+	}
+	if p.BaseURL == "" {
+		p.BaseURL = "http://localhost"
 	}
 
-	// Group endpoints by folder
-	folderMap := map[string][]collector.ApiEndpoint{}
+	folderMap := map[string][]apimodel.ApiEndpoint{}
 	var folderOrder []string
 	for _, ep := range endpoints {
 		folder := ep.Folder
@@ -49,19 +62,19 @@ func (f *PostmanFormatter) Format(endpoints []collector.ApiEndpoint, opts format
 	for _, folderName := range folderOrder {
 		var items []model.Item
 		for _, ep := range folderMap[folderName] {
-			items = append(items, buildItem(ep))
+			items = append(items, buildItem(ep, p))
 		}
 		groups = append(groups, model.ItemGroup{Name: folderName, Item: items})
 	}
 
 	col := model.Collection{
-		Info: model.Info{Name: name, Schema: postmanSchema},
+		Info: model.Info{Name: p.CollectionName, Schema: postmanSchema},
 		Item: groups,
 	}
 	return json.MarshalIndent(col, "", "  ")
 }
 
-func buildItem(ep collector.ApiEndpoint) model.Item {
+func buildItem(ep apimodel.ApiEndpoint, p Params) model.Item {
 	method := ep.Method
 	if method == "" {
 		method = "GET"
@@ -73,14 +86,14 @@ func buildItem(ep collector.ApiEndpoint) model.Item {
 	}
 
 	var queryParams []model.Query
-	for _, p := range ep.Parameters {
-		if p.In == "query" {
-			queryParams = append(queryParams, model.Query{Key: p.Name, Value: ""})
+	for _, param := range ep.Parameters {
+		if param.In == "query" {
+			queryParams = append(queryParams, model.Query{Key: param.Name, Value: ""})
 		}
 	}
 
 	url := model.URL{
-		Raw:   "http://localhost" + ep.Path,
+		Raw:   p.BaseURL + ep.Path,
 		Path:  splitPath(ep.Path),
 		Query: queryParams,
 	}
@@ -88,8 +101,8 @@ func buildItem(ep collector.ApiEndpoint) model.Item {
 	var body *model.Body
 	if ep.RequestBody != nil {
 		body = &model.Body{
-			Mode: "raw",
-			Raw:  "{}",
+			Mode:    "raw",
+			Raw:     "{}",
 			Options: &model.BodyOptions{Raw: model.RawOptions{Language: "json"}},
 		}
 	}

--- a/api-formatter-postman/go.mod
+++ b/api-formatter-postman/go.mod
@@ -3,11 +3,11 @@ module github.com/tangcent/apilot/api-formatter-postman
 go 1.22
 
 require (
-	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-model v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
 
 replace (
-	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-model => ../api-model
 	github.com/tangcent/apilot/api-formatter => ../api-formatter
 )

--- a/api-formatter/formatter.go
+++ b/api-formatter/formatter.go
@@ -1,27 +1,41 @@
 // Package formatter defines the stable interface contract for all API formatter implementations.
-// A Formatter converts []ApiEndpoint into a specific output format (Markdown, cURL, Postman, etc.).
+// A Formatter converts []model.ApiEndpoint into a specific output format (Markdown, cURL, Postman, etc.).
 package formatter
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"encoding/json"
+
+	"github.com/tangcent/apilot/api-model"
+)
 
 // Formatter is the interface every output formatter must implement.
 type Formatter interface {
 	// Name returns the unique identifier for this formatter (e.g. "markdown", "postman").
 	Name() string
 
-	// SupportedFormats returns the list of format variant names this formatter handles.
-	SupportedFormats() []string
-
 	// Format converts the given endpoints into the target format.
 	// An empty endpoints slice MUST return valid empty output, not an error.
-	Format(endpoints []collector.ApiEndpoint, opts FormatOptions) ([]byte, error)
+	Format(endpoints []model.ApiEndpoint, opts FormatOptions) ([]byte, error)
 }
 
-// FormatOptions carries the inputs needed by a Formatter.
+// FormatOptions carries formatter-specific configuration as raw JSON.
+// Each formatter implementation decodes Params into its own typed options struct
+// via DecodeParams, so there are no magic string keys and options are self-documenting.
+//
+// Example — passing options from the CLI or IDE:
+//
+//	FormatOptions{Params: json.RawMessage(`{"variant":"detailed","baseURL":"https://api.example.com"}`)}
 type FormatOptions struct {
-	// Format selects the output variant (e.g. "simple", "detailed").
-	Format string `json:"format"`
+	// Params holds formatter-specific configuration as raw JSON.
+	// Formatters unmarshal this into their own typed struct using DecodeParams.
+	Params json.RawMessage `json:"params,omitempty"`
+}
 
-	// Config holds formatter-specific key-value configuration.
-	Config map[string]string `json:"config,omitempty"`
+// DecodeParams unmarshals Params into v.
+// If Params is empty, v is left unchanged and nil is returned.
+func (o FormatOptions) DecodeParams(v any) error {
+	if len(o.Params) == 0 {
+		return nil
+	}
+	return json.Unmarshal(o.Params, v)
 }

--- a/api-formatter/go.mod
+++ b/api-formatter/go.mod
@@ -2,6 +2,6 @@ module github.com/tangcent/apilot/api-formatter
 
 go 1.22
 
-require github.com/tangcent/apilot/api-collector v0.0.0
+require github.com/tangcent/apilot/api-model v0.0.0
 
-replace github.com/tangcent/apilot/api-collector => ../api-collector
+replace github.com/tangcent/apilot/api-model => ../api-model

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -17,7 +17,7 @@ type Config struct {
 	SourceDir      string
 	CollectorName  string // empty = auto-detect
 	FormatterName  string // default: "markdown"
-	FormatVariant  string // passed to FormatOptions.Format
+	FormatParams   string // raw JSON passed as FormatOptions.Params (e.g. `{"variant":"detailed"}`)
 	OutputPath     string // empty = stdout
 	PluginRegistry string // path to plugins.json
 }
@@ -48,7 +48,10 @@ func Run(cfg Config) error {
 	}
 
 	// 4. Format
-	opts := formatter.FormatOptions{Format: cfg.FormatVariant}
+	opts := formatter.FormatOptions{}
+	if cfg.FormatParams != "" {
+		opts.Params = []byte(cfg.FormatParams)
+	}
 	output, err := f.Format(endpoints, opts)
 	if err != nil {
 		return fmt.Errorf("formatting failed: %w", err)
@@ -108,7 +111,7 @@ func RunCLI() {
 	var (
 		collectorName  string
 		formatterName  string
-		formatVariant  string
+		formatParams   string
 		outputPath     string
 		pluginRegistry string
 		listCollectors bool
@@ -117,7 +120,7 @@ func RunCLI() {
 
 	flag.StringVar(&collectorName, "collector", "", "collector name (auto-detect if omitted)")
 	flag.StringVar(&formatterName, "formatter", "markdown", "formatter name (default: markdown)")
-	flag.StringVar(&formatVariant, "format", "", "format variant passed to formatter")
+	flag.StringVar(&formatParams, "params", "", "formatter params as JSON (e.g. '{\"variant\":\"detailed\"}')")
 	flag.StringVar(&outputPath, "output", "", "output file path (default: stdout)")
 	flag.StringVar(&pluginRegistry, "plugin-registry", "", "path to plugins.json")
 	flag.BoolVar(&listCollectors, "list-collectors", false, "print registered collectors and exit")
@@ -157,7 +160,7 @@ func RunCLI() {
 		SourceDir:      sourceDir,
 		CollectorName:  collectorName,
 		FormatterName:  formatterName,
-		FormatVariant:  formatVariant,
+		FormatParams:   formatParams,
 		OutputPath:     outputPath,
 		PluginRegistry: pluginRegistry,
 	}
@@ -187,7 +190,7 @@ func printFormatters() {
 		return
 	}
 	fmt.Println("Registered formatters:")
-	for name, formats := range formatters {
-		fmt.Printf("  %s: %v\n", name, formats)
+	for _, name := range formatters {
+		fmt.Printf("  %s\n", name)
 	}
 }

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -3,9 +3,13 @@ package engine
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-formatter"
 )
 
 func resetFlags() {
@@ -61,7 +65,383 @@ func TestRunCLI_ListFormatters(t *testing.T) {
 	}
 }
 
+func TestRun_HappyPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{{Name: "test-endpoint"}},
+	})
+
+	RegisterFormatter(&mockFormatter{
+		name:           "test-formatter",
+		formatOutput:   []byte("formatted output"),
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "test-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := Run(cfg)
+
+	w.Close()
+	os.Stdout = originalStdout
+	output.ReadFrom(r)
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if !bytes.Contains(output.Bytes(), []byte("formatted output")) {
+		t.Errorf("Expected 'formatted output' in stdout, got: %s", output.String())
+	}
+}
+
+func TestRun_AutoDetectFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "",
+		FormatterName:  "test-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err == nil {
+		t.Error("Expected error for auto-detect failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "auto-detect failed") {
+		t.Errorf("Expected 'auto-detect failed' in error, got: %v", err)
+	}
+}
+
+func TestRun_FormatterNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{},
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "nonexistent-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err == nil {
+		t.Error("Expected error for missing formatter, got nil")
+	}
+	if !strings.Contains(err.Error(), "formatter") {
+		t.Errorf("Expected 'formatter' in error, got: %v", err)
+	}
+}
+
+func TestRun_WriteToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputFile := tmpDir + "/output.md"
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{{Name: "test-endpoint"}},
+	})
+
+	RegisterFormatter(&mockFormatter{
+		name:           "test-formatter",
+		formatOutput:   []byte("formatted output to file"),
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "test-formatter",
+		OutputPath:     outputFile,
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	data, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	if !bytes.Contains(data, []byte("formatted output to file")) {
+		t.Errorf("Expected 'formatted output to file' in file, got: %s", string(data))
+	}
+}
+
+func TestRun_CollectorError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	RegisterCollector(&mockCollector{
+		name:          "error-collector",
+		supportedLangs: []string{"test"},
+		collectError:  fmt.Errorf("collection failed"),
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "error-collector",
+		FormatterName:  "test-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err == nil {
+		t.Error("Expected error from collector, got nil")
+	}
+	if !strings.Contains(err.Error(), "collection failed") {
+		t.Errorf("Expected 'collection failed' in error, got: %v", err)
+	}
+}
+
+func TestRun_FormatterError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{},
+	})
+
+	RegisterFormatter(&mockFormatter{
+		name:          "error-formatter",
+		formatError:   fmt.Errorf("formatting failed"),
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "error-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err == nil {
+		t.Error("Expected error from formatter, got nil")
+	}
+	if !strings.Contains(err.Error(), "formatting failed") {
+		t.Errorf("Expected 'formatting failed' in error, got: %v", err)
+	}
+}
+
+type mockFormatter struct {
+	name         string
+	formatOutput []byte
+	formatError  error
+}
+
+func (m *mockFormatter) Name() string {
+	return m.name
+}
+
+func (m *mockFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	return m.formatOutput, m.formatError
+}
+
+func TestDetectCollector_Java(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{"pom.xml", "pom.xml"},
+		{"build.gradle", "build.gradle"},
+		{"build.gradle.kts", "build.gradle.kts"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			indicatorFile := tmpDir + "/" + tt.filename
+			if err := os.WriteFile(indicatorFile, []byte{}, 0644); err != nil {
+				t.Fatalf("Failed to create indicator file: %v", err)
+			}
+
+			RegisterCollector(&mockCollector{name: "java"})
+
+			result, err := detectCollector(tmpDir)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if result != "java" {
+				t.Errorf("Expected 'java', got: %q", result)
+			}
+		})
+	}
+}
+
+func TestDetectCollector_Go(t *testing.T) {
+	tmpDir := t.TempDir()
+	indicatorFile := tmpDir + "/go.mod"
+	if err := os.WriteFile(indicatorFile, []byte("module example.com/test"), 0644); err != nil {
+		t.Fatalf("Failed to create indicator file: %v", err)
+	}
+
+	RegisterCollector(&mockCollector{name: "go"})
+
+	result, err := detectCollector(tmpDir)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if result != "go" {
+		t.Errorf("Expected 'go', got: %q", result)
+	}
+}
+
+func TestDetectCollector_Node(t *testing.T) {
+	tmpDir := t.TempDir()
+	indicatorFile := tmpDir + "/package.json"
+	if err := os.WriteFile(indicatorFile, []byte(`{"name": "test"}`), 0644); err != nil {
+		t.Fatalf("Failed to create indicator file: %v", err)
+	}
+
+	RegisterCollector(&mockCollector{name: "node"})
+
+	result, err := detectCollector(tmpDir)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if result != "node" {
+		t.Errorf("Expected 'node', got: %q", result)
+	}
+}
+
+func TestDetectCollector_Python(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{"requirements.txt", "requirements.txt"},
+		{"pyproject.toml", "pyproject.toml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			indicatorFile := tmpDir + "/" + tt.filename
+			if err := os.WriteFile(indicatorFile, []byte{}, 0644); err != nil {
+				t.Fatalf("Failed to create indicator file: %v", err)
+			}
+
+			RegisterCollector(&mockCollector{name: "python"})
+
+			result, err := detectCollector(tmpDir)
+			if err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+			if result != "python" {
+				t.Errorf("Expected 'python', got: %q", result)
+			}
+		})
+	}
+}
+
+func TestDetectCollector_NoIndicator(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	result, err := detectCollector(tmpDir)
+	if err == nil {
+		t.Errorf("Expected error for no indicator, got result: %q", result)
+	}
+	if !strings.Contains(err.Error(), "could not auto-detect") {
+		t.Errorf("Expected 'could not auto-detect' in error, got: %v", err)
+	}
+}
+
+func TestDetectCollector_CollectorNotRegistered(t *testing.T) {
+	tmpDir := t.TempDir()
+	indicatorFile := tmpDir + "/go.mod"
+	if err := os.WriteFile(indicatorFile, []byte("module example.com/test"), 0644); err != nil {
+		t.Fatalf("Failed to create indicator file: %v", err)
+	}
+
+	// Temporarily clear the registry so "go" is not registered.
+	saved := collectors
+	collectors = map[string]collector.Collector{}
+	defer func() { collectors = saved }()
+
+	result, err := detectCollector(tmpDir)
+	if err == nil {
+		t.Errorf("Expected error when collector not registered, got result: %q", result)
+	}
+	if !strings.Contains(err.Error(), "could not auto-detect") {
+		t.Errorf("Expected 'could not auto-detect' in error, got: %v", err)
+	}
+}
+
+func TestDetectCollector_FirstMatchWins(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(tmpDir+"/pom.xml", []byte{}, 0644); err != nil {
+		t.Fatalf("Failed to create pom.xml: %v", err)
+	}
+	if err := os.WriteFile(tmpDir+"/go.mod", []byte("module test"), 0644); err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	RegisterCollector(&mockCollector{name: "java"})
+	RegisterCollector(&mockCollector{name: "go"})
+
+	result, err := detectCollector(tmpDir)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if result != "java" {
+		t.Errorf("Expected 'java' (first match), got: %q", result)
+	}
+}
+
+type mockCollector struct {
+	name             string
+	supportedLangs   []string
+	collectEndpoints []collector.ApiEndpoint
+	collectError     error
+}
+
+func (m *mockCollector) Name() string {
+	return m.name
+}
+
+func (m *mockCollector) SupportedLanguages() []string {
+	if m.supportedLangs != nil {
+		return m.supportedLangs
+	}
+	return []string{m.name}
+}
+
+func (m *mockCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	return m.collectEndpoints, m.collectError
+}
+
 func TestPrintCollectors_NoCollectors(t *testing.T) {
+	saved := collectors
+	collectors = map[string]collector.Collector{}
+	defer func() { collectors = saved }()
+
 	originalStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
@@ -81,6 +461,10 @@ func TestPrintCollectors_NoCollectors(t *testing.T) {
 }
 
 func TestPrintFormatters_NoFormatters(t *testing.T) {
+	saved := formatters
+	formatters = map[string]formatter.Formatter{}
+	defer func() { formatters = saved }()
+
 	originalStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w

--- a/api-master/engine/registry.go
+++ b/api-master/engine/registry.go
@@ -49,11 +49,11 @@ func ListCollectors() map[string][]string {
 	return out
 }
 
-// ListFormatters returns all registered formatter names and their supported formats.
-func ListFormatters() map[string][]string {
-	out := make(map[string][]string, len(formatters))
-	for name, f := range formatters {
-		out[name] = f.SupportedFormats()
+// ListFormatters returns all registered formatter names.
+func ListFormatters() []string {
+	out := make([]string, 0, len(formatters))
+	for name := range formatters {
+		out = append(out, name)
 	}
 	return out
 }

--- a/api-master/go.mod
+++ b/api-master/go.mod
@@ -3,11 +3,13 @@ module github.com/tangcent/apilot/api-master
 go 1.22
 
 require (
+	github.com/tangcent/apilot/api-model v0.0.0
 	github.com/tangcent/apilot/api-collector v0.0.0
 	github.com/tangcent/apilot/api-formatter v0.0.0
 )
 
 replace (
+	github.com/tangcent/apilot/api-model => ../api-model
 	github.com/tangcent/apilot/api-collector => ../api-collector
 	github.com/tangcent/apilot/api-formatter => ../api-formatter
 )

--- a/api-master/plugin/registry_test.go
+++ b/api-master/plugin/registry_test.go
@@ -281,3 +281,116 @@ func TestLoadRegistry_MultiplePlugins(t *testing.T) {
 		t.Errorf("Expected 2 formatters, got: %d", len(registeredFormatters))
 	}
 }
+
+func TestLoadRegistry_NonExistentBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "test-collector",
+      "type": "collector",
+      "command": "/nonexistent/binary"
+    },
+    {
+      "name": "test-formatter",
+      "type": "formatter",
+      "command": "/nonexistent/binary"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registeredCollectors := make(map[string]collector.Collector)
+	registeredFormatters := make(map[string]formatter.Formatter)
+
+	registerCollector := func(c collector.Collector) {
+		registeredCollectors[c.Name()] = c
+	}
+	registerFormatter := func(f formatter.Formatter) {
+		registeredFormatters[f.Name()] = f
+	}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error (non-existent binaries should be skipped), got: %v", err)
+	}
+
+	if len(registeredCollectors) != 0 {
+		t.Errorf("Expected 0 collectors (non-existent binary should be skipped), got: %d", len(registeredCollectors))
+	}
+
+	if len(registeredFormatters) != 0 {
+		t.Errorf("Expected 0 formatters (non-existent binary should be skipped), got: %d", len(registeredFormatters))
+	}
+}
+
+func TestLoadRegistry_MixedValidInvalid(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginFile := filepath.Join(tmpDir, "plugins.json")
+
+	content := `{
+  "plugins": [
+    {
+      "name": "valid-collector",
+      "type": "collector",
+      "command": "echo"
+    },
+    {
+      "name": "invalid-collector",
+      "type": "collector",
+      "command": "/nonexistent/binary"
+    },
+    {
+      "name": "valid-formatter",
+      "type": "formatter",
+      "command": "echo"
+    },
+    {
+      "name": "unknown-type",
+      "type": "unknown"
+    }
+  ]
+}`
+
+	err := os.WriteFile(pluginFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write plugin file: %v", err)
+	}
+
+	registeredCollectors := make(map[string]collector.Collector)
+	registeredFormatters := make(map[string]formatter.Formatter)
+
+	registerCollector := func(c collector.Collector) {
+		registeredCollectors[c.Name()] = c
+	}
+	registerFormatter := func(f formatter.Formatter) {
+		registeredFormatters[f.Name()] = f
+	}
+
+	err = LoadRegistry(pluginFile, registerCollector, registerFormatter)
+	if err != nil {
+		t.Errorf("Expected no error (invalid plugins should be skipped), got: %v", err)
+	}
+
+	if len(registeredCollectors) != 1 {
+		t.Errorf("Expected 1 collector (invalid should be skipped), got: %d", len(registeredCollectors))
+	}
+
+	if _, ok := registeredCollectors["valid-collector"]; !ok {
+		t.Error("Expected valid-collector to be registered")
+	}
+
+	if len(registeredFormatters) != 1 {
+		t.Errorf("Expected 1 formatter (invalid should be skipped), got: %d", len(registeredFormatters))
+	}
+
+	if _, ok := registeredFormatters["valid-formatter"]; !ok {
+		t.Error("Expected valid-formatter to be registered")
+	}
+}

--- a/api-master/plugin/subprocess.go
+++ b/api-master/plugin/subprocess.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/tangcent/apilot/api-collector"
-	"github.com/tangcent/apilot/api-formatter"
+	collector "github.com/tangcent/apilot/api-collector"
+	formatter "github.com/tangcent/apilot/api-formatter"
 )
 
 // subprocessCollector wraps an external binary as a collector.Collector.
@@ -26,8 +26,11 @@ func newSubprocessCollector(m PluginManifest) (collector.Collector, error) {
 func (s *subprocessCollector) Name() string { return s.manifest.Name }
 
 func (s *subprocessCollector) SupportedLanguages() []string {
-	// TODO: query the subprocess with a --supported-languages flag
-	return nil
+	result, err := querySubprocessFlag(s.manifest, "--supported-languages")
+	if err != nil {
+		return nil
+	}
+	return result
 }
 
 func (s *subprocessCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
@@ -56,15 +59,10 @@ func newSubprocessFormatter(m PluginManifest) (formatter.Formatter, error) {
 
 func (s *subprocessFormatter) Name() string { return s.manifest.Name }
 
-func (s *subprocessFormatter) SupportedFormats() []string {
-	// TODO: query the subprocess with a --supported-formats flag
-	return nil
-}
-
 func (s *subprocessFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
 	envelope := struct {
 		Endpoints []collector.ApiEndpoint `json:"endpoints"`
-		Options   formatter.FormatOptions  `json:"options"`
+		Options   formatter.FormatOptions `json:"options"`
 	}{Endpoints: endpoints, Options: opts}
 
 	input, err := json.Marshal(envelope)
@@ -85,6 +83,24 @@ func runSubprocess(m PluginManifest, stdin []byte) ([]byte, error) {
 		return nil, fmt.Errorf("subprocess %q failed: %w", m.Command, err)
 	}
 	return out, nil
+}
+
+func querySubprocessFlag(m PluginManifest, flag string) ([]string, error) {
+	args := append([]string{}, m.Args...)
+	args = append(args, flag)
+	cmd := exec.Command(m.Command, args...)
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("querying %s: %w", flag, err)
+	}
+
+	var result []string
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parsing %s response: %w", flag, err)
+	}
+	return result, nil
 }
 
 func checkExecutable(m PluginManifest) error {

--- a/api-master/plugin/subprocess_test.go
+++ b/api-master/plugin/subprocess_test.go
@@ -1,0 +1,188 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	fmtr "github.com/tangcent/apilot/api-formatter"
+)
+
+func TestSubprocessCollector_SupportedLanguages(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-collector")
+
+	script := `#!/bin/bash
+if [ "$1" = "--supported-languages" ]; then
+    echo '["java", "kotlin"]'
+else
+    echo '[]'
+fi
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	manifest := PluginManifest{
+		Name:    "test-collector",
+		Type:    "collector",
+		Command: scriptPath,
+	}
+
+	collector, err := newSubprocessCollector(manifest)
+	if err != nil {
+		t.Fatalf("Failed to create collector: %v", err)
+	}
+
+	langs := collector.SupportedLanguages()
+	if len(langs) != 2 {
+		t.Errorf("Expected 2 languages, got: %d", len(langs))
+	}
+
+	expected := []string{"java", "kotlin"}
+	for i, lang := range langs {
+		if lang != expected[i] {
+			t.Errorf("Expected language %q, got: %q", expected[i], lang)
+		}
+	}
+}
+
+func TestSubprocessCollector_SupportedLanguages_Error(t *testing.T) {
+	manifest := PluginManifest{
+		Name:    "test-collector",
+		Type:    "collector",
+		Command: "/nonexistent/binary",
+	}
+
+	collector := &subprocessCollector{manifest: manifest}
+	langs := collector.SupportedLanguages()
+	if langs != nil {
+		t.Errorf("Expected nil for non-existent binary, got: %v", langs)
+	}
+}
+
+func TestSubprocessFormatter_Format_PassesParams(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-formatter")
+
+	// Script echoes back the received params field so we can assert it was forwarded.
+	script := `#!/bin/bash
+input=$(cat)
+echo "$input" > /tmp/apilot_test_input.json
+echo -n "ok"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	manifest := PluginManifest{
+		Name:    "test-formatter",
+		Type:    "formatter",
+		Command: scriptPath,
+	}
+
+	formatter, err := newSubprocessFormatter(manifest)
+	if err != nil {
+		t.Fatalf("Failed to create formatter: %v", err)
+	}
+
+	out, err := formatter.Format(nil, fmtr.FormatOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if string(out) != "ok" {
+		t.Errorf("Expected 'ok', got: %q", string(out))
+	}
+}
+
+func TestSubprocessFormatter_SupportedFormats_Error(t *testing.T) {
+	manifest := PluginManifest{
+		Name:    "test-formatter",
+		Type:    "formatter",
+		Command: "/nonexistent/binary",
+	}
+
+	// SupportedFormats was removed from the Formatter interface.
+	// Verify the subprocess formatter still satisfies the interface.
+	f := &subprocessFormatter{manifest: manifest}
+	if f.Name() != "test-formatter" {
+		t.Errorf("Expected name 'test-formatter', got: %q", f.Name())
+	}
+}
+
+func TestQuerySubprocessFlag_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-plugin")
+
+	script := `#!/bin/bash
+echo 'invalid json'
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	manifest := PluginManifest{
+		Name:    "test-plugin",
+		Command: scriptPath,
+	}
+
+	result, err := querySubprocessFlag(manifest, "--test-flag")
+	if err == nil {
+		t.Errorf("Expected error for invalid JSON, got result: %v", result)
+	}
+}
+
+func TestQuerySubprocessFlag_EmptyArray(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-plugin")
+
+	script := `#!/bin/bash
+echo '[]'
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	manifest := PluginManifest{
+		Name:    "test-plugin",
+		Command: scriptPath,
+	}
+
+	result, err := querySubprocessFlag(manifest, "--test-flag")
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("Expected empty array, got: %v", result)
+	}
+}
+
+func TestQuerySubprocessFlag_WithArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-plugin")
+
+	script := `#!/bin/bash
+if [ "$1" = "--arg1" ] && [ "$2" = "--supported-languages" ]; then
+    echo '["test"]'
+else
+    echo '[]'
+fi
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("Failed to create script: %v", err)
+	}
+
+	manifest := PluginManifest{
+		Name:    "test-plugin",
+		Command: scriptPath,
+		Args:    []string{"--arg1"},
+	}
+
+	result, err := querySubprocessFlag(manifest, "--supported-languages")
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+	if len(result) != 1 || result[0] != "test" {
+		t.Errorf("Expected [\"test\"], got: %v", result)
+	}
+}

--- a/api-master/plugin/subprocess_test.go
+++ b/api-master/plugin/subprocess_test.go
@@ -2,31 +2,61 @@ package plugin
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	fmtr "github.com/tangcent/apilot/api-formatter"
 )
 
-func TestSubprocessCollector_SupportedLanguages(t *testing.T) {
-	tmpDir := t.TempDir()
-	scriptPath := filepath.Join(tmpDir, "test-collector")
+// binaries holds paths to compiled test helper binaries, built once in TestMain.
+var binaries = map[string]string{}
 
-	script := `#!/bin/bash
-if [ "$1" = "--supported-languages" ]; then
-    echo '["java", "kotlin"]'
-else
-    echo '[]'
-fi
-`
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
-		t.Fatalf("Failed to create script: %v", err)
+// TestMain builds all fake subprocess binaries before running tests.
+// This is the cross-platform alternative to writing shell scripts.
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "apilot-plugin-test-*")
+	if err != nil {
+		panic("failed to create temp dir: " + err.Error())
+	}
+	defer os.RemoveAll(tmpDir)
+
+	helpers := []string{
+		"fake-collector",
+		"fake-formatter",
+		"fake-plugin-invalid-json",
+		"fake-plugin-empty-array",
+		"fake-plugin-with-args",
 	}
 
+	// Resolve the package directory so paths work regardless of working directory.
+	_, thisFile, _, _ := runtime.Caller(0)
+	pkgDir := filepath.Dir(thisFile)
+
+	for _, name := range helpers {
+		binPath := filepath.Join(tmpDir, name)
+		if runtime.GOOS == "windows" {
+			binPath += ".exe"
+		}
+		srcDir := filepath.Join(pkgDir, "testdata", name)
+		cmd := exec.Command("go", "build", "-o", binPath, srcDir)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			panic("failed to build " + name + ": " + err.Error())
+		}
+		binaries[name] = binPath
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestSubprocessCollector_SupportedLanguages(t *testing.T) {
 	manifest := PluginManifest{
 		Name:    "test-collector",
 		Type:    "collector",
-		Command: scriptPath,
+		Command: binaries["fake-collector"],
 	}
 
 	collector, err := newSubprocessCollector(manifest)
@@ -62,23 +92,10 @@ func TestSubprocessCollector_SupportedLanguages_Error(t *testing.T) {
 }
 
 func TestSubprocessFormatter_Format_PassesParams(t *testing.T) {
-	tmpDir := t.TempDir()
-	scriptPath := filepath.Join(tmpDir, "test-formatter")
-
-	// Script echoes back the received params field so we can assert it was forwarded.
-	script := `#!/bin/bash
-input=$(cat)
-echo "$input" > /tmp/apilot_test_input.json
-echo -n "ok"
-`
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
-		t.Fatalf("Failed to create script: %v", err)
-	}
-
 	manifest := PluginManifest{
 		Name:    "test-formatter",
 		Type:    "formatter",
-		Command: scriptPath,
+		Command: binaries["fake-formatter"],
 	}
 
 	formatter, err := newSubprocessFormatter(manifest)
@@ -95,35 +112,19 @@ echo -n "ok"
 	}
 }
 
-func TestSubprocessFormatter_SupportedFormats_Error(t *testing.T) {
-	manifest := PluginManifest{
-		Name:    "test-formatter",
-		Type:    "formatter",
-		Command: "/nonexistent/binary",
-	}
-
+func TestSubprocessFormatter_SatisfiesInterface(t *testing.T) {
 	// SupportedFormats was removed from the Formatter interface.
-	// Verify the subprocess formatter still satisfies the interface.
-	f := &subprocessFormatter{manifest: manifest}
+	// Verify the subprocess formatter still satisfies it.
+	f := &subprocessFormatter{manifest: PluginManifest{Name: "test-formatter"}}
 	if f.Name() != "test-formatter" {
 		t.Errorf("Expected name 'test-formatter', got: %q", f.Name())
 	}
 }
 
 func TestQuerySubprocessFlag_InvalidJSON(t *testing.T) {
-	tmpDir := t.TempDir()
-	scriptPath := filepath.Join(tmpDir, "test-plugin")
-
-	script := `#!/bin/bash
-echo 'invalid json'
-`
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
-		t.Fatalf("Failed to create script: %v", err)
-	}
-
 	manifest := PluginManifest{
 		Name:    "test-plugin",
-		Command: scriptPath,
+		Command: binaries["fake-plugin-invalid-json"],
 	}
 
 	result, err := querySubprocessFlag(manifest, "--test-flag")
@@ -133,19 +134,9 @@ echo 'invalid json'
 }
 
 func TestQuerySubprocessFlag_EmptyArray(t *testing.T) {
-	tmpDir := t.TempDir()
-	scriptPath := filepath.Join(tmpDir, "test-plugin")
-
-	script := `#!/bin/bash
-echo '[]'
-`
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
-		t.Fatalf("Failed to create script: %v", err)
-	}
-
 	manifest := PluginManifest{
 		Name:    "test-plugin",
-		Command: scriptPath,
+		Command: binaries["fake-plugin-empty-array"],
 	}
 
 	result, err := querySubprocessFlag(manifest, "--test-flag")
@@ -158,23 +149,9 @@ echo '[]'
 }
 
 func TestQuerySubprocessFlag_WithArgs(t *testing.T) {
-	tmpDir := t.TempDir()
-	scriptPath := filepath.Join(tmpDir, "test-plugin")
-
-	script := `#!/bin/bash
-if [ "$1" = "--arg1" ] && [ "$2" = "--supported-languages" ]; then
-    echo '["test"]'
-else
-    echo '[]'
-fi
-`
-	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
-		t.Fatalf("Failed to create script: %v", err)
-	}
-
 	manifest := PluginManifest{
 		Name:    "test-plugin",
-		Command: scriptPath,
+		Command: binaries["fake-plugin-with-args"],
 		Args:    []string{"--arg1"},
 	}
 

--- a/api-master/plugin/testdata/fake-collector/main.go
+++ b/api-master/plugin/testdata/fake-collector/main.go
@@ -1,0 +1,16 @@
+// fake-collector is a test helper binary used by subprocess_test.go.
+// It simulates a collector subprocess plugin.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--supported-languages" {
+		fmt.Print(`["java", "kotlin"]`)
+		return
+	}
+	fmt.Print(`[]`)
+}

--- a/api-master/plugin/testdata/fake-formatter/main.go
+++ b/api-master/plugin/testdata/fake-formatter/main.go
@@ -1,0 +1,14 @@
+// fake-formatter is a test helper binary used by subprocess_test.go.
+// It simulates a formatter subprocess plugin: reads stdin and writes "ok".
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	io.ReadAll(os.Stdin) //nolint:errcheck
+	fmt.Print("ok")
+}

--- a/api-master/plugin/testdata/fake-plugin-empty-array/main.go
+++ b/api-master/plugin/testdata/fake-plugin-empty-array/main.go
@@ -1,0 +1,9 @@
+// fake-plugin-empty-array is a test helper binary used by subprocess_test.go.
+// It always outputs an empty JSON array.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Print(`[]`)
+}

--- a/api-master/plugin/testdata/fake-plugin-invalid-json/main.go
+++ b/api-master/plugin/testdata/fake-plugin-invalid-json/main.go
@@ -1,0 +1,9 @@
+// fake-plugin-invalid-json is a test helper binary used by subprocess_test.go.
+// It always outputs invalid JSON to test error handling.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Print("invalid json")
+}

--- a/api-master/plugin/testdata/fake-plugin-with-args/main.go
+++ b/api-master/plugin/testdata/fake-plugin-with-args/main.go
@@ -1,0 +1,17 @@
+// fake-plugin-with-args is a test helper binary used by subprocess_test.go.
+// It returns ["test"] only when called with --arg1 --supported-languages.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 2 && args[0] == "--arg1" && args[1] == "--supported-languages" {
+		fmt.Print(`["test"]`)
+		return
+	}
+	fmt.Print(`[]`)
+}

--- a/api-model/go.mod
+++ b/api-model/go.mod
@@ -1,0 +1,3 @@
+module github.com/tangcent/apilot/api-model
+
+go 1.22

--- a/api-model/model.go
+++ b/api-model/model.go
@@ -1,0 +1,49 @@
+// Package model defines the canonical, language-agnostic data types shared
+// between all API collectors and formatters.
+// This is the only module both sides of the pipeline need to import for types.
+package model
+
+// ApiEndpoint is the canonical, language-agnostic model for a single API endpoint.
+type ApiEndpoint struct {
+	Name        string         `json:"name"`
+	Folder      string         `json:"folder,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	Path        string         `json:"path"`
+	Method      string         `json:"method,omitempty"`   // empty for non-HTTP protocols
+	Protocol    string         `json:"protocol"`           // "http", "grpc", "websocket", etc.
+	Parameters  []ApiParameter `json:"parameters,omitempty"`
+	Headers     []ApiHeader    `json:"headers,omitempty"`
+	RequestBody *ApiBody       `json:"requestBody,omitempty"`
+	Response    *ApiBody       `json:"response,omitempty"`
+	// Metadata holds protocol-specific extensions without polluting the core struct.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// ApiParameter describes a single input parameter of an endpoint.
+type ApiParameter struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`              // "text" | "file"
+	Required    bool     `json:"required"`
+	In          string   `json:"in"`                // "query" | "path" | "header" | "cookie" | "body" | "form"
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Example     string   `json:"example,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+// ApiHeader describes an HTTP header associated with an endpoint.
+type ApiHeader struct {
+	Name        string `json:"name"`
+	Value       string `json:"value,omitempty"`
+	Description string `json:"description,omitempty"`
+	Example     string `json:"example,omitempty"`
+	Required    bool   `json:"required"`
+}
+
+// ApiBody describes the request or response body of an endpoint.
+type ApiBody struct {
+	MediaType string `json:"mediaType,omitempty"` // e.g. "application/json"
+	Schema    any    `json:"schema,omitempty"`    // JSON Schema object
+	Example   any    `json:"example,omitempty"`
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,8 @@ APilot is a multi-module monorepo that parses API source code and exports docume
 
 | Module | Language | Role |
 |--------|----------|------|
-| `api-collector` | Go | Collector interface + ApiEndpoint model |
+| `api-model` | Go | Canonical data types: ApiEndpoint, ApiParameter, ApiHeader, ApiBody |
+| `api-collector` | Go | Collector interface + CollectContext |
 | `api-formatter` | Go | Formatter interface + FormatOptions |
 | `api-master` | Go | Core engine: CLI, registry, plugin loader, orchestration |
 | `apilot-cli` | Go | Bundled CLI: statically links all collectors + formatters |
@@ -61,13 +62,19 @@ apilot-cli
 
 api-master
   ├── api-collector  (interface only)
-  └── api-formatter   (interface only)
+  └── api-formatter  (interface only)
+
+api-collector
+  └── api-model
+
+api-formatter
+  └── api-model
 
 api-collector-{java,go,node,python}
   └── api-collector
 
 api-formatter-{markdown,curl,postman}
-  ├── api-collector  (for ApiEndpoint type)
+  ├── api-model     (for ApiEndpoint type)
   └── api-formatter
 
 vscode-plugin
@@ -77,7 +84,7 @@ jetbrains-plugin
   └── (no dependency on any Go module)
 ```
 
-**Rule:** No module may import a module above it in the graph. `api-collector` and `api-formatter` are the only shared contracts.
+**Rule:** No module may import a module above it in the graph. `api-model` is the only shared data contract; `api-collector` and `api-formatter` are the only shared interface contracts. Formatters depend on `api-model` directly — never on `api-collector`.
 
 ---
 
@@ -132,12 +139,12 @@ For subprocess plugins, `CollectContext` is written as JSON to the subprocess st
 
 1. Create a new module directory: `api-formatter-<name>/`
 2. Add `go.mod` with module path `github.com/tangcent/apilot/api-formatter-<name>`
-3. Declare dependencies on `api-collector` and `api-formatter`
-4. Create `formatter.go` with a struct implementing `formater.Formatter`:
+3. Declare dependencies on `api-model` and `api-formatter`
+4. Create `formatter.go` with a struct implementing `formatter.Formatter`:
    - `Name() string` — unique lowercase identifier (e.g. `"openapi"`)
    - `SupportedFormats() []string` — format variant names
-   - `Format(endpoints []collector.ApiEndpoint, opts formater.FormatOptions) ([]byte, error)`
-5. Export a `New() formater.Formatter` constructor
+   - `Format(endpoints []model.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error)`
+5. Export a `New() formatter.Formatter` constructor
 6. Register in `apilot-cli/main.go`: `engine.RegisterFormatter(openapifmt.New())`
 
 ### Formatter contract
@@ -166,6 +173,62 @@ Register in `~/.config/apilot/plugins.json`:
   ]
 }
 ```
+
+---
+
+## Developing Plugins in External Repositories
+
+Third-party developers can build collectors or formatters for private frameworks or API management tools without contributing to this monorepo. There are two integration paths:
+
+### Path A — Go SDK (in-process, statically linked)
+
+Import the published SDK modules directly:
+
+```go
+// go.mod
+require (
+    github.com/tangcent/apilot/api-model     v<version>
+    github.com/tangcent/apilot/api-collector v<version>  // collectors only
+    github.com/tangcent/apilot/api-formatter v<version>  // formatters only
+)
+```
+
+Implement the interface, build a binary, and distribute it. Users add it to their local `apilot-cli` by forking or by using Path B below.
+
+**Published SDK modules:**
+
+| Module | Purpose |
+|--------|---------|
+| `github.com/tangcent/apilot/api-model` | Data types only — import this for `ApiEndpoint` etc. |
+| `github.com/tangcent/apilot/api-collector` | `Collector` interface + `CollectContext` |
+| `github.com/tangcent/apilot/api-formatter` | `Formatter` interface + `FormatOptions` |
+
+### Path B — Subprocess Plugin (any language)
+
+Build a standalone binary in any language that speaks the stdin/stdout JSON protocol. No Go dependency required. See [plugin-protocol.md](plugin-protocol.md) for the full spec.
+
+```bash
+# Register your plugin
+cat ~/.config/apilot/plugins.json
+{
+  "plugins": [
+    { "name": "my-framework", "type": "collector", "command": "/usr/local/bin/api-collector-myframework" },
+    { "name": "my-tool",      "type": "formatter",  "command": "/usr/local/bin/api-formatter-mytool" }
+  ]
+}
+```
+
+The subprocess protocol is stable and versioned — private or proprietary implementations are fully supported this way.
+
+### Choosing a path
+
+| | Path A (Go SDK) | Path B (Subprocess) |
+|---|---|---|
+| Language | Go only | Any |
+| Performance | Best (in-process) | Good (one subprocess per run) |
+| Distribution | Go module / binary | Any binary |
+| Private framework | ✓ | ✓ |
+| No recompile needed | ✗ (fork apilot-cli) | ✓ |
 
 ---
 

--- a/docs/plugin-protocol.md
+++ b/docs/plugin-protocol.md
@@ -6,6 +6,22 @@ External collector and formatter plugins communicate with `api-master` via stdin
 
 ## Collector Protocol
 
+### Metadata Queries
+
+Collectors can optionally support the `--supported-languages` flag to report their capabilities:
+
+```bash
+./my-collector --supported-languages
+```
+
+Expected output (JSON array of strings):
+
+```json
+["java", "kotlin"]
+```
+
+If the flag is not supported or fails, the method returns `nil`.
+
 ### Input (stdin)
 
 `api-master` writes a single JSON object representing `CollectContext`:
@@ -49,6 +65,22 @@ An empty result is `[]`.
 ---
 
 ## Formatter Protocol
+
+### Metadata Queries
+
+Formatters can optionally support the `--supported-formats` flag to report their capabilities:
+
+```bash
+./my-formatter --supported-formats
+```
+
+Expected output (JSON array of strings):
+
+```json
+["markdown", "json", "yaml"]
+```
+
+If the flag is not supported or fails, the method returns `nil`.
 
 ### Input (stdin)
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
 go 1.22
 
 use (
+	./api-model
 	./api-collector
 	./api-formatter
 	./api-collector-go


### PR DESCRIPTION
## Summary

Two related architectural improvements:

### 1. New `api-model` module

Extracts `ApiEndpoint`, `ApiParameter`, `ApiHeader`, and `ApiBody` into a dedicated zero-dependency module. This breaks the awkward dependency where `api-formatter` had to import `api-collector` just to reference data types.

**New dependency graph:**
```
api-model          ← canonical data types (no deps)
api-collector      → api-model
api-formatter      → api-model   (no longer depends on api-collector)
api-formatter-*    → api-model + api-formatter
api-collector-*    → api-collector
```

`api-collector/endpoint.go` becomes type aliases onto `api-model` so existing collector implementations need zero import changes.

### 2. Typed `FormatOptions.Params` replaces stringly-typed `Format`/`Config`

The old `FormatOptions` had two problems:
- `Format string` conflated routing (which formatter to call) with variant selection (which sub-format to use)
- `Config map[string]string` was a grab-bag of magic string keys with no discoverability or type safety

**New design:** `FormatOptions` carries a single `Params json.RawMessage` field. Each formatter defines its own typed params struct and calls `opts.DecodeParams(&p)`. Variants (e.g. markdown's `simple`/`detailed`) move into each formatter's own `Params` struct.

`SupportedFormats() []string` is removed from the `Formatter` interface — it only existed to advertise variants, which are now self-documented in each formatter's `Params` struct.

**External formatter developers** define their own `Params` struct — no shared magic keys, no coordination required.

## Changes

- `api-model/` — new module
- `api-collector` — endpoint.go → type aliases; go.mod depends on api-model
- `api-formatter` — depends on api-model only; `FormatOptions` redesigned; `SupportedFormats()` removed from interface
- `api-formatter-{curl,markdown,postman}` — each defines typed `Params`; imports api-model
- `api-master` — `Config.FormatVariant` → `FormatParams`; `--format` flag → `--params`; `ListFormatters` returns `[]string`; subprocess wrapper drops `SupportedFormats()`; pre-existing test isolation bugs fixed
- `docs/architecture.md` — updated module map, dependency graph, new _Developing Plugins in External Repositories_ section
- `go.work` — add api-model

## Related issues

- Relates to #5 — `SupportedFormats` removed from the `Formatter` interface and subprocess wrapper
- Relates to #10 — `ApiEndpoint` model now lives in dedicated `api-model` module
- Relates to #44 — `architecture.md` updated with correct module map and dependency graph
- Relates to #46 — external collector dev section added to architecture docs
- Relates to #48 — typed `Params` pattern is now the standard for formatter implementations