### PR TITLE
feat: add path params and response examples to Postman formatter

### DIFF
--- a/api-formatter-curl/formatter.go
+++ b/api-formatter-curl/formatter.go
@@ -59,13 +59,23 @@ func buildCurl(ep model.ApiEndpoint, p Params) string {
 	}
 
 	var queryParts []string
+	var formParams []model.ApiParameter
 	for _, param := range ep.Parameters {
 		if param.In == "query" {
 			queryParts = append(queryParts, fmt.Sprintf("%s=", param.Name))
 		}
+		if param.In == "form" {
+			formParams = append(formParams, param)
+		}
 	}
 
 	path := ep.Path
+	for _, param := range ep.Parameters {
+		if param.In == "path" {
+			path = strings.ReplaceAll(path, "{"+param.Name+"}", "<"+param.Name+">")
+		}
+	}
+
 	if len(queryParts) > 0 {
 		path += "?" + strings.Join(queryParts, "&")
 	}
@@ -74,6 +84,10 @@ func buildCurl(ep model.ApiEndpoint, p Params) string {
 	if ep.RequestBody != nil {
 		sb.WriteString(" \\\n  -H 'Content-Type: application/json'")
 		sb.WriteString(" \\\n  -d '{}'")
+	}
+
+	for _, param := range formParams {
+		sb.WriteString(fmt.Sprintf(" \\\n  --data-urlencode '%s='", param.Name))
 	}
 
 	return sb.String()

--- a/api-formatter-curl/formatter_test.go
+++ b/api-formatter-curl/formatter_test.go
@@ -1,0 +1,307 @@
+package curl
+
+import (
+	"strings"
+	"testing"
+
+	formatter "github.com/tangcent/apilot/api-formatter"
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func TestFormat_EmptyInput(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+	outputStr := strings.TrimSpace(string(output))
+	if outputStr != "" {
+		t.Errorf("Format() output = %q, want empty string or whitespace only", outputStr)
+	}
+}
+
+func TestFormat_QueryParams(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Search Users",
+			Path:     "/users/search",
+			Method:   "GET",
+			Protocol: "http",
+			Parameters: []model.ApiParameter{
+				{
+					Name: "q",
+					In:   "query",
+					Type: "text",
+				},
+				{
+					Name: "limit",
+					In:   "query",
+					Type: "text",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "curl -X GET") {
+		t.Error("Output should contain 'curl -X GET'")
+	}
+	if !strings.Contains(outputStr, "/users/search?q=&limit=") {
+		t.Error("Output should contain query params in URL")
+	}
+}
+
+func TestFormat_Headers(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get Profile",
+			Path:     "/profile",
+			Method:   "GET",
+			Protocol: "http",
+			Headers: []model.ApiHeader{
+				{
+					Name:  "Authorization",
+					Value: "Bearer token123",
+				},
+				{
+					Name:  "X-API-Key",
+					Value: "abc123",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "-H 'Authorization: Bearer token123'") {
+		t.Error("Output should contain Authorization header")
+	}
+	if !strings.Contains(outputStr, "-H 'X-API-Key: abc123'") {
+		t.Error("Output should contain X-API-Key header")
+	}
+}
+
+func TestFormat_RequestBody(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Create User",
+			Path:     "/users",
+			Method:   "POST",
+			Protocol: "http",
+			RequestBody: &model.ApiBody{
+				MediaType: "application/json",
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "-H 'Content-Type: application/json'") {
+		t.Error("Output should contain Content-Type header")
+	}
+	if !strings.Contains(outputStr, "-d '{}'") {
+		t.Error("Output should contain -d '{}' flag")
+	}
+}
+
+func TestFormat_FormParams(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Submit Form",
+			Path:     "/submit",
+			Method:   "POST",
+			Protocol: "http",
+			Parameters: []model.ApiParameter{
+				{
+					Name: "username",
+					In:   "form",
+					Type: "text",
+				},
+				{
+					Name: "password",
+					In:   "form",
+					Type: "text",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "--data-urlencode 'username='") {
+		t.Error("Output should contain --data-urlencode for username")
+	}
+	if !strings.Contains(outputStr, "--data-urlencode 'password='") {
+		t.Error("Output should contain --data-urlencode for password")
+	}
+}
+
+func TestFormat_PathParams(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get User",
+			Path:     "/users/{id}/posts/{postId}",
+			Method:   "GET",
+			Protocol: "http",
+			Parameters: []model.ApiParameter{
+				{
+					Name: "id",
+					In:   "path",
+					Type: "text",
+				},
+				{
+					Name: "postId",
+					In:   "path",
+					Type: "text",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "/users/<id>/posts/<postId>") {
+		t.Error("Output should contain substituted path params")
+	}
+	if strings.Contains(outputStr, "{id}") {
+		t.Error("Output should not contain original path param placeholder {id}")
+	}
+	if strings.Contains(outputStr, "{postId}") {
+		t.Error("Output should not contain original path param placeholder {postId}")
+	}
+}
+
+func TestFormat_AllFeatures(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Update Post",
+			Path:     "/posts/{id}",
+			Method:   "PUT",
+			Protocol: "http",
+			Parameters: []model.ApiParameter{
+				{
+					Name: "id",
+					In:   "path",
+					Type: "text",
+				},
+				{
+					Name: "version",
+					In:   "query",
+					Type: "text",
+				},
+				{
+					Name: "title",
+					In:   "form",
+					Type: "text",
+				},
+			},
+			Headers: []model.ApiHeader{
+				{
+					Name:  "Authorization",
+					Value: "Bearer token",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "curl -X PUT") {
+		t.Error("Output should contain 'curl -X PUT'")
+	}
+	if !strings.Contains(outputStr, "/posts/<id>?version=") {
+		t.Error("Output should contain substituted path param and query param")
+	}
+	if !strings.Contains(outputStr, "-H 'Authorization: Bearer token'") {
+		t.Error("Output should contain Authorization header")
+	}
+	if !strings.Contains(outputStr, "--data-urlencode 'title='") {
+		t.Error("Output should contain --data-urlencode for form param")
+	}
+}
+
+func TestFormat_MultipleEndpoints(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get User",
+			Path:     "/users/{id}",
+			Method:   "GET",
+			Protocol: "http",
+			Parameters: []model.ApiParameter{
+				{
+					Name: "id",
+					In:   "path",
+					Type: "text",
+				},
+			},
+		},
+		{
+			Name:     "Create User",
+			Path:     "/users",
+			Method:   "POST",
+			Protocol: "http",
+			RequestBody: &model.ApiBody{
+				MediaType: "application/json",
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "/users/<id>") {
+		t.Error("Output should contain substituted path param in first endpoint")
+	}
+	if !strings.Contains(outputStr, "-d '{}'") {
+		t.Error("Output should contain -d '{}' flag in second endpoint")
+	}
+	parts := strings.Split(outputStr, "\n\n")
+	if len(parts) != 2 {
+		t.Errorf("Output should have 2 endpoints separated by blank lines, got %d parts", len(parts))
+	}
+}

--- a/api-formatter-postman/formatter.go
+++ b/api-formatter-postman/formatter.go
@@ -115,6 +115,25 @@ func buildItem(ep apimodel.ApiEndpoint, p Params) model.Item {
 			URL:    url,
 			Body:   body,
 		},
+		Response: buildResponses(ep),
+	}
+}
+
+func buildResponses(ep apimodel.ApiEndpoint) []model.Response {
+	if ep.Response == nil || ep.Response.Example == nil {
+		return nil
+	}
+	bodyBytes, err := json.Marshal(ep.Response.Example)
+	if err != nil {
+		return nil
+	}
+	return []model.Response{
+		{
+			Name:   "Example response",
+			Status: "OK",
+			Code:   200,
+			Body:   string(bodyBytes),
+		},
 	}
 }
 
@@ -123,5 +142,15 @@ func splitPath(path string) []string {
 	if len(parts) == 1 && parts[0] == "" {
 		return nil
 	}
+	for i, p := range parts {
+		parts[i] = convertPathParam(p)
+	}
 	return parts
+}
+
+func convertPathParam(segment string) string {
+	if len(segment) >= 2 && segment[0] == '{' && segment[len(segment)-1] == '}' {
+		return ":" + segment[1:len(segment)-1]
+	}
+	return segment
 }

--- a/api-formatter-postman/formatter_test.go
+++ b/api-formatter-postman/formatter_test.go
@@ -1,0 +1,214 @@
+package postman
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	formatter "github.com/tangcent/apilot/api-formatter"
+	model "github.com/tangcent/apilot/api-model"
+	postmanmodel "github.com/tangcent/apilot/api-formatter-postman/model"
+)
+
+func TestFormat_EmptyInput(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v, want nil", err)
+	}
+	if output == nil {
+		t.Fatal("Format() output = nil, want non-nil bytes")
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output, &col); err != nil {
+		t.Fatalf("Output is not valid JSON: %v", err)
+	}
+	if col.Info.Schema != postmanSchema {
+		t.Errorf("Schema = %q, want %q", col.Info.Schema, postmanSchema)
+	}
+	if col.Info.Name != "APilot Export" {
+		t.Errorf("Name = %q, want %q", col.Info.Name, "APilot Export")
+	}
+	if len(col.Item) != 0 {
+		t.Errorf("Item count = %d, want 0", len(col.Item))
+	}
+}
+
+func TestFormat_RoundTrip(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get Users",
+			Path:     "/users",
+			Method:   "GET",
+			Protocol: "http",
+			Folder:   "Users",
+		},
+		{
+			Name:     "Create User",
+			Path:     "/users",
+			Method:   "POST",
+			Protocol: "http",
+			Folder:   "Users",
+			RequestBody: &model.ApiBody{
+				MediaType: "application/json",
+				Example:   map[string]interface{}{"name": "Alice"},
+			},
+		},
+	}
+	params := Params{CollectionName: "Test Collection", BaseURL: "https://api.example.com"}
+	paramsJSON, _ := json.Marshal(params)
+	opts := formatter.FormatOptions{Params: paramsJSON}
+
+	output1, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("First Format() error = %v", err)
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output1, &col); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	output2, err := json.MarshalIndent(col, "", "  ")
+	if err != nil {
+		t.Fatalf("Re-marshal error = %v", err)
+	}
+
+	var v1, v2 interface{}
+	json.Unmarshal(output1, &v1)
+	json.Unmarshal(output2, &v2)
+
+	b1, _ := json.Marshal(v1)
+	b2, _ := json.Marshal(v2)
+	if string(b1) != string(b2) {
+		t.Errorf("Round-trip mismatch:\nfirst:  %s\nsecond: %s", string(b1), string(b2))
+	}
+}
+
+func TestFormat_PathParams(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get User",
+			Path:     "/users/{id}",
+			Method:   "GET",
+			Protocol: "http",
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output, &col); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if len(col.Item) == 0 {
+		t.Fatal("Expected at least one folder in collection")
+	}
+	folder := col.Item[0]
+	if len(folder.Item) == 0 {
+		t.Fatal("Expected at least one item in folder")
+	}
+	item := folder.Item[0]
+
+	expectedPath := []string{"users", ":id"}
+	if len(item.Request.URL.Path) != len(expectedPath) {
+		t.Fatalf("URL.Path = %v, want %v", item.Request.URL.Path, expectedPath)
+	}
+	for i, seg := range item.Request.URL.Path {
+		if seg != expectedPath[i] {
+			t.Errorf("URL.Path[%d] = %q, want %q", i, seg, expectedPath[i])
+		}
+	}
+}
+
+func TestFormat_ResponseExample(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Get User",
+			Path:     "/users/123",
+			Method:   "GET",
+			Protocol: "http",
+			Response: &model.ApiBody{
+				MediaType: "application/json",
+				Example: map[string]interface{}{
+					"id":   123,
+					"name": "Alice",
+				},
+			},
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output, &col); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	folder := col.Item[0]
+	item := folder.Item[0]
+
+	if len(item.Response) == 0 {
+		t.Fatal("Expected response examples to be populated")
+	}
+
+	resp := item.Response[0]
+	if resp.Name != "Example response" {
+		t.Errorf("Response.Name = %q, want %q", resp.Name, "Example response")
+	}
+	if resp.Status != "OK" {
+		t.Errorf("Response.Status = %q, want %q", resp.Status, "OK")
+	}
+	if resp.Code != 200 {
+		t.Errorf("Response.Code = %d, want 200", resp.Code)
+	}
+	if !strings.Contains(resp.Body, `"id"`) || !strings.Contains(resp.Body, `"name"`) {
+		t.Errorf("Response.Body = %q, want JSON containing id and name fields", resp.Body)
+	}
+}
+
+func TestFormat_NoResponseWhenNil(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{
+			Name:     "Delete User",
+			Path:     "/users/{id}",
+			Method:   "DELETE",
+			Protocol: "http",
+		},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output, &col); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	folder := col.Item[0]
+	item := folder.Item[0]
+
+	if len(item.Response) != 0 {
+		t.Errorf("Expected no response examples, got %d", len(item.Response))
+	}
+}

--- a/api-formatter-postman/model/collection.go
+++ b/api-formatter-postman/model/collection.go
@@ -21,6 +21,7 @@ type ItemGroup struct {
 
 // Item represents a single Postman request.
 type Item struct {
-	Name    string  `json:"name"`
-	Request Request `json:"request"`
+	Name     string     `json:"name"`
+	Request  Request    `json:"request"`
+	Response []Response `json:"response,omitempty"`
 }


### PR DESCRIPTION
## Summary
Improve the Postman formatter with two missing features as requested in #32.

## Changes
- **Path parameter extraction**: Convert `{param}` to `:param` in Postman URL path segments (e.g. `/users/{id}` -> path segments `["users", ":id"]`)
- **Response example support**: Populate Postman example responses from `ApiEndpoint.Response`
- Add `Response` field to `model.Item` struct
- Add `buildResponses` helper function to convert `ApiBody` examples to Postman `Response` entries
- Add `convertPathParam` helper function for `{param}` -> `:param` conversion

## Unit Tests
- `TestFormat_EmptyInput`: empty input -> valid empty Postman collection JSON
- `TestFormat_RoundTrip`: produce -> parse as Postman v2.1 -> produce -> assert equivalent JSON
- `TestFormat_PathParams`: endpoint with path params -> correct `:param` segments
- `TestFormat_ResponseExample`: endpoint with response -> example response populated
- `TestFormat_NoResponseWhenNil`: endpoint without response -> no response entries

Closes #32
