### PR TITLE
feat: implement Fiber route parser using go/ast

### DIFF
--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -1,10 +1,601 @@
 // Package fiber parses Fiber route registrations using Go's standard go/ast package.
+// It walks Go source files for fiber.App and fiber.Router method calls
+// (Get, Post, Put, Delete, Patch) and extracts endpoint metadata
+// including path, HTTP method, handler name, doc comments, parameters,
+// request body, and response body.
 package fiber
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+// fiberMethods maps Fiber route-registration method names that we recognize.
+// Fiber uses capitalized first letter (Get, Post, etc.) unlike Gin/Echo (GET, POST).
+var fiberMethods = map[string]bool{
+	"Get":    true,
+	"Post":   true,
+	"Put":    true,
+	"Delete": true,
+	"Patch":  true,
+}
 
 // Parse extracts endpoints from Fiber route registrations in the given source directory.
+//
+// It performs the following extractions per file:
+//  1. Function doc comments — builds a map from function name to its
+//     Go doc comment text, used later to populate ApiEndpoint.Description.
+//  2. Handler body analysis — inspects each function's body for *fiber.Ctx
+//     method calls to discover query params, form params, path params,
+//     request body bindings, and response writes.
+//  3. Group prefixes — finds assignments like
+//     `v1 := app.Group("/v1")` and records the variable-to-prefix mapping,
+//     so that subsequent route calls on that variable (e.g. `v1.Get("/users", ...)`)
+//     resolve to the full path `/v1/users`.
+//  4. Route registrations — finds method calls matching the Fiber HTTP
+//     method names (Get, Post, Put, Delete, Patch) and extracts
+//     the path (first argument as a string literal), HTTP method (from the call
+//     selector name, uppercased for output), handler function name, and the
+//     handler's doc comment.
+//
+// After merging per-file results, path parameters are extracted from the route
+// path string (e.g. `/users/:id` → path param "id"), and the handler body
+// analysis is applied to populate Parameters, RequestBody, and Response.
+//
+// Memory optimization:
+//   - Files are discovered first via filepath.Walk, then parsed and processed
+//     one at a time in goroutines. Each goroutine processes a single file and
+//     sends its partial results through channels, so we never hold all ASTs in
+//     memory simultaneously beyond what is needed for the current file.
+//   - Maps are merged incrementally as results arrive.
+//
+// Per the collector contract:
+//   - Returns nil, nil (not an error) when no endpoints are found.
+//   - Skips unparseable files silently.
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	// TODO: implement using go/parser and go/ast
-	return nil, nil
+	goFiles, err := discoverGoFiles(sourceDir)
+	if err != nil || len(goFiles) == 0 {
+		return nil, nil
+	}
+
+	ch := make(chan fileResult, len(goFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range goFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	funcDocs := make(map[string]string)
+	groupPrefixes := make(map[string]string)
+	handlerAnalyses := make(map[string]handlerAnalysis)
+	var allRaw []rawEndpoint
+
+	for res := range ch {
+		for k, v := range res.funcDocs {
+			funcDocs[k] = v
+		}
+		for k, v := range res.groupPrefixes {
+			groupPrefixes[k] = v
+		}
+		for k, v := range res.handlerAnalyses {
+			handlerAnalyses[k] = v
+		}
+		allRaw = append(allRaw, res.rawEndpoints...)
+	}
+
+	if len(allRaw) == 0 {
+		return nil, nil
+	}
+
+	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
+	for _, raw := range allRaw {
+		path := raw.path
+		prefix := groupPrefixes[raw.receiverVar]
+		if prefix != "" {
+			path = prefix + path
+		}
+
+		handlerKey := raw.handlerName
+		if idx := strings.LastIndex(handlerKey, "."); idx >= 0 {
+			handlerKey = handlerKey[idx+1:]
+		}
+
+		ep := collector.ApiEndpoint{
+			Name:        raw.handlerName,
+			Path:        path,
+			Method:      strings.ToUpper(raw.method),
+			Protocol:    "http",
+			Description: funcDocs[handlerKey],
+		}
+
+		pathParams := extractPathParams(path)
+
+		paramSet := make(map[string]bool)
+		var params []collector.ApiParameter
+		for _, p := range pathParams {
+			params = append(params, collector.ApiParameter{
+				Name:     p.name,
+				In:       p.in,
+				Required: p.required,
+				Type:     p.typ,
+			})
+			paramSet[p.name+"|"+p.in] = true
+		}
+
+		analysis := handlerAnalyses[handlerKey]
+		for _, p := range analysis.params {
+			key := p.name + "|" + p.in
+			if !paramSet[key] {
+				params = append(params, collector.ApiParameter{
+					Name:     p.name,
+					In:       p.in,
+					Required: p.required,
+					Type:     p.typ,
+					Default:  p.def,
+				})
+				paramSet[key] = true
+			}
+		}
+
+		if len(params) > 0 {
+			ep.Parameters = params
+		}
+
+		if analysis.requestBody != nil {
+			ep.RequestBody = &collector.ApiBody{
+				MediaType: analysis.requestBody.mediaType,
+			}
+			if analysis.requestBody.typeName != "" {
+				ep.RequestBody.Schema = map[string]string{"type": analysis.requestBody.typeName}
+			}
+		}
+
+		if analysis.response != nil {
+			ep.Response = &collector.ApiBody{
+				MediaType: analysis.response.mediaType,
+			}
+			if analysis.response.typeName != "" {
+				ep.Response.Schema = map[string]string{"type": analysis.response.typeName}
+			}
+		}
+
+		endpoints = append(endpoints, ep)
+	}
+
+	return endpoints, nil
+}
+
+// rawParam holds parameter info extracted from handler body or path string.
+type rawParam struct {
+	name     string
+	in       string // "path", "query", "form", "header", "cookie"
+	required bool
+	def      string
+	typ      string // "text" or "file"
+}
+
+// rawBody holds request/response body info extracted from handler body.
+type rawBody struct {
+	mediaType string
+	typeName  string
+}
+
+// rawEndpoint holds the raw data extracted from a single route-registration call
+// before group-prefix resolution and doc-comment lookup.
+type rawEndpoint struct {
+	method      string
+	path        string
+	handlerName string
+	receiverVar string
+}
+
+// handlerAnalysis holds the extracted info from analyzing a handler function body.
+type handlerAnalysis struct {
+	params      []rawParam
+	requestBody *rawBody
+	response    *rawBody
+}
+
+// fileResult holds the per-file extraction output produced by processFile.
+type fileResult struct {
+	funcDocs        map[string]string
+	groupPrefixes   map[string]string
+	rawEndpoints    []rawEndpoint
+	handlerAnalyses map[string]handlerAnalysis
+}
+
+// discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
+// Returns nil on any filesystem error (per collector contract: skip gracefully).
+func discoverGoFiles(sourceDir string) ([]string, error) {
+	var goFiles []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			goFiles = append(goFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return goFiles, nil
+}
+
+// processFile parses a single Go source file and extracts:
+//   - funcDocs: map of function names to their doc comment text
+//   - handlerAnalyses: map of function names to their handler body analysis
+//   - groupPrefixes: map of variable names to their Fiber Group prefix
+//   - rawEndpoints: route registrations found in this file
+func processFile(filePath string) fileResult {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return fileResult{}
+	}
+
+	funcDocs := make(map[string]string)
+	handlerAnalyses := make(map[string]handlerAnalysis)
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		name := fn.Name.Name
+		if fn.Doc != nil {
+			funcDocs[name] = strings.TrimSpace(fn.Doc.Text())
+		}
+		params, reqBody, respBody := analyzeHandlerBody(fn)
+		if len(params) > 0 || reqBody != nil || respBody != nil {
+			handlerAnalyses[name] = handlerAnalysis{
+				params:      params,
+				requestBody: reqBody,
+				response:    respBody,
+			}
+		}
+	}
+
+	groupPrefixes := make(map[string]string)
+	ast.Inspect(f, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range assign.Lhs {
+			ident, ok := lhs.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			if i >= len(assign.Rhs) {
+				continue
+			}
+			prefix := extractGroupPrefix(assign.Rhs[i])
+			if prefix != "" {
+				groupPrefixes[ident.Name] = prefix
+			}
+		}
+		return true
+	})
+
+	var rawEndpoints []rawEndpoint
+	ast.Inspect(f, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		methodName := selExpr.Sel.Name
+		if !fiberMethods[methodName] {
+			return true
+		}
+
+		if len(callExpr.Args) < 2 {
+			return true
+		}
+
+		path := extractStringLiteral(callExpr.Args[0])
+		handlerName := extractHandlerName(callExpr.Args[1])
+		receiverVar := resolveReceiverVar(selExpr.X)
+
+		rawEndpoints = append(rawEndpoints, rawEndpoint{
+			method:      methodName,
+			path:        path,
+			handlerName: handlerName,
+			receiverVar: receiverVar,
+		})
+		return true
+	})
+
+	return fileResult{
+		funcDocs:        funcDocs,
+		groupPrefixes:   groupPrefixes,
+		rawEndpoints:    rawEndpoints,
+		handlerAnalyses: handlerAnalyses,
+	}
+}
+
+// analyzeHandlerBody inspects the handler function body to extract query params,
+// form params, path params, request body bindings, and response writes
+// by walking *fiber.Ctx method calls.
+//
+// Recognized fiber.Ctx methods:
+//   - Params                          → path parameter (from c.Params("name"))
+//   - Query                           → query parameter (required)
+//   - QueryInt / QueryBool / QueryFloat → query parameter (required, typed)
+//   - FormValue                       → form parameter
+//   - FormFile                        → file parameter (type="file")
+//   - Get                             → header parameter (c.Get("Header-Name"))
+//   - Cookies                         → cookie parameter
+//   - BodyParser                      → request body (auto-detect media type)
+//   - JSON                            → JSON response
+//   - XML                             → XML response
+//   - SendString                      → text/plain response
+//   - Send / SendStatus               → binary response (application/octet-stream)
+func analyzeHandlerBody(fn *ast.FuncDecl) ([]rawParam, *rawBody, *rawBody) {
+	if fn.Body == nil {
+		return nil, nil, nil
+	}
+
+	ctxVar := findContextParamName(fn)
+	if ctxVar == "" {
+		return nil, nil, nil
+	}
+
+	var params []rawParam
+	var requestBody *rawBody
+	var response *rawBody
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		callExpr, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		ident, ok := selExpr.X.(*ast.Ident)
+		if !ok || ident.Name != ctxVar {
+			return true
+		}
+
+		methodName := selExpr.Sel.Name
+
+		switch methodName {
+		case "Params":
+			if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+				params = append(params, rawParam{name: name, in: "path", required: true, typ: "text"})
+			}
+		case "Query", "QueryInt", "QueryBool", "QueryFloat":
+			if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+				params = append(params, rawParam{name: name, in: "query", required: true, typ: "text"})
+			}
+		case "FormValue":
+			if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+				params = append(params, rawParam{name: name, in: "form", required: true, typ: "text"})
+			}
+		case "FormFile":
+			if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+				params = append(params, rawParam{name: name, in: "form", required: true, typ: "file"})
+			}
+		case "Get":
+			if len(callExpr.Args) >= 1 {
+				if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+					params = append(params, rawParam{name: name, in: "header", required: false, typ: "text"})
+				}
+			}
+		case "Cookies":
+			if len(callExpr.Args) >= 1 {
+				if name := extractStringLiteral(callExpr.Args[0]); name != "" {
+					params = append(params, rawParam{name: name, in: "cookie", required: false, typ: "text"})
+				}
+			}
+		case "BodyParser":
+			typeName := ""
+			if len(callExpr.Args) >= 1 {
+				typeName = extractTypeName(callExpr.Args[0])
+			}
+			requestBody = &rawBody{mediaType: "application/json", typeName: typeName}
+		case "JSON":
+			typeName := ""
+			if len(callExpr.Args) >= 1 {
+				typeName = extractTypeName(callExpr.Args[0])
+			}
+			response = &rawBody{mediaType: "application/json", typeName: typeName}
+		case "XML":
+			typeName := ""
+			if len(callExpr.Args) >= 1 {
+				typeName = extractTypeName(callExpr.Args[0])
+			}
+			response = &rawBody{mediaType: "application/xml", typeName: typeName}
+		case "SendString":
+			response = &rawBody{mediaType: "text/plain"}
+		case "Send", "SendStatus":
+			response = &rawBody{mediaType: "application/octet-stream"}
+		}
+
+		return true
+	})
+
+	return params, requestBody, response
+}
+
+// findContextParamName returns the variable name of the *fiber.Ctx parameter
+// in the given function declaration. Returns "" if no fiber.Ctx parameter is found.
+func findContextParamName(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return ""
+	}
+
+	for _, param := range fn.Type.Params.List {
+		if isFiberContext(param.Type) && len(param.Names) > 0 {
+			return param.Names[0].Name
+		}
+	}
+
+	return ""
+}
+
+// isFiberContext checks if the expression represents *fiber.Ctx.
+func isFiberContext(expr ast.Expr) bool {
+	starExpr, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+
+	selExpr, ok := starExpr.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	if selExpr.Sel.Name != "Ctx" {
+		return false
+	}
+
+	ident, ok := selExpr.X.(*ast.Ident)
+	return ok && ident.Name == "fiber"
+}
+
+// extractTypeName returns a human-readable type name from an expression.
+// Handles:
+//   - &obj  → "obj"
+//   - obj   → "obj"
+//   - Type{} → "Type"
+//   - pkg.Type{} → "pkg.Type"
+//   - map[...]... → "map"
+func extractTypeName(expr ast.Expr) string {
+	if unary, ok := expr.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+		expr = unary.X
+	}
+
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		if x, ok := e.X.(*ast.Ident); ok {
+			return x.Name + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.CompositeLit:
+		return extractTypeName(e.Type)
+	case *ast.MapType:
+		return "map"
+	}
+
+	return ""
+}
+
+// extractPathParams parses path parameters from a Fiber route path.
+// Fiber uses `:paramName` syntax for path parameters (e.g. `/users/:id` → param "id").
+func extractPathParams(path string) []rawParam {
+	var params []rawParam
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, ":") {
+			name := segment[1:]
+			params = append(params, rawParam{
+				name:     name,
+				in:       "path",
+				required: true,
+				typ:      "text",
+			})
+		}
+	}
+	return params
+}
+
+// extractStringLiteral returns the unquoted string value of a BasicLit node,
+// supporting both double-quoted and backtick-quoted strings.
+func extractStringLiteral(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	s := lit.Value
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// extractHandlerName returns the handler function name from the second argument
+// of a Fiber route-registration call. Supports:
+//   - Simple identifier: listUsers → "listUsers"
+//   - Selector expression: handler.ListUsers → "handler.ListUsers"
+//   - Any other form (closure, call): returns ""
+func extractHandlerName(expr ast.Expr) string {
+	switch arg := expr.(type) {
+	case *ast.Ident:
+		return arg.Name
+	case *ast.SelectorExpr:
+		if x, ok := arg.X.(*ast.Ident); ok {
+			return x.Name + "." + arg.Sel.Name
+		}
+		return arg.Sel.Name
+	default:
+		return ""
+	}
+}
+
+// extractGroupPrefix checks if an expression is a fiber.App.Group() call
+// and returns the prefix string literal from its first argument.
+// For example, `app.Group("/v1")` returns "/v1".
+func extractGroupPrefix(expr ast.Expr) string {
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+
+	selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+
+	if selExpr.Sel.Name != "Group" {
+		return ""
+	}
+
+	if len(callExpr.Args) < 1 {
+		return ""
+	}
+
+	return extractStringLiteral(callExpr.Args[0])
+}
+
+// resolveReceiverVar returns the variable name of a selector expression's
+// receiver (the X part of X.Method). Used to look up group prefixes later.
+// Returns "" if the receiver is not a simple identifier.
+func resolveReceiverVar(expr ast.Expr) string {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return ident.Name
 }

--- a/api-collector-go/fiber/parser_test.go
+++ b/api-collector-go/fiber/parser_test.go
@@ -1,0 +1,295 @@
+package fiber
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector"
+)
+
+func TestParse_EmptyDir(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "empty"))
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for empty dir, got %d", len(endpoints))
+	}
+}
+
+func TestParse_NoRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "noroutes"))
+	if err != nil {
+		t.Fatalf("no routes should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for no routes, got %d", len(endpoints))
+	}
+}
+
+func TestParse_BasicRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "basic"))
+	if err != nil {
+		t.Fatalf("basic routes should not error: %v", err)
+	}
+	if len(endpoints) != 7 {
+		t.Fatalf("expected 7 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "deleteUser", Path: "/users/:id", Method: "DELETE", Protocol: "http",
+		Description: "deleteUser removes a user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/octet-stream"},
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "listUsers", Path: "/users", Method: "GET", Protocol: "http",
+		Description: "listUsers returns all users.",
+		Parameters: []collector.ApiParameter{
+			{Name: "name", In: "query", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "getUser", Path: "/users/:id", Method: "GET", Protocol: "http",
+		Description: "getUser returns a single user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "patchUser", Path: "/users/:id", Method: "PATCH", Protocol: "http",
+		Description: "patchUser partially updates a user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+			{Name: "name", In: "query", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
+		Name: "uploadFile", Path: "/upload", Method: "POST", Protocol: "http",
+		Description: "uploadFile handles file uploads.",
+		Parameters: []collector.ApiParameter{
+			{Name: "file", In: "form", Required: true, Type: "file"},
+			{Name: "description", In: "form", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
+		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
+		Description: "createUser creates a new user.",
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+	})
+
+	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
+		Name: "updateUser", Path: "/users/:id", Method: "PUT", Protocol: "http",
+		Description: "updateUser updates an existing user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+	})
+}
+
+func TestParse_GroupRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "groups"))
+	if err != nil {
+		t.Fatalf("group routes should not error: %v", err)
+	}
+	if len(endpoints) != 5 {
+		t.Fatalf("expected 5 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return endpoints[i].Method < endpoints[j].Method
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "listItems", Path: "/api/items", Method: "GET", Protocol: "http",
+		Description: "listItems returns all items.",
+		Response:    &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "deleteItem", Path: "/api/items/:id", Method: "DELETE", Protocol: "http",
+		Description: "deleteItem removes an item by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/octet-stream"},
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "healthCheck", Path: "/health", Method: "GET", Protocol: "http",
+		Description: "healthCheck returns service health status.",
+		Response:    &collector.ApiBody{MediaType: "text/plain"},
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "listUsers", Path: "/v1/users", Method: "GET", Protocol: "http",
+		Description: "listUsers returns all users.",
+		Parameters: []collector.ApiParameter{
+			{Name: "name", In: "query", Required: true, Type: "text"},
+		},
+		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+
+	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
+		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
+		Description: "createUser creates a new user.",
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+	})
+}
+
+func TestParse_NonexistentDir(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "nonexistent"))
+	if err != nil {
+		t.Fatalf("nonexistent dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for nonexistent dir, got %d", len(endpoints))
+	}
+}
+
+func TestExtractPathParams(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected []rawParam
+	}{
+		{"/users", nil},
+		{"/users/:id", []rawParam{{name: "id", in: "path", required: true, typ: "text"}}},
+		{"/users/:id/posts/:postId", []rawParam{
+			{name: "id", in: "path", required: true, typ: "text"},
+			{name: "postId", in: "path", required: true, typ: "text"},
+		}},
+	}
+
+	for _, tt := range tests {
+		result := extractPathParams(tt.path)
+		if len(result) != len(tt.expected) {
+			t.Errorf("extractPathParams(%q): got %d params, want %d", tt.path, len(result), len(tt.expected))
+			continue
+		}
+		for i, p := range result {
+			if p.name != tt.expected[i].name {
+				t.Errorf("extractPathParams(%q)[%d].name = %q, want %q", tt.path, i, p.name, tt.expected[i].name)
+			}
+			if p.in != tt.expected[i].in {
+				t.Errorf("extractPathParams(%q)[%d].in = %q, want %q", tt.path, i, p.in, tt.expected[i].in)
+			}
+		}
+	}
+}
+
+func TestMethodUppercase(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "basic"))
+	if err != nil {
+		t.Fatalf("basic routes should not error: %v", err)
+	}
+
+	for _, ep := range endpoints {
+		switch ep.Method {
+		case "GET", "POST", "PUT", "DELETE", "PATCH":
+		default:
+			t.Errorf("Method %q should be uppercase standard HTTP method", ep.Method)
+		}
+	}
+}
+
+func assertEndpoint(t *testing.T, got collector.ApiEndpoint, want collector.ApiEndpoint) {
+	t.Helper()
+
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Path != want.Path {
+		t.Errorf("Path = %q, want %q", got.Path, want.Path)
+	}
+	if got.Method != want.Method {
+		t.Errorf("Method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Protocol != want.Protocol {
+		t.Errorf("Protocol = %q, want %q", got.Protocol, want.Protocol)
+	}
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
+	}
+
+	assertParams(t, got.Parameters, want.Parameters)
+	assertBody(t, "RequestBody", got.RequestBody, want.RequestBody)
+	assertBody(t, "Response", got.Response, want.Response)
+}
+
+func assertParams(t *testing.T, got, want []collector.ApiParameter) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Errorf("Parameters: got %d, want %d", len(got), len(want))
+		return
+	}
+
+	for i, g := range got {
+		w := want[i]
+		if g.Name != w.Name {
+			t.Errorf("Parameters[%d].Name = %q, want %q", i, g.Name, w.Name)
+		}
+		if g.In != w.In {
+			t.Errorf("Parameters[%d].In = %q, want %q", i, g.In, w.In)
+		}
+		if g.Required != w.Required {
+			t.Errorf("Parameters[%d].Required = %v, want %v", i, g.Required, w.Required)
+		}
+		if g.Type != w.Type {
+			t.Errorf("Parameters[%d].Type = %q, want %q", i, g.Type, w.Type)
+		}
+		if g.Default != w.Default {
+			t.Errorf("Parameters[%d].Default = %q, want %q", i, g.Default, w.Default)
+		}
+	}
+}
+
+func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
+	t.Helper()
+
+	if got == nil && want == nil {
+		return
+	}
+	if got == nil {
+		t.Errorf("%s: got nil, want %+v", field, want)
+		return
+	}
+	if want == nil {
+		t.Errorf("%s: got %+v, want nil", field, got)
+		return
+	}
+	if got.MediaType != want.MediaType {
+		t.Errorf("%s.MediaType = %q, want %q", field, got.MediaType, want.MediaType)
+	}
+	if want.Schema != nil {
+		if got.Schema == nil {
+			t.Errorf("%s.Schema = nil, want %+v", field, want.Schema)
+		}
+	}
+}

--- a/api-collector-go/fiber/testdata/basic/main.go
+++ b/api-collector-go/fiber/testdata/basic/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+type CreateUserReq struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+func main() {
+	app := fiber.New()
+
+	app.Get("/users", listUsers)
+	app.Post("/users", createUser)
+	app.Get("/users/:id", getUser)
+	app.Put("/users/:id", updateUser)
+	app.Delete("/users/:id", deleteUser)
+	app.Patch("/users/:id", patchUser)
+	app.Post("/upload", uploadFile)
+
+	app.Listen(":3000")
+}
+
+// listUsers returns all users.
+func listUsers(c *fiber.Ctx) error {
+	name := c.Query("name")
+	_ = name
+	return c.JSON(map[string]interface{}{"users": []string{}})
+}
+
+// createUser creates a new user.
+func createUser(c *fiber.Ctx) error {
+	var req CreateUserReq
+	_ = c.BodyParser(&req)
+	return c.JSON(req)
+}
+
+// getUser returns a single user by ID.
+func getUser(c *fiber.Ctx) error {
+	id := c.Params("id")
+	_ = id
+	return c.JSON(map[string]interface{}{"id": id})
+}
+
+// updateUser updates an existing user.
+func updateUser(c *fiber.Ctx) error {
+	var req CreateUserReq
+	_ = c.BodyParser(&req)
+	return c.JSON(req)
+}
+
+// deleteUser removes a user by ID.
+func deleteUser(c *fiber.Ctx) error {
+	return c.SendStatus(204)
+}
+
+// patchUser partially updates a user.
+func patchUser(c *fiber.Ctx) error {
+	name := c.Query("name")
+	_ = name
+	return c.JSON(map[string]interface{}{"id": c.Params("id")})
+}
+
+// uploadFile handles file uploads.
+func uploadFile(c *fiber.Ctx) error {
+	_, _ = c.FormFile("file")
+	desc := c.FormValue("description")
+	_ = desc
+	return c.JSON(map[string]string{"status": "ok"})
+}

--- a/api-collector-go/fiber/testdata/groups/main.go
+++ b/api-collector-go/fiber/testdata/groups/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func main() {
+	app := fiber.New()
+
+	v1 := app.Group("/v1")
+	{
+		v1.Get("/users", listUsers)
+		v1.Post("/users", createUser)
+	}
+
+	api := app.Group("/api")
+	{
+		api.Get("/items", listItems)
+		api.Delete("/items/:id", deleteItem)
+	}
+
+	app.Get("/health", healthCheck)
+
+	app.Listen(":3000")
+}
+
+// listUsers returns all users.
+func listUsers(c *fiber.Ctx) error {
+	c.Query("name")
+	return c.JSON(map[string]interface{}{})
+}
+
+// createUser creates a new user.
+func createUser(c *fiber.Ctx) error {
+	var req struct{}
+	_ = c.BodyParser(&req)
+	return c.JSON(map[string]interface{}{})
+}
+
+// listItems returns all items.
+func listItems(c *fiber.Ctx) error {
+	return c.JSON(map[string]interface{}{})
+}
+
+// deleteItem removes an item by ID.
+func deleteItem(c *fiber.Ctx) error {
+	return c.SendStatus(204)
+}
+
+// healthCheck returns service health status.
+func healthCheck(c *fiber.Ctx) error {
+	return c.SendString("ok")
+}

--- a/api-collector-go/fiber/testdata/noroutes/main.go
+++ b/api-collector-go/fiber/testdata/noroutes/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("no routes here")
+}


### PR DESCRIPTION
## Summary

Implement the Fiber route parser that extracts API endpoints from Fiber framework route registrations using Go standard go/parser and go/ast packages.

## Changes

- Implement fiber.Parse(sourceDir) that walks .go files and extracts route registrations
- Parse fiber.App and fiber.Router method calls: Get Post Put Delete Patch
- Extract per route: path string literal, HTTP method (uppercased), handler function name, and Go doc comment
- Resolve fiber.App.Group() prefixes to compute full route paths
- Handler body analysis for *fiber.Ctx method calls:
  - c.Params → path parameters
  - c.Query/QueryInt/QueryBool/QueryFloat → query parameters
  - c.FormValue → form parameters
  - c.FormFile → file parameters
  - c.Get → header parameters
  - c.Cookies → cookie parameters
  - c.BodyParser → request body binding
  - c.JSON/XML/SendString/Send/SendStatus → response writes
- Method names are uppercased in output (Get -> GET) for consistency with other collectors
- Skip unparseable files gracefully
- Return nil nil when no endpoints found
- Add unit tests covering: empty dir, no routes, basic routes, group routes, nonexistent dir, method uppercase
- Add test fixture data under fiber/testdata/
- Memory optimization: each file is parsed in its own goroutine, AST is released after extraction

## Testing

All 7 test cases pass with race detector enabled. go vet is clean.

Closes #13
