### PR TITLE
feat: wire Gin/Echo/Fiber parsers into Collect() and add unit tests

### DIFF
--- a/api-collector-go/collector.go
+++ b/api-collector-go/collector.go
@@ -2,7 +2,15 @@
 // Supported frameworks: Gin, Echo, Fiber.
 package gocollector
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"log"
+	"sync"
+
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-collector-go/echo"
+	"github.com/tangcent/apilot/api-collector-go/fiber"
+	"github.com/tangcent/apilot/api-collector-go/gin"
+)
 
 // GoCollector parses Go source trees for API route registrations.
 type GoCollector struct{}
@@ -14,10 +22,58 @@ func (c *GoCollector) Name() string { return "go" }
 
 func (c *GoCollector) SupportedLanguages() []string { return []string{"go"} }
 
-// Collect walks the source directory and extracts endpoints from Gin, Echo, and Fiber route registrations.
+// Collect walks the source directory and extracts endpoints from Gin, Echo,
+// and Fiber route registrations.
+//
+// Each framework parser is invoked concurrently. Results are merged into a
+// single slice. If a parser returns an error, a warning is logged and
+// collection continues with the remaining parsers — the overall Collect call
+// does not fail.
 func (c *GoCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
-	// TODO: implement
-	// 1. Walk .go files under ctx.SourceDir using go/parser
-	// 2. Delegate to gin/, echo/, fiber/ sub-packages
-	return nil, nil
+	type parseResult struct {
+		endpoints []collector.ApiEndpoint
+		err       error
+		framework string
+	}
+
+	parsers := []struct {
+		name    string
+		parse   func(string) ([]collector.ApiEndpoint, error)
+	}{
+		{"gin", gin.Parse},
+		{"echo", echo.Parse},
+		{"fiber", fiber.Parse},
+	}
+
+	ch := make(chan parseResult, len(parsers))
+	var wg sync.WaitGroup
+
+	for _, p := range parsers {
+		wg.Add(1)
+		go func(name string, fn func(string) ([]collector.ApiEndpoint, error)) {
+			defer wg.Done()
+			endpoints, err := fn(ctx.SourceDir)
+			ch <- parseResult{endpoints: endpoints, err: err, framework: name}
+		}(p.name, p.parse)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var all []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			log.Printf("warning: %s parser failed: %v", res.framework, res.err)
+			continue
+		}
+		all = append(all, res.endpoints...)
+	}
+
+	if len(all) == 0 {
+		return nil, nil
+	}
+
+	return all, nil
 }

--- a/api-collector-go/collector_test.go
+++ b/api-collector-go/collector_test.go
@@ -1,0 +1,234 @@
+package gocollector
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+func TestCollect_EmptyDir(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "empty"),
+	})
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for empty dir, got %d", len(endpoints))
+	}
+}
+
+func TestCollect_NonexistentDir(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "nonexistent"),
+	})
+	if err != nil {
+		t.Fatalf("nonexistent dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for nonexistent dir, got %d", len(endpoints))
+	}
+}
+
+func TestCollect_GinOnly(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "ginonly"),
+	})
+	if err != nil {
+		t.Fatalf("ginonly should not error: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+
+	ep := endpoints[0]
+	if ep.Name != "ping" {
+		t.Errorf("Name = %q, want %q", ep.Name, "ping")
+	}
+	if ep.Path != "/ping" {
+		t.Errorf("Path = %q, want %q", ep.Path, "/ping")
+	}
+	if ep.Method != "GET" {
+		t.Errorf("Method = %q, want %q", ep.Method, "GET")
+	}
+	if ep.Protocol != "http" {
+		t.Errorf("Protocol = %q, want %q", ep.Protocol, "http")
+	}
+	if ep.Description != "ping returns pong." {
+		t.Errorf("Description = %q, want %q", ep.Description, "ping returns pong.")
+	}
+}
+
+func TestCollect_EchoOnly(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "echonly"),
+	})
+	if err != nil {
+		t.Fatalf("echonly should not error: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+
+	ep := endpoints[0]
+	if ep.Name != "healthCheck" {
+		t.Errorf("Name = %q, want %q", ep.Name, "healthCheck")
+	}
+	if ep.Path != "/health" {
+		t.Errorf("Path = %q, want %q", ep.Path, "/health")
+	}
+	if ep.Method != "GET" {
+		t.Errorf("Method = %q, want %q", ep.Method, "GET")
+	}
+	if ep.Protocol != "http" {
+		t.Errorf("Protocol = %q, want %q", ep.Protocol, "http")
+	}
+	if ep.Description != "healthCheck returns service health." {
+		t.Errorf("Description = %q, want %q", ep.Description, "healthCheck returns service health.")
+	}
+}
+
+func TestCollect_FiberOnly(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "fiberonly"),
+	})
+	if err != nil {
+		t.Fatalf("fiberonly should not error: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+
+	ep := endpoints[0]
+	if ep.Name != "statusHandler" {
+		t.Errorf("Name = %q, want %q", ep.Name, "statusHandler")
+	}
+	if ep.Path != "/status" {
+		t.Errorf("Path = %q, want %q", ep.Path, "/status")
+	}
+	if ep.Method != "GET" {
+		t.Errorf("Method = %q, want %q", ep.Method, "GET")
+	}
+	if ep.Protocol != "http" {
+		t.Errorf("Protocol = %q, want %q", ep.Protocol, "http")
+	}
+	if ep.Description != "statusHandler returns service status." {
+		t.Errorf("Description = %q, want %q", ep.Description, "statusHandler returns service status.")
+	}
+}
+
+func TestCollect_Mixed(t *testing.T) {
+	c := New()
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir: filepath.Join("testdata", "mixed"),
+	})
+	if err != nil {
+		t.Fatalf("mixed should not error: %v", err)
+	}
+	if len(endpoints) != 6 {
+		t.Fatalf("expected 6 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return endpoints[i].Method < endpoints[j].Method
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "echoHello", Path: "/echo/hello", Method: "GET", Protocol: "http",
+		Description: "echoHello returns a greeting from Echo.",
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "echoDeleteUser", Path: "/echo/users/:id", Method: "DELETE", Protocol: "http",
+		Description: "echoDeleteUser deletes a user via Echo.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "fiberHello", Path: "/fiber/hello", Method: "GET", Protocol: "http",
+		Description: "fiberHello returns a greeting from Fiber.",
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "fiberUpdateUser", Path: "/fiber/users/:id", Method: "PUT", Protocol: "http",
+		Description: "fiberUpdateUser updates a user via Fiber.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
+		Name: "ginHello", Path: "/gin/hello", Method: "GET", Protocol: "http",
+		Description: "ginHello returns a greeting from Gin.",
+	})
+
+	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
+		Name: "ginCreateUser", Path: "/gin/users", Method: "POST", Protocol: "http",
+		Description: "ginCreateUser creates a new user via Gin.",
+	})
+}
+
+func TestGoCollector_Interface(t *testing.T) {
+	c := New()
+
+	if c.Name() != "go" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "go")
+	}
+
+	langs := c.SupportedLanguages()
+	if len(langs) != 1 || langs[0] != "go" {
+		t.Errorf("SupportedLanguages() = %v, want [go]", langs)
+	}
+}
+
+func assertEndpoint(t *testing.T, got collector.ApiEndpoint, want collector.ApiEndpoint) {
+	t.Helper()
+
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Path != want.Path {
+		t.Errorf("Path = %q, want %q", got.Path, want.Path)
+	}
+	if got.Method != want.Method {
+		t.Errorf("Method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Protocol != want.Protocol {
+		t.Errorf("Protocol = %q, want %q", got.Protocol, want.Protocol)
+	}
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
+	}
+
+	if len(got.Parameters) != len(want.Parameters) {
+		t.Errorf("Parameters: got %d, want %d", len(got.Parameters), len(want.Parameters))
+		return
+	}
+	for i, g := range got.Parameters {
+		w := want.Parameters[i]
+		if g.Name != w.Name {
+			t.Errorf("Parameters[%d].Name = %q, want %q", i, g.Name, w.Name)
+		}
+		if g.In != w.In {
+			t.Errorf("Parameters[%d].In = %q, want %q", i, g.In, w.In)
+		}
+		if g.Required != w.Required {
+			t.Errorf("Parameters[%d].Required = %v, want %v", i, g.Required, w.Required)
+		}
+		if g.Type != w.Type {
+			t.Errorf("Parameters[%d].Type = %q, want %q", i, g.Type, w.Type)
+		}
+	}
+}

--- a/api-collector-go/echo/parser.go
+++ b/api-collector-go/echo/parser.go
@@ -250,6 +250,11 @@ func processFile(filePath string) fileResult {
 		return fileResult{}
 	}
 
+	if !importsPackage(f, "github.com/labstack/echo/v4") {
+		return fileResult{}
+	}
+
+	echoHandlers := make(map[string]bool)
 	funcDocs := make(map[string]string)
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	for _, decl := range f.Decls {
@@ -260,6 +265,9 @@ func processFile(filePath string) fileResult {
 		name := fn.Name.Name
 		if fn.Doc != nil {
 			funcDocs[name] = strings.TrimSpace(fn.Doc.Text())
+		}
+		if findContextParamName(fn) != "" {
+			echoHandlers[name] = true
 		}
 		params, reqBody, respBody := analyzeHandlerBody(fn)
 		if len(params) > 0 || reqBody != nil || respBody != nil {
@@ -317,6 +325,10 @@ func processFile(filePath string) fileResult {
 		path := extractStringLiteral(callExpr.Args[0])
 		handlerName := extractHandlerName(callExpr.Args[1])
 		receiverVar := resolveReceiverVar(selExpr.X)
+
+		if !echoHandlers[handlerName] {
+			return true
+		}
 
 		rawEndpoints = append(rawEndpoints, rawEndpoint{
 			method:      methodName,
@@ -577,4 +589,15 @@ func resolveReceiverVar(expr ast.Expr) string {
 		return ""
 	}
 	return ident.Name
+}
+
+// importsPackage checks whether the given file imports the specified package path.
+func importsPackage(f *ast.File, pkgPath string) bool {
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == pkgPath {
+			return true
+		}
+	}
+	return false
 }

--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -252,6 +252,11 @@ func processFile(filePath string) fileResult {
 		return fileResult{}
 	}
 
+	if !importsPackage(f, "github.com/gofiber/fiber/v2") {
+		return fileResult{}
+	}
+
+	fiberHandlers := make(map[string]bool)
 	funcDocs := make(map[string]string)
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	for _, decl := range f.Decls {
@@ -262,6 +267,9 @@ func processFile(filePath string) fileResult {
 		name := fn.Name.Name
 		if fn.Doc != nil {
 			funcDocs[name] = strings.TrimSpace(fn.Doc.Text())
+		}
+		if findContextParamName(fn) != "" {
+			fiberHandlers[name] = true
 		}
 		params, reqBody, respBody := analyzeHandlerBody(fn)
 		if len(params) > 0 || reqBody != nil || respBody != nil {
@@ -319,6 +327,10 @@ func processFile(filePath string) fileResult {
 		path := extractStringLiteral(callExpr.Args[0])
 		handlerName := extractHandlerName(callExpr.Args[1])
 		receiverVar := resolveReceiverVar(selExpr.X)
+
+		if !fiberHandlers[handlerName] {
+			return true
+		}
 
 		rawEndpoints = append(rawEndpoints, rawEndpoint{
 			method:      methodName,
@@ -598,4 +610,15 @@ func resolveReceiverVar(expr ast.Expr) string {
 		return ""
 	}
 	return ident.Name
+}
+
+// importsPackage checks whether the given file imports the specified package path.
+func importsPackage(f *ast.File, pkgPath string) bool {
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == pkgPath {
+			return true
+		}
+	}
+	return false
 }

--- a/api-collector-go/gin/parser.go
+++ b/api-collector-go/gin/parser.go
@@ -252,6 +252,11 @@ func processFile(filePath string) fileResult {
 		return fileResult{}
 	}
 
+	if !importsPackage(f, "github.com/gin-gonic/gin") {
+		return fileResult{}
+	}
+
+	ginHandlers := make(map[string]bool)
 	funcDocs := make(map[string]string)
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	for _, decl := range f.Decls {
@@ -262,6 +267,9 @@ func processFile(filePath string) fileResult {
 		name := fn.Name.Name
 		if fn.Doc != nil {
 			funcDocs[name] = strings.TrimSpace(fn.Doc.Text())
+		}
+		if findContextParamName(fn) != "" {
+			ginHandlers[name] = true
 		}
 		params, reqBody, respBody := analyzeHandlerBody(fn)
 		if len(params) > 0 || reqBody != nil || respBody != nil {
@@ -319,6 +327,10 @@ func processFile(filePath string) fileResult {
 		path := extractStringLiteral(callExpr.Args[0])
 		handlerName := extractHandlerName(callExpr.Args[1])
 		receiverVar := resolveReceiverVar(selExpr.X)
+
+		if !ginHandlers[handlerName] {
+			return true
+		}
 
 		rawEndpoints = append(rawEndpoints, rawEndpoint{
 			method:      methodName,
@@ -614,4 +626,15 @@ func resolveReceiverVar(expr ast.Expr) string {
 		return ""
 	}
 	return ident.Name
+}
+
+// importsPackage checks whether the given file imports the specified package path.
+func importsPackage(f *ast.File, pkgPath string) bool {
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == pkgPath {
+			return true
+		}
+	}
+	return false
 }

--- a/api-collector-go/testdata/echonly/main.go
+++ b/api-collector-go/testdata/echonly/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	e := echo.New()
+	e.GET("/health", healthCheck)
+	e.Logger.Fatal(e.Start(":8080"))
+}
+
+// healthCheck returns service health.
+func healthCheck(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/api-collector-go/testdata/fiberonly/main.go
+++ b/api-collector-go/testdata/fiberonly/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func main() {
+	app := fiber.New()
+	app.Get("/status", statusHandler)
+	app.Listen(":3000")
+}
+
+// statusHandler returns service status.
+func statusHandler(c *fiber.Ctx) error {
+	return c.JSON(map[string]string{"status": "ok"})
+}

--- a/api-collector-go/testdata/ginonly/main.go
+++ b/api-collector-go/testdata/ginonly/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.GET("/ping", ping)
+	r.Run()
+}
+
+// ping returns pong.
+func ping(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"message": "pong"})
+}

--- a/api-collector-go/testdata/mixed/main.go
+++ b/api-collector-go/testdata/mixed/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gofiber/fiber/v2"
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	// Gin routes
+	r := gin.Default()
+	r.GET("/gin/hello", ginHello)
+	r.POST("/gin/users", ginCreateUser)
+
+	// Echo routes
+	e := echo.New()
+	e.GET("/echo/hello", echoHello)
+	e.DELETE("/echo/users/:id", echoDeleteUser)
+
+	// Fiber routes
+	app := fiber.New()
+	app.Get("/fiber/hello", fiberHello)
+	app.Put("/fiber/users/:id", fiberUpdateUser)
+}
+
+// ginHello returns a greeting from Gin.
+func ginHello(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"message": "hello from gin"})
+}
+
+// ginCreateUser creates a new user via Gin.
+func ginCreateUser(c *gin.Context) {
+	var req struct{}
+	_ = c.ShouldBindJSON(&req)
+	c.JSON(http.StatusCreated, gin.H{"created": true})
+}
+
+// echoHello returns a greeting from Echo.
+func echoHello(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{"message": "hello from echo"})
+}
+
+// echoDeleteUser deletes a user via Echo.
+func echoDeleteUser(c echo.Context) error {
+	id := c.Param("id")
+	return c.JSON(http.StatusOK, map[string]string{"deleted": id})
+}
+
+// fiberHello returns a greeting from Fiber.
+func fiberHello(c *fiber.Ctx) error {
+	return c.JSON(map[string]string{"message": "hello from fiber"})
+}
+
+// fiberUpdateUser updates a user via Fiber.
+func fiberUpdateUser(c *fiber.Ctx) error {
+	id := c.Params("id")
+	return c.JSON(map[string]string{"updated": id})
+}


### PR DESCRIPTION
## Summary

Wire the Gin, Echo, and Fiber parsers into GoCollector.Collect() in api-collector-go/collector.go.

## Changes

- Implement GoCollector.Collect() that delegates to gin.Parse, echo.Parse, and fiber.Parse concurrently
- Merge results into a single []ApiEndpoint slice
- Log warnings for parser failures instead of failing the whole collection
- Add import check to each parser (importsPackage) so files without the framework import are skipped
- Add handler context type check to each parser so cross-framework false positives are eliminated
- Add unit tests with fixture .go source files under api-collector-go/testdata/:
  - empty dir, nonexistent dir (edge cases)
  - ginonly, echonly, fiberonly (single framework)
  - mixed (all three frameworks in one file)
  - GoCollector interface compliance test

## Testing

All 21 tests pass with race detector enabled across all packages. go vet is clean.

Closes #14
