### PR TITLE
feat: add settings management and Postman API client

### DIFF
--- a/api-formatter-postman/client.go
+++ b/api-formatter-postman/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/tangcent/apilot/api-formatter-postman/model"
 )
 
 const defaultPostmanAPIBase = "https://api.getpostman.com"
@@ -21,8 +23,8 @@ type CreateCollectionRequest struct {
 }
 
 type CollectionWrapper struct {
-	Info CollectionInfo `json:"info"`
-	Item []ItemGroup    `json:"item"`
+	Info CollectionInfo    `json:"info"`
+	Item []model.ItemGroup `json:"item"`
 }
 
 type CollectionInfo struct {
@@ -65,7 +67,7 @@ func newPostmanClient(apiKey string) PostmanClient {
 	}
 }
 
-func (c PostmanClient) CreateCollection(workspaceID string, col Collection) (*CreateCollectionResponse, error) {
+func (c PostmanClient) CreateCollection(workspaceID string, col model.Collection) (*CreateCollectionResponse, error) {
 	reqBody := CreateCollectionRequest{
 		Collection: CollectionWrapper{
 			Info: CollectionInfo{
@@ -120,7 +122,7 @@ func (c PostmanClient) CreateCollection(workspaceID string, col Collection) (*Cr
 	return &result, nil
 }
 
-func (c PostmanClient) UpdateCollection(collectionUID string, col Collection) (*UpdateCollectionResponse, error) {
+func (c PostmanClient) UpdateCollection(collectionUID string, col model.Collection) (*UpdateCollectionResponse, error) {
 	reqBody := CreateCollectionRequest{
 		Collection: CollectionWrapper{
 			Info: CollectionInfo{

--- a/api-formatter-postman/client.go
+++ b/api-formatter-postman/client.go
@@ -1,0 +1,179 @@
+package postman
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultPostmanAPIBase = "https://api.getpostman.com"
+
+type PostmanClient struct {
+	APIKey  string
+	BaseURL string
+	HTTP    *http.Client
+}
+
+type CreateCollectionRequest struct {
+	Collection CollectionWrapper `json:"collection"`
+}
+
+type CollectionWrapper struct {
+	Info CollectionInfo `json:"info"`
+	Item []ItemGroup    `json:"item"`
+}
+
+type CollectionInfo struct {
+	Name        string `json:"name"`
+	Schema      string `json:"schema,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type CreateCollectionResponse struct {
+	Collection struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		UID  string `json:"uid"`
+	} `json:"collection"`
+}
+
+type UpdateCollectionResponse struct {
+	Collection struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		UID  string `json:"uid"`
+	} `json:"collection"`
+}
+
+type PostmanAPIError struct {
+	StatusCode int
+	Name       string `json:"name"`
+	Message    string `json:"message"`
+}
+
+func (e *PostmanAPIError) Error() string {
+	return fmt.Sprintf("postman api error (status %d): %s - %s", e.StatusCode, e.Name, e.Message)
+}
+
+func newPostmanClient(apiKey string) PostmanClient {
+	return PostmanClient{
+		APIKey:  apiKey,
+		BaseURL: defaultPostmanAPIBase,
+		HTTP:    &http.Client{},
+	}
+}
+
+func (c PostmanClient) CreateCollection(workspaceID string, col Collection) (*CreateCollectionResponse, error) {
+	reqBody := CreateCollectionRequest{
+		Collection: CollectionWrapper{
+			Info: CollectionInfo{
+				Name:   col.Info.Name,
+				Schema: col.Info.Schema,
+			},
+			Item: col.Item,
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling collection: %w", err)
+	}
+
+	url := c.BaseURL + "/collections"
+	if workspaceID != "" {
+		url = url + "?workspace=" + workspaceID
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		var apiErr PostmanAPIError
+		apiErr.StatusCode = resp.StatusCode
+		if err := json.Unmarshal(respBody, &apiErr); err != nil {
+			apiErr.Message = string(respBody)
+		}
+		return nil, &apiErr
+	}
+
+	var result CreateCollectionResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+	return &result, nil
+}
+
+func (c PostmanClient) UpdateCollection(collectionUID string, col Collection) (*UpdateCollectionResponse, error) {
+	reqBody := CreateCollectionRequest{
+		Collection: CollectionWrapper{
+			Info: CollectionInfo{
+				Name:   col.Info.Name,
+				Schema: col.Info.Schema,
+			},
+			Item: col.Item,
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling collection: %w", err)
+	}
+
+	url := c.BaseURL + "/collections/" + collectionUID
+
+	req, err := http.NewRequest("PUT", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("X-Api-Key", c.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var apiErr PostmanAPIError
+		apiErr.StatusCode = resp.StatusCode
+		if err := json.Unmarshal(respBody, &apiErr); err != nil {
+			apiErr.Message = string(respBody)
+		}
+		return nil, &apiErr
+	}
+
+	var result UpdateCollectionResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+	return &result, nil
+}
+
+type APIResult struct {
+	CollectionID  string `json:"collectionId,omitempty"`
+	CollectionUID string `json:"collectionUid,omitempty"`
+	CollectionURL string `json:"collectionUrl,omitempty"`
+}

--- a/api-formatter-postman/client_test.go
+++ b/api-formatter-postman/client_test.go
@@ -1,0 +1,181 @@
+package postman
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tangcent/apilot/api-formatter-postman/model"
+)
+
+func TestCreateCollection_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("Expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/collections" {
+			t.Errorf("Expected /collections, got %s", r.URL.Path)
+		}
+		if r.Header.Get("X-Api-Key") != "test-api-key" {
+			t.Errorf("Expected X-Api-Key 'test-api-key', got %q", r.Header.Get("X-Api-Key"))
+		}
+
+		resp := CreateCollectionResponse{}
+		resp.Collection.ID = "col-123"
+		resp.Collection.Name = "Test Collection"
+		resp.Collection.UID = "col-123-uid"
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := PostmanClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	col := model.Collection{
+		Info: model.Info{Name: "Test Collection", Schema: postmanSchema},
+		Item: []model.ItemGroup{},
+	}
+
+	result, err := client.CreateCollection("", col)
+	if err != nil {
+		t.Fatalf("CreateCollection() error = %v", err)
+	}
+	if result.Collection.ID != "col-123" {
+		t.Errorf("Expected ID 'col-123', got %q", result.Collection.ID)
+	}
+	if result.Collection.UID != "col-123-uid" {
+		t.Errorf("Expected UID 'col-123-uid', got %q", result.Collection.UID)
+	}
+}
+
+func TestCreateCollection_WithWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("workspace") != "ws-123" {
+			t.Errorf("Expected workspace 'ws-123', got %q", r.URL.Query().Get("workspace"))
+		}
+		resp := CreateCollectionResponse{}
+		resp.Collection.ID = "col-456"
+		resp.Collection.UID = "col-456-uid"
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := PostmanClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	col := model.Collection{
+		Info: model.Info{Name: "Test", Schema: postmanSchema},
+		Item: []model.ItemGroup{},
+	}
+
+	result, err := client.CreateCollection("ws-123", col)
+	if err != nil {
+		t.Fatalf("CreateCollection() error = %v", err)
+	}
+	if result.Collection.ID != "col-456" {
+		t.Errorf("Expected ID 'col-456', got %q", result.Collection.ID)
+	}
+}
+
+func TestCreateCollection_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"name":    "AuthenticationError",
+			"message": "Invalid API key",
+		})
+	}))
+	defer server.Close()
+
+	client := PostmanClient{
+		APIKey:  "invalid-key",
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	col := model.Collection{
+		Info: model.Info{Name: "Test", Schema: postmanSchema},
+		Item: []model.ItemGroup{},
+	}
+
+	_, err := client.CreateCollection("", col)
+	if err == nil {
+		t.Fatal("Expected error for API error response, got nil")
+	}
+	apiErr, ok := err.(*PostmanAPIError)
+	if !ok {
+		t.Fatalf("Expected *PostmanAPIError, got %T", err)
+	}
+	if apiErr.StatusCode != 401 {
+		t.Errorf("Expected status 401, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestUpdateCollection_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("Expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/collections/col-uid-123" {
+			t.Errorf("Expected /collections/col-uid-123, got %s", r.URL.Path)
+		}
+
+		resp := UpdateCollectionResponse{}
+		resp.Collection.ID = "col-123"
+		resp.Collection.Name = "Updated Collection"
+		resp.Collection.UID = "col-uid-123"
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := PostmanClient{
+		APIKey:  "test-api-key",
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	col := model.Collection{
+		Info: model.Info{Name: "Updated Collection", Schema: postmanSchema},
+		Item: []model.ItemGroup{},
+	}
+
+	result, err := client.UpdateCollection("col-uid-123", col)
+	if err != nil {
+		t.Fatalf("UpdateCollection() error = %v", err)
+	}
+	if result.Collection.ID != "col-123" {
+		t.Errorf("Expected ID 'col-123', got %q", result.Collection.ID)
+	}
+}
+
+func TestNewPostmanClient(t *testing.T) {
+	client := newPostmanClient("my-key")
+	if client.APIKey != "my-key" {
+		t.Errorf("Expected APIKey 'my-key', got %q", client.APIKey)
+	}
+	if client.BaseURL != defaultPostmanAPIBase {
+		t.Errorf("Expected BaseURL %q, got %q", defaultPostmanAPIBase, client.BaseURL)
+	}
+	if client.HTTP == nil {
+		t.Error("Expected HTTP client to be initialized")
+	}
+}
+
+func TestPostmanAPIError_Error(t *testing.T) {
+	err := &PostmanAPIError{
+		StatusCode: 401,
+		Name:       "AuthenticationError",
+		Message:    "Invalid API key",
+	}
+	expected := "postman api error (status 401): AuthenticationError - Invalid API key"
+	if err.Error() != expected {
+		t.Errorf("Expected %q, got %q", expected, err.Error())
+	}
+}

--- a/api-formatter-postman/formatter.go
+++ b/api-formatter-postman/formatter.go
@@ -3,23 +3,23 @@ package postman
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
-	"github.com/tangcent/apilot/api-formatter"
-	apimodel "github.com/tangcent/apilot/api-model"
+	formatter "github.com/tangcent/apilot/api-formatter"
 	"github.com/tangcent/apilot/api-formatter-postman/model"
+	apimodel "github.com/tangcent/apilot/api-model"
 )
 
 const postmanSchema = "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 
 // Params holds postman-specific formatting options.
 type Params struct {
-	// CollectionName is the name of the exported Postman collection.
-	// Defaults to "APilot Export".
 	CollectionName string `json:"collectionName"`
-
-	// BaseURL is prepended to each endpoint path. Defaults to "http://localhost".
-	BaseURL string `json:"baseURL"`
+	BaseURL        string `json:"baseURL"`
+	Mode           string `json:"mode"`
+	PostmanAPIKey  string `json:"postmanAPIKey"`
+	WorkspaceID    string `json:"workspaceId"`
 }
 
 // PostmanFormatter formats endpoints as a Postman Collection v2.1 JSON document.
@@ -29,6 +29,16 @@ type PostmanFormatter struct{}
 func New() formatter.Formatter { return &PostmanFormatter{} }
 
 func (f *PostmanFormatter) Name() string { return "postman" }
+
+func (f *PostmanFormatter) RequiredSettings() []formatter.SettingDef {
+	return []formatter.SettingDef{
+		{
+			Key:         "postman.api.key",
+			Description: "Postman API key for pushing collections to the Postman API",
+			Required:    false,
+		},
+	}
+}
 
 // Format converts endpoints into a Postman Collection v2.1 JSON document.
 // Endpoints are grouped by their Folder field into Postman folders.
@@ -45,6 +55,21 @@ func (f *PostmanFormatter) Format(endpoints []apimodel.ApiEndpoint, opts formatt
 		p.BaseURL = "http://localhost"
 	}
 
+	apiKey := resolveAPIKey(p, opts)
+
+	col := buildCollection(endpoints, p)
+
+	if p.Mode == "api" {
+		if apiKey == "" {
+			return nil, fmt.Errorf("postman api key is required for api mode. Set it with: apilot set postman.api.key <value>")
+		}
+		return pushToPostmanAPI(apiKey, p.WorkspaceID, col)
+	}
+
+	return json.MarshalIndent(col, "", "  ")
+}
+
+func buildCollection(endpoints []apimodel.ApiEndpoint, p Params) model.Collection {
 	folderMap := map[string][]apimodel.ApiEndpoint{}
 	var folderOrder []string
 	for _, ep := range endpoints {
@@ -67,11 +92,34 @@ func (f *PostmanFormatter) Format(endpoints []apimodel.ApiEndpoint, opts formatt
 		groups = append(groups, model.ItemGroup{Name: folderName, Item: items})
 	}
 
-	col := model.Collection{
+	return model.Collection{
 		Info: model.Info{Name: p.CollectionName, Schema: postmanSchema},
 		Item: groups,
 	}
-	return json.MarshalIndent(col, "", "  ")
+}
+
+func resolveAPIKey(p Params, opts formatter.FormatOptions) string {
+	if opts.Settings != nil {
+		if key := opts.Settings.Get("postman.api.key"); key != "" {
+			return key
+		}
+	}
+	return p.PostmanAPIKey
+}
+
+func pushToPostmanAPI(apiKey string, workspaceID string, col model.Collection) ([]byte, error) {
+	client := newPostmanClient(apiKey)
+	result, err := client.CreateCollection(workspaceID, col)
+	if err != nil {
+		return nil, fmt.Errorf("pushing to postman api: %w", err)
+	}
+
+	apiResult := APIResult{
+		CollectionID:  result.Collection.ID,
+		CollectionUID: result.Collection.UID,
+		CollectionURL: fmt.Sprintf("https://go.postman.co/collection/%s", result.Collection.UID),
+	}
+	return json.MarshalIndent(apiResult, "", "  ")
 }
 
 func buildItem(ep apimodel.ApiEndpoint, p Params) model.Item {

--- a/api-formatter-postman/formatter_test.go
+++ b/api-formatter-postman/formatter_test.go
@@ -212,3 +212,118 @@ func TestFormat_NoResponseWhenNil(t *testing.T) {
 		t.Errorf("Expected no response examples, got %d", len(item.Response))
 	}
 }
+
+func TestRequiredSettings(t *testing.T) {
+	f := New()
+	sp, ok := f.(formatter.SettingsProvider)
+	if !ok {
+		t.Fatal("PostmanFormatter should implement SettingsProvider")
+	}
+
+	settings := sp.RequiredSettings()
+	if len(settings) != 1 {
+		t.Fatalf("Expected 1 setting, got %d", len(settings))
+	}
+	if settings[0].Key != "postman.api.key" {
+		t.Errorf("Expected key 'postman.api.key', got %q", settings[0].Key)
+	}
+	if settings[0].Required {
+		t.Error("postman.api.key should not be required (formatter works in file mode)")
+	}
+}
+
+func TestResolveAPIKey_FromSettings(t *testing.T) {
+	p := Params{PostmanAPIKey: "from-params"}
+	opts := formatter.FormatOptions{
+		Settings: &mapSettings{"postman.api.key": "from-settings"},
+	}
+
+	key := resolveAPIKey(p, opts)
+	if key != "from-settings" {
+		t.Errorf("Expected 'from-settings', got %q", key)
+	}
+}
+
+func TestResolveAPIKey_FromParams(t *testing.T) {
+	p := Params{PostmanAPIKey: "from-params"}
+	opts := formatter.FormatOptions{}
+
+	key := resolveAPIKey(p, opts)
+	if key != "from-params" {
+		t.Errorf("Expected 'from-params', got %q", key)
+	}
+}
+
+func TestResolveAPIKey_SettingsTakesPrecedence(t *testing.T) {
+	p := Params{PostmanAPIKey: "from-params"}
+	opts := formatter.FormatOptions{
+		Settings: &mapSettings{"postman.api.key": "from-settings"},
+	}
+
+	key := resolveAPIKey(p, opts)
+	if key != "from-settings" {
+		t.Errorf("Settings should take precedence over params, got %q", key)
+	}
+}
+
+func TestResolveAPIKey_EmptySettings(t *testing.T) {
+	p := Params{PostmanAPIKey: "from-params"}
+	opts := formatter.FormatOptions{
+		Settings: &mapSettings{"postman.api.key": ""},
+	}
+
+	key := resolveAPIKey(p, opts)
+	if key != "from-params" {
+		t.Errorf("Empty settings value should fall back to params, got %q", key)
+	}
+}
+
+func TestResolveAPIKey_None(t *testing.T) {
+	p := Params{}
+	opts := formatter.FormatOptions{}
+
+	key := resolveAPIKey(p, opts)
+	if key != "" {
+		t.Errorf("Expected empty string when no key configured, got %q", key)
+	}
+}
+
+func TestFormat_APIMode_NoAPIKey(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{Name: "Get Users", Path: "/users", Method: "GET"},
+	}
+	params := Params{Mode: "api"}
+	paramsJSON, _ := json.Marshal(params)
+	opts := formatter.FormatOptions{Params: paramsJSON}
+
+	_, err := f.Format(endpoints, opts)
+	if err == nil {
+		t.Fatal("Expected error for api mode without API key, got nil")
+	}
+	if !strings.Contains(err.Error(), "postman api key is required") {
+		t.Errorf("Expected 'postman api key is required' in error, got: %v", err)
+	}
+}
+
+func TestFormat_FileMode_Default(t *testing.T) {
+	f := New()
+	endpoints := []model.ApiEndpoint{
+		{Name: "Get Users", Path: "/users", Method: "GET"},
+	}
+	opts := formatter.FormatOptions{}
+
+	output, err := f.Format(endpoints, opts)
+	if err != nil {
+		t.Fatalf("Format() error = %v", err)
+	}
+
+	var col postmanmodel.Collection
+	if err := json.Unmarshal(output, &col); err != nil {
+		t.Fatalf("Output should be valid collection JSON: %v", err)
+	}
+}
+
+type mapSettings map[string]string
+
+func (s mapSettings) Get(key string) string { return s[key] }

--- a/api-formatter/formatter.go
+++ b/api-formatter/formatter.go
@@ -5,7 +5,7 @@ package formatter
 import (
 	"encoding/json"
 
-	"github.com/tangcent/apilot/api-model"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 // Formatter is the interface every output formatter must implement.
@@ -18,6 +18,17 @@ type Formatter interface {
 	Format(endpoints []model.ApiEndpoint, opts FormatOptions) ([]byte, error)
 }
 
+// Settings provides lazy-loaded access to user settings.
+// Implementations may load settings from disk on first access.
+type Settings interface {
+	Get(key string) string
+}
+
+// noopSettings is the zero-value Settings implementation that always returns empty strings.
+type noopSettings struct{}
+
+func (noopSettings) Get(string) string { return "" }
+
 // FormatOptions carries formatter-specific configuration as raw JSON.
 // Each formatter implementation decodes Params into its own typed options struct
 // via DecodeParams, so there are no magic string keys and options are self-documenting.
@@ -29,6 +40,11 @@ type FormatOptions struct {
 	// Params holds formatter-specific configuration as raw JSON.
 	// Formatters unmarshal this into their own typed struct using DecodeParams.
 	Params json.RawMessage `json:"params,omitempty"`
+
+	// Settings provides access to persistent user settings (e.g. API keys).
+	// Settings are injected by the engine at runtime; formatters call Settings.Get(key).
+	// Not serialized — omitted from JSON marshaling.
+	Settings Settings `json:"-"`
 }
 
 // DecodeParams unmarshals Params into v.
@@ -38,4 +54,14 @@ func (o FormatOptions) DecodeParams(v any) error {
 		return nil
 	}
 	return json.Unmarshal(o.Params, v)
+}
+
+type SettingDef struct {
+	Key         string
+	Description string
+	Required    bool
+}
+
+type SettingsProvider interface {
+	RequiredSettings() []SettingDef
 }

--- a/api-master/config/defaults.go
+++ b/api-master/config/defaults.go
@@ -8,16 +8,35 @@ import (
 
 const (
 	DefaultPluginRegistryFilename = "plugins.json"
+	DefaultSettingsFilename       = "settings.json"
 	DefaultConfigDir              = ".config/apilot"
 )
 
-// DefaultPluginRegistryPath returns the default path to plugins.json,
-// respecting the API_MASTER_CONFIG_DIR environment variable if set.
-func DefaultPluginRegistryPath() string {
-	dir := os.Getenv("API_MASTER_CONFIG_DIR")
+// ConfigDir returns the base configuration directory path.
+//
+// The path is determined in the following order of precedence:
+//  1. APILOT_CONFIG_DIR environment variable (if set)
+//  2. ~/.config/apilot (default)
+//
+// Returns an empty string if the home directory cannot be determined
+// and APILOT_CONFIG_DIR is not set.
+func ConfigDir() string {
+	dir := os.Getenv("APILOT_CONFIG_DIR")
 	if dir == "" {
-		home, _ := os.UserHomeDir()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
 		dir = filepath.Join(home, DefaultConfigDir)
+	}
+	return dir
+}
+
+// DefaultPluginRegistryPath returns the default path to plugins.json.
+func DefaultPluginRegistryPath() string {
+	dir := ConfigDir()
+	if dir == "" {
+		return ""
 	}
 	return filepath.Join(dir, DefaultPluginRegistryFilename)
 }

--- a/api-master/config/settings.go
+++ b/api-master/config/settings.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	formatter "github.com/tangcent/apilot/api-formatter"
+)
+
+// SettingsFilePath returns the absolute path to the settings file.
+// Returns an empty string if the config directory cannot be determined.
+func SettingsFilePath() string {
+	dir := ConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, DefaultSettingsFilename)
+}
+
+func LoadSettings() (map[string]string, error) {
+	path := SettingsFilePath()
+	if path == "" {
+		return map[string]string{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	var settings map[string]string
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return map[string]string{}, nil
+	}
+	if settings == nil {
+		settings = map[string]string{}
+	}
+	return settings, nil
+}
+
+func SaveSettings(settings map[string]string) error {
+	path := SettingsFilePath()
+	if path == "" {
+		return fmt.Errorf("cannot determine settings path: home directory unavailable and APILOT_CONFIG_DIR not set")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func GetSetting(key string) (string, error) {
+	settings, err := LoadSettings()
+	if err != nil {
+		return "", err
+	}
+	return settings[key], nil
+}
+
+func SetSetting(key, value string) error {
+	settings, err := LoadSettings()
+	if err != nil {
+		return err
+	}
+	settings[key] = value
+	return SaveSettings(settings)
+}
+
+// LazySettings implements formatter.Settings with on-demand loading.
+// The settings file is read only when Get() is first called.
+type LazySettings struct {
+	once     sync.Once
+	settings map[string]string
+}
+
+func NewLazySettings() *LazySettings {
+	return &LazySettings{}
+}
+
+func (s *LazySettings) load() {
+	s.settings, _ = LoadSettings()
+	if s.settings == nil {
+		s.settings = map[string]string{}
+	}
+}
+
+func (s *LazySettings) Get(key string) string {
+	s.once.Do(s.load)
+	return s.settings[key]
+}
+
+// MapSettings implements formatter.Settings backed by a simple map.
+// Useful for testing and for CLI commands that already have settings loaded.
+type MapSettings struct {
+	Values map[string]string
+}
+
+func NewMapSettings(values map[string]string) *MapSettings {
+	if values == nil {
+		values = map[string]string{}
+	}
+	return &MapSettings{Values: values}
+}
+
+func (s *MapSettings) Get(key string) string {
+	return s.Values[key]
+}
+
+var _ formatter.Settings = (*LazySettings)(nil)
+var _ formatter.Settings = (*MapSettings)(nil)

--- a/api-master/config/settings_test.go
+++ b/api-master/config/settings_test.go
@@ -331,8 +331,9 @@ func TestConfigDir_Default(t *testing.T) {
 	if dir == "" {
 		t.Fatal("ConfigDir() returned empty string")
 	}
-	if !strings.HasSuffix(dir, ".config/apilot") {
-		t.Errorf("Expected dir to end with '.config/apilot', got %q", dir)
+	expectedSuffix := filepath.FromSlash(".config/apilot")
+	if !strings.HasSuffix(dir, expectedSuffix) {
+		t.Errorf("Expected dir to end with %q, got %q", expectedSuffix, dir)
 	}
 }
 

--- a/api-master/config/settings_test.go
+++ b/api-master/config/settings_test.go
@@ -1,0 +1,372 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSettingsFilePath_Default(t *testing.T) {
+	os.Unsetenv("APILOT_CONFIG_DIR")
+	path := SettingsFilePath()
+	if path == "" {
+		t.Fatal("SettingsFilePath() returned empty string")
+	}
+	if filepath.Base(path) != "settings.json" {
+		t.Errorf("Expected base name 'settings.json', got %q", filepath.Base(path))
+	}
+}
+
+func TestSettingsFilePath_EnvOverride(t *testing.T) {
+	customDir := "/tmp/apilot-test-config"
+	os.Setenv("APILOT_CONFIG_DIR", customDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := SettingsFilePath()
+	expected := filepath.Join(customDir, "settings.json")
+	if path != expected {
+		t.Errorf("Expected %q, got %q", expected, path)
+	}
+}
+
+func TestLoadSettings_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	settings, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() error = %v", err)
+	}
+	if len(settings) != 0 {
+		t.Errorf("Expected empty settings, got %v", settings)
+	}
+}
+
+func TestSaveAndLoadSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	original := map[string]string{
+		"postman.api.key": "PMAK-test-key",
+		"other.setting":   "value",
+	}
+
+	if err := SaveSettings(original); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	loaded, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() error = %v", err)
+	}
+
+	if len(loaded) != len(original) {
+		t.Errorf("Expected %d settings, got %d", len(original), len(loaded))
+	}
+	for k, v := range original {
+		if loaded[k] != v {
+			t.Errorf("settings[%q] = %q, want %q", k, loaded[k], v)
+		}
+	}
+}
+
+func TestSaveSettings_CreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	nestedDir := filepath.Join(tmpDir, "nested", "dir")
+	os.Setenv("APILOT_CONFIG_DIR", nestedDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	settings := map[string]string{"key": "value"}
+	if err := SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(nestedDir, "settings.json")); os.IsNotExist(err) {
+		t.Error("settings.json was not created in nested directory")
+	}
+}
+
+func TestLoadSettings_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(path, []byte("not valid json"), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	settings, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() with invalid JSON should not error, got: %v", err)
+	}
+	if len(settings) != 0 {
+		t.Errorf("Expected empty settings for invalid JSON, got %v", settings)
+	}
+}
+
+func TestGetSetting(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	settings := map[string]string{"test.key": "test-value"}
+	if err := SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	value, err := GetSetting("test.key")
+	if err != nil {
+		t.Fatalf("GetSetting() error = %v", err)
+	}
+	if value != "test-value" {
+		t.Errorf("GetSetting() = %q, want %q", value, "test-value")
+	}
+}
+
+func TestGetSetting_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	value, err := GetSetting("nonexistent")
+	if err != nil {
+		t.Fatalf("GetSetting() error = %v", err)
+	}
+	if value != "" {
+		t.Errorf("GetSetting() for nonexistent key should return empty string, got %q", value)
+	}
+}
+
+func TestSetSetting(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	if err := SetSetting("new.key", "new-value"); err != nil {
+		t.Fatalf("SetSetting() error = %v", err)
+	}
+
+	value, err := GetSetting("new.key")
+	if err != nil {
+		t.Fatalf("GetSetting() error = %v", err)
+	}
+	if value != "new-value" {
+		t.Errorf("GetSetting() = %q, want %q", value, "new-value")
+	}
+}
+
+func TestSetSetting_Overwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	if err := SetSetting("key", "value1"); err != nil {
+		t.Fatalf("SetSetting() error = %v", err)
+	}
+	if err := SetSetting("key", "value2"); err != nil {
+		t.Fatalf("SetSetting() error = %v", err)
+	}
+
+	value, err := GetSetting("key")
+	if err != nil {
+		t.Fatalf("GetSetting() error = %v", err)
+	}
+	if value != "value2" {
+		t.Errorf("GetSetting() = %q, want %q", value, "value2")
+	}
+}
+
+func TestSaveSettings_AtomicWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	settings := map[string]string{"key": "value"}
+	if err := SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("Failed to read settings file: %v", err)
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Settings file is not valid JSON: %v", err)
+	}
+
+	if parsed["key"] != "value" {
+		t.Errorf("Expected key=value, got %v", parsed)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "settings.json.tmp")); !os.IsNotExist(err) {
+		t.Error("Temp file should not exist after save")
+	}
+}
+
+func TestLazySettings_Get(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	settings := map[string]string{"lazy.key": "lazy-value"}
+	if err := SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	ls := NewLazySettings()
+	value := ls.Get("lazy.key")
+	if value != "lazy-value" {
+		t.Errorf("LazySettings.Get() = %q, want %q", value, "lazy-value")
+	}
+}
+
+func TestLazySettings_Get_MissingKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	ls := NewLazySettings()
+	value := ls.Get("nonexistent")
+	if value != "" {
+		t.Errorf("LazySettings.Get() for missing key should return empty string, got %q", value)
+	}
+}
+
+func TestLazySettings_LazyLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv("APILOT_CONFIG_DIR", tmpDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	ls := NewLazySettings()
+
+	if err := SaveSettings(map[string]string{"key": "value"}); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+
+	value := ls.Get("key")
+	if value != "value" {
+		t.Errorf("LazySettings.Get() = %q, want %q", value, "value")
+	}
+}
+
+func TestMapSettings_Get(t *testing.T) {
+	ms := NewMapSettings(map[string]string{"map.key": "map-value"})
+
+	value := ms.Get("map.key")
+	if value != "map-value" {
+		t.Errorf("MapSettings.Get() = %q, want %q", value, "map-value")
+	}
+}
+
+func TestMapSettings_Get_MissingKey(t *testing.T) {
+	ms := NewMapSettings(map[string]string{})
+
+	value := ms.Get("nonexistent")
+	if value != "" {
+		t.Errorf("MapSettings.Get() for missing key should return empty string, got %q", value)
+	}
+}
+
+func TestMapSettings_NilMap(t *testing.T) {
+	ms := NewMapSettings(nil)
+
+	value := ms.Get("any.key")
+	if value != "" {
+		t.Errorf("MapSettings.Get() with nil map should return empty string, got %q", value)
+	}
+}
+
+func TestSettingsFilePath_EnvOverrideEmpty(t *testing.T) {
+	os.Setenv("APILOT_CONFIG_DIR", "")
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := SettingsFilePath()
+	if path == "" {
+		t.Fatal("SettingsFilePath() should not return empty when env is empty string (should use default)")
+	}
+}
+
+func TestLoadSettings_EmptyPath(t *testing.T) {
+	os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := SettingsFilePath()
+	if path == "" {
+		settings, err := LoadSettings()
+		if err != nil {
+			t.Errorf("LoadSettings() with empty path should not error, got: %v", err)
+		}
+		if len(settings) != 0 {
+			t.Errorf("LoadSettings() with empty path should return empty map, got: %v", settings)
+		}
+	} else {
+		t.Skip("Home directory available, cannot test empty path case")
+	}
+}
+
+func TestSaveSettings_EmptyPath(t *testing.T) {
+	os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := SettingsFilePath()
+	if path == "" {
+		err := SaveSettings(map[string]string{"key": "value"})
+		if err == nil {
+			t.Error("SaveSettings() with empty path should return error")
+		}
+	} else {
+		t.Skip("Home directory available, cannot test empty path case")
+	}
+}
+
+func TestConfigDir_Default(t *testing.T) {
+	os.Unsetenv("APILOT_CONFIG_DIR")
+
+	dir := ConfigDir()
+	if dir == "" {
+		t.Fatal("ConfigDir() returned empty string")
+	}
+	if !strings.HasSuffix(dir, ".config/apilot") {
+		t.Errorf("Expected dir to end with '.config/apilot', got %q", dir)
+	}
+}
+
+func TestConfigDir_EnvOverride(t *testing.T) {
+	customDir := "/tmp/custom-config"
+	os.Setenv("APILOT_CONFIG_DIR", customDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	dir := ConfigDir()
+	if dir != customDir {
+		t.Errorf("Expected %q, got %q", customDir, dir)
+	}
+}
+
+func TestDefaultPluginRegistryPath(t *testing.T) {
+	os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := DefaultPluginRegistryPath()
+	if path == "" {
+		t.Fatal("DefaultPluginRegistryPath() returned empty string")
+	}
+	if filepath.Base(path) != "plugins.json" {
+		t.Errorf("Expected base name 'plugins.json', got %q", filepath.Base(path))
+	}
+}
+
+func TestDefaultPluginRegistryPath_EnvOverride(t *testing.T) {
+	customDir := "/tmp/custom-apilot"
+	os.Setenv("APILOT_CONFIG_DIR", customDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	path := DefaultPluginRegistryPath()
+	expected := filepath.Join(customDir, "plugins.json")
+	if path != expected {
+		t.Errorf("Expected %q, got %q", expected, path)
+	}
+}

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	collector "github.com/tangcent/apilot/api-collector"
 	formatter "github.com/tangcent/apilot/api-formatter"
@@ -12,32 +13,27 @@ import (
 	"github.com/tangcent/apilot/api-master/plugin"
 )
 
-// Config holds the runtime configuration for a single engine run.
 type Config struct {
 	SourceDir      string
-	CollectorName  string // empty = auto-detect
-	FormatterName  string // default: "markdown"
-	FormatParams   string // raw JSON passed as FormatOptions.Params (e.g. `{"variant":"detailed"}`)
-	OutputPath     string // empty = stdout
-	PluginRegistry string // path to plugins.json
+	CollectorName  string
+	FormatterName  string
+	FormatParams   string
+	OutputPath     string
+	PluginRegistry string
 }
 
-// Run executes the full collect → format → output pipeline.
 func Run(cfg Config) error {
-	// 1. Resolve collector
 	c, err := resolveCollector(cfg)
 	if err != nil {
 		return fmt.Errorf("collector: %w", err)
 	}
 
-	// 2. Collect endpoints
 	ctx := collector.CollectContext{SourceDir: cfg.SourceDir}
 	endpoints, err := c.Collect(ctx)
 	if err != nil {
 		return fmt.Errorf("collection failed: %w", err)
 	}
 
-	// 3. Resolve formatter
 	formatterName := cfg.FormatterName
 	if formatterName == "" {
 		formatterName = "markdown"
@@ -47,8 +43,15 @@ func Run(cfg Config) error {
 		return fmt.Errorf("formatter: %w", err)
 	}
 
-	// 4. Format
-	opts := formatter.FormatOptions{}
+	settings := config.NewLazySettings()
+
+	if checkErr := checkRequiredSettings(f, settings); checkErr != nil {
+		return checkErr
+	}
+
+	opts := formatter.FormatOptions{
+		Settings: settings,
+	}
 	if cfg.FormatParams != "" {
 		opts.Params = []byte(cfg.FormatParams)
 	}
@@ -57,8 +60,22 @@ func Run(cfg Config) error {
 		return fmt.Errorf("formatting failed: %w", err)
 	}
 
-	// 5. Write output
 	return writeOutput(cfg.OutputPath, output)
+}
+
+func checkRequiredSettings(f formatter.Formatter, settings formatter.Settings) error {
+	sp, ok := f.(formatter.SettingsProvider)
+	if !ok {
+		return nil
+	}
+	for _, def := range sp.RequiredSettings() {
+		if def.Required {
+			if settings.Get(def.Key) == "" {
+				return fmt.Errorf("setting %q is required for formatter %q but not configured. Set it with: apilot set %s <value>", def.Key, f.Name(), def.Key)
+			}
+		}
+	}
+	return nil
 }
 
 func resolveCollector(cfg Config) (collector.Collector, error) {
@@ -73,8 +90,6 @@ func resolveCollector(cfg Config) (collector.Collector, error) {
 	return LookupCollector(name)
 }
 
-// detectCollector inspects the source directory for well-known indicator files
-// and returns the name of the most appropriate registered collector.
 func detectCollector(sourceDir string) (string, error) {
 	indicators := []struct {
 		file      string
@@ -106,8 +121,100 @@ func writeOutput(path string, data []byte) error {
 	return os.WriteFile(path, data, 0644)
 }
 
-// RunCLI parses os.Args and calls Run. Used by apilot-cli and api-master main.
 func RunCLI() {
+	args := os.Args[1:]
+
+	if len(args) == 0 {
+		printHelp()
+		os.Exit(1)
+	}
+
+	subcommand := args[0]
+	switch subcommand {
+	case "settings":
+		handleSettings()
+	case "set":
+		handleSet(args[1:])
+	case "get":
+		handleGet(args[1:])
+	case "export":
+		handleExport(args[1:])
+	case "--help", "-h", "help":
+		printHelp()
+	default:
+		if strings.HasPrefix(subcommand, "-") {
+			handleExport(args)
+		} else {
+			handleExport(args)
+		}
+	}
+}
+
+func handleSettings() {
+	loadPlugins()
+
+	settingDefs := ListFormatterSettings()
+	if len(settingDefs) == 0 {
+		fmt.Println("No settings required by registered formatters.")
+		return
+	}
+
+	settings, err := config.LoadSettings()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load settings: %v\n", err)
+		settings = map[string]string{}
+	}
+	settingsReader := config.NewMapSettings(settings)
+
+	fmt.Println("Settings:")
+	for _, def := range settingDefs {
+		value := settingsReader.Get(def.Key)
+		if value != "" {
+			masked := maskValue(value)
+			fmt.Printf("  %-30s %s (current: %s)\n", def.Key, def.Description, masked)
+		} else {
+			required := ""
+			if def.Required {
+				required = " [required]"
+			}
+			fmt.Printf("  %-30s %s%s\n", def.Key, def.Description, required)
+		}
+	}
+}
+
+func handleSet(args []string) {
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: apilot set <key> <value>\n")
+		os.Exit(1)
+	}
+	key := args[0]
+	value := args[1]
+	if err := config.SetSetting(key, value); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Set %s\n", key)
+}
+
+func handleGet(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: apilot get <key>\n")
+		os.Exit(1)
+	}
+	key := args[0]
+	value, err := config.GetSetting(key)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if value == "" {
+		fmt.Fprintf(os.Stderr, "Setting %q not found\n", key)
+		os.Exit(1)
+	}
+	fmt.Println(value)
+}
+
+func handleExport(args []string) {
 	var (
 		collectorName  string
 		formatterName  string
@@ -119,20 +226,21 @@ func RunCLI() {
 		showHelp       bool
 	)
 
-	flag.StringVar(&collectorName, "collector", "", "collector name (auto-detect if omitted)")
-	flag.StringVar(&formatterName, "formatter", "markdown", "formatter name (default: markdown)")
-	flag.StringVar(&formatParams, "params", "", "formatter params as JSON (e.g. '{\"variant\":\"detailed\"}')")
-	flag.StringVar(&outputPath, "output", "", "output file path (default: stdout)")
-	flag.StringVar(&pluginRegistry, "plugin-registry", "", "path to plugins.json")
-	flag.BoolVar(&listCollectors, "list-collectors", false, "print registered collectors and exit")
-	flag.BoolVar(&listFormatters, "list-formatters", false, "print registered formatters and exit")
-	flag.BoolVar(&showHelp, "help", false, "print help and exit")
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	fs.StringVar(&collectorName, "collector", "", "collector name (auto-detect if omitted)")
+	fs.StringVar(&formatterName, "formatter", "markdown", "formatter name (default: markdown)")
+	fs.StringVar(&formatParams, "params", "", "formatter params as JSON (e.g. '{\"variant\":\"detailed\"}')")
+	fs.StringVar(&outputPath, "output", "", "output file path (default: stdout)")
+	fs.StringVar(&pluginRegistry, "plugin-registry", "", "path to plugins.json")
+	fs.BoolVar(&listCollectors, "list-collectors", false, "print registered collectors and exit")
+	fs.BoolVar(&listFormatters, "list-formatters", false, "print registered formatters and exit")
+	fs.BoolVar(&showHelp, "help", false, "print help and exit")
 
-	flag.Usage = func() {
-		printHelp()
+	fs.Usage = func() {
+		printExportHelp()
 	}
 
-	flag.Parse()
+	fs.Parse(args)
 
 	if pluginRegistry == "" {
 		pluginRegistry = config.DefaultPluginRegistryPath()
@@ -144,7 +252,7 @@ func RunCLI() {
 	}
 
 	if showHelp {
-		printHelp()
+		printExportHelp()
 		os.Exit(0)
 	}
 
@@ -158,14 +266,14 @@ func RunCLI() {
 		return
 	}
 
-	args := flag.Args()
-	if len(args) == 0 {
+	remaining := fs.Args()
+	if len(remaining) == 0 {
 		fmt.Fprintf(os.Stderr, "error: source path required\n\n")
-		printHelp()
+		printExportHelp()
 		os.Exit(1)
 	}
 
-	sourceDir := args[0]
+	sourceDir := remaining[0]
 
 	cfg := Config{
 		SourceDir:      sourceDir,
@@ -182,8 +290,36 @@ func RunCLI() {
 	}
 }
 
+func loadPlugins() {
+	pluginRegistry := config.DefaultPluginRegistryPath()
+	if err := plugin.LoadRegistry(pluginRegistry, RegisterCollector, RegisterFormatter); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not load plugin registry: %v\n", err)
+	}
+}
+
+func maskValue(value string) string {
+	if len(value) <= 8 {
+		return "****"
+	}
+	return value[:4] + "****" + value[len(value)-4:]
+}
+
 func printHelp() {
-	fmt.Fprintln(os.Stderr, "Usage: apilot <source-path> [flags]")
+	fmt.Fprintln(os.Stderr, "Usage: apilot <command> [arguments]")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  export <source-path> [flags]  Export API endpoints from source code")
+	fmt.Fprintln(os.Stderr, "  settings                      List settings required by formatters")
+	fmt.Fprintln(os.Stderr, "  set <key> <value>             Set a configuration value")
+	fmt.Fprintln(os.Stderr, "  get <key>                     Get a configuration value")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Run 'apilot export --help' for export flags.")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Shorthand: 'apilot <source-path> [flags]' is equivalent to 'apilot export <source-path> [flags]'.")
+}
+
+func printExportHelp() {
+	fmt.Fprintln(os.Stderr, "Usage: apilot export <source-path> [flags]")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Flags:")
 	fmt.Fprintln(os.Stderr, "  --collector string")

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -305,17 +305,17 @@ func maskValue(value string) string {
 }
 
 func printHelp() {
-	fmt.Fprintln(os.Stderr, "Usage: apilot <command> [arguments]")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Commands:")
-	fmt.Fprintln(os.Stderr, "  export <source-path> [flags]  Export API endpoints from source code")
-	fmt.Fprintln(os.Stderr, "  settings                      List settings required by formatters")
-	fmt.Fprintln(os.Stderr, "  set <key> <value>             Set a configuration value")
-	fmt.Fprintln(os.Stderr, "  get <key>                     Get a configuration value")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Run 'apilot export --help' for export flags.")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Shorthand: 'apilot <source-path> [flags]' is equivalent to 'apilot export <source-path> [flags]'.")
+	fmt.Println("Usage: apilot <command> [arguments]")
+	fmt.Println("")
+	fmt.Println("Commands:")
+	fmt.Println("  export <source-path> [flags]  Export API endpoints from source code")
+	fmt.Println("  settings                      List settings required by formatters")
+	fmt.Println("  set <key> <value>             Set a configuration value")
+	fmt.Println("  get <key>                     Get a configuration value")
+	fmt.Println("")
+	fmt.Println("Run 'apilot export --help' for export flags.")
+	fmt.Println("")
+	fmt.Println("Shorthand: 'apilot <source-path> [flags]' is equivalent to 'apilot export <source-path> [flags]'.")
 }
 
 func printExportHelp() {

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -140,7 +140,7 @@ func RunCLI() {
 	case "export":
 		handleExport(args[1:])
 	case "--help", "-h", "help":
-		printHelp()
+		printExportHelp()
 	default:
 		if strings.HasPrefix(subcommand, "-") {
 			handleExport(args)
@@ -319,29 +319,29 @@ func printHelp() {
 }
 
 func printExportHelp() {
-	fmt.Fprintln(os.Stderr, "Usage: apilot export <source-path> [flags]")
-	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Flags:")
-	fmt.Fprintln(os.Stderr, "  --collector string")
-	fmt.Fprintln(os.Stderr, "        collector name (auto-detect if omitted)")
-	fmt.Fprintln(os.Stderr, "  --formatter string")
-	fmt.Fprintln(os.Stderr, "        formatter name (default: markdown)")
-	fmt.Fprintln(os.Stderr, "  --params string")
-	fmt.Fprintln(os.Stderr, "        formatter params as JSON (e.g. '{\"variant\":\"detailed\"}')")
-	fmt.Fprintln(os.Stderr, "  --output string")
-	fmt.Fprintln(os.Stderr, "        output file path (default: stdout)")
-	fmt.Fprintln(os.Stderr, "  --plugin-registry string")
-	fmt.Fprintln(os.Stderr, "        path to plugins.json")
-	fmt.Fprintln(os.Stderr, "  --list-collectors")
-	fmt.Fprintln(os.Stderr, "        print registered collectors and exit")
-	fmt.Fprintln(os.Stderr, "  --list-formatters")
-	fmt.Fprintln(os.Stderr, "        print registered formatters and exit")
-	fmt.Fprintln(os.Stderr, "  --help")
-	fmt.Fprintln(os.Stderr, "        print help and exit")
-	fmt.Fprintln(os.Stderr, "")
+	fmt.Println("Usage: apilot <source-path> [flags]")
+	fmt.Println("")
+	fmt.Println("Flags:")
+	fmt.Println("  --collector string")
+	fmt.Println("        collector name (auto-detect if omitted)")
+	fmt.Println("  --formatter string")
+	fmt.Println("        formatter name (default: markdown)")
+	fmt.Println("  --params string")
+	fmt.Println("        formatter params as JSON (e.g. '{\"variant\":\"detailed\"}')")
+	fmt.Println("  --output string")
+	fmt.Println("        output file path (default: stdout)")
+	fmt.Println("  --plugin-registry string")
+	fmt.Println("        path to plugins.json")
+	fmt.Println("  --list-collectors")
+	fmt.Println("        print registered collectors and exit")
+	fmt.Println("  --list-formatters")
+	fmt.Println("        print registered formatters and exit")
+	fmt.Println("  --help")
+	fmt.Println("        print help and exit")
+	fmt.Println("")
 
 	printCollectors()
-	fmt.Fprintln(os.Stderr, "")
+	fmt.Println("")
 
 	printFormatters()
 }

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -356,6 +356,8 @@ func TestListFormatterSettings(t *testing.T) {
 }
 
 func TestRunCLI_SettingsCommand(t *testing.T) {
+	ResetRegistry()
+
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tangcent/apilot/api-collector"
-	"github.com/tangcent/apilot/api-formatter"
+	collector "github.com/tangcent/apilot/api-collector"
+	formatter "github.com/tangcent/apilot/api-formatter"
 	"github.com/tangcent/apilot/api-master/config"
 )
 
@@ -188,9 +188,9 @@ func TestRun_CollectorError(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	RegisterCollector(&mockCollector{
-		name:          "error-collector",
+		name:           "error-collector",
 		supportedLangs: []string{"test"},
-		collectError:  fmt.Errorf("collection failed"),
+		collectError:   fmt.Errorf("collection failed"),
 	})
 
 	cfg := Config{
@@ -442,8 +442,8 @@ func TestRunCLI_HelpCommand(t *testing.T) {
 	output.ReadFrom(r)
 
 	result := output.String()
-	if !strings.Contains(result, "Commands:") {
-		t.Errorf("Expected 'Commands:' in help output, got: %s", result)
+	if !strings.Contains(result, "Flags:") {
+		t.Errorf("Expected 'Flags:' in help output, got: %s", result)
 	}
 }
 

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -2,7 +2,6 @@ package engine
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -10,19 +9,14 @@ import (
 
 	"github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-formatter"
+	"github.com/tangcent/apilot/api-master/config"
 )
 
-func resetFlags() {
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	flag.CommandLine.SetOutput(&bytes.Buffer{})
-}
-
 func TestRunCLI_ListCollectors(t *testing.T) {
-	resetFlags()
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
-	os.Args = []string{"api-master", "--list-collectors"}
+	os.Args = []string{"apilot", "export", "--list-collectors"}
 
 	var output bytes.Buffer
 	originalStdout := os.Stdout
@@ -42,11 +36,10 @@ func TestRunCLI_ListCollectors(t *testing.T) {
 }
 
 func TestRunCLI_ListFormatters(t *testing.T) {
-	resetFlags()
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
-	os.Args = []string{"api-master", "--list-formatters"}
+	os.Args = []string{"apilot", "export", "--list-formatters"}
 
 	var output bytes.Buffer
 	originalStdout := os.Stdout
@@ -75,8 +68,8 @@ func TestRun_HappyPath(t *testing.T) {
 	})
 
 	RegisterFormatter(&mockFormatter{
-		name:           "test-formatter",
-		formatOutput:   []byte("formatted output"),
+		name:         "test-formatter",
+		formatOutput: []byte("formatted output"),
 	})
 
 	cfg := Config{
@@ -164,8 +157,8 @@ func TestRun_WriteToFile(t *testing.T) {
 	})
 
 	RegisterFormatter(&mockFormatter{
-		name:           "test-formatter",
-		formatOutput:   []byte("formatted output to file"),
+		name:         "test-formatter",
+		formatOutput: []byte("formatted output to file"),
 	})
 
 	cfg := Config{
@@ -227,8 +220,8 @@ func TestRun_FormatterError(t *testing.T) {
 	})
 
 	RegisterFormatter(&mockFormatter{
-		name:          "error-formatter",
-		formatError:   fmt.Errorf("formatting failed"),
+		name:        "error-formatter",
+		formatError: fmt.Errorf("formatting failed"),
 	})
 
 	cfg := Config{
@@ -248,18 +241,208 @@ func TestRun_FormatterError(t *testing.T) {
 	}
 }
 
-type mockFormatter struct {
-	name         string
-	formatOutput []byte
-	formatError  error
+func TestRun_SettingsInjectedIntoFormatOptions(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/config"
+	os.Setenv("APILOT_CONFIG_DIR", configDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	config.SetSetting("test.key", "test-value")
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{{Name: "test-endpoint"}},
+	})
+
+	RegisterFormatter(&mockFormatterWithSettings{
+		name: "settings-formatter",
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "settings-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
 }
 
-func (m *mockFormatter) Name() string {
-	return m.name
+func TestRun_RequiredSettingMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/config2"
+	os.Setenv("APILOT_CONFIG_DIR", configDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{{Name: "test-endpoint"}},
+	})
+
+	RegisterFormatter(&mockFormatterWithRequiredSetting{
+		name: "required-setting-formatter",
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "required-setting-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err == nil {
+		t.Error("Expected error for missing required setting, got nil")
+	}
+	if !strings.Contains(err.Error(), "required.key") {
+		t.Errorf("Expected 'required.key' in error, got: %v", err)
+	}
 }
 
-func (m *mockFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
-	return m.formatOutput, m.formatError
+func TestRun_RequiredSettingPresent(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/config3"
+	os.Setenv("APILOT_CONFIG_DIR", configDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	config.SetSetting("required.key", "required-value")
+
+	RegisterCollector(&mockCollector{
+		name:             "test-collector",
+		supportedLangs:   []string{"test"},
+		collectEndpoints: []collector.ApiEndpoint{{Name: "test-endpoint"}},
+	})
+
+	RegisterFormatter(&mockFormatterWithRequiredSetting{
+		name: "required-setting-formatter",
+	})
+
+	cfg := Config{
+		SourceDir:      tmpDir,
+		CollectorName:  "test-collector",
+		FormatterName:  "required-setting-formatter",
+		OutputPath:     "",
+		PluginRegistry: "",
+	}
+
+	err := Run(cfg)
+	if err != nil {
+		t.Errorf("Expected no error when required setting is present, got: %v", err)
+	}
+}
+
+func TestListFormatterSettings(t *testing.T) {
+	saved := formatters
+	formatters = map[string]formatter.Formatter{}
+	defer func() { formatters = saved }()
+
+	RegisterFormatter(&mockFormatterWithSettings{name: "fmt-with-settings"})
+	RegisterFormatter(&mockFormatter{name: "fmt-without-settings"})
+
+	settingDefs := ListFormatterSettings()
+	if len(settingDefs) != 1 {
+		t.Fatalf("Expected 1 setting, got %d", len(settingDefs))
+	}
+	if settingDefs[0].Key != "test.key" {
+		t.Errorf("Expected key 'test.key', got %q", settingDefs[0].Key)
+	}
+}
+
+func TestRunCLI_SettingsCommand(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"apilot", "settings"}
+
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = originalStdout
+	output.ReadFrom(r)
+
+	result := output.String()
+	if !strings.Contains(result, "No settings required") {
+		t.Errorf("Expected 'No settings required' in output, got: %s", result)
+	}
+}
+
+func TestRunCLI_SetAndGetCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/config"
+	os.Setenv("APILOT_CONFIG_DIR", configDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"apilot", "set", "test.cli.key", "test-cli-value"}
+
+	var setOutput bytes.Buffer
+	setStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = setStdout
+	setOutput.ReadFrom(r)
+
+	if !strings.Contains(setOutput.String(), "Set test.cli.key") {
+		t.Errorf("Expected 'Set test.cli.key' in output, got: %s", setOutput.String())
+	}
+
+	os.Args = []string{"apilot", "get", "test.cli.key"}
+
+	var getOutput bytes.Buffer
+	getStdout := os.Stdout
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+
+	RunCLI()
+
+	w2.Close()
+	os.Stdout = getStdout
+	getOutput.ReadFrom(r2)
+
+	if !strings.Contains(getOutput.String(), "test-cli-value") {
+		t.Errorf("Expected 'test-cli-value' in output, got: %s", getOutput.String())
+	}
+}
+
+func TestRunCLI_HelpCommand(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"apilot", "--help"}
+
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = originalStdout
+	output.ReadFrom(r)
+
+	result := output.String()
+	if !strings.Contains(result, "Commands:") {
+		t.Errorf("Expected 'Commands:' in help output, got: %s", result)
+	}
 }
 
 func TestDetectCollector_Java(t *testing.T) {
@@ -287,7 +470,7 @@ func TestDetectCollector_Java(t *testing.T) {
 				t.Errorf("Expected no error, got: %v", err)
 			}
 			if result != "java" {
-				t.Errorf("Expected 'java', got: %q", result)
+				t.Errorf("Expected 'java', got %q", result)
 			}
 		})
 	}
@@ -307,7 +490,7 @@ func TestDetectCollector_Go(t *testing.T) {
 		t.Errorf("Expected no error, got: %v", err)
 	}
 	if result != "go" {
-		t.Errorf("Expected 'go', got: %q", result)
+		t.Errorf("Expected 'go', got %q", result)
 	}
 }
 
@@ -325,7 +508,7 @@ func TestDetectCollector_Node(t *testing.T) {
 		t.Errorf("Expected no error, got: %v", err)
 	}
 	if result != "node" {
-		t.Errorf("Expected 'node', got: %q", result)
+		t.Errorf("Expected 'node', got %q", result)
 	}
 }
 
@@ -353,7 +536,7 @@ func TestDetectCollector_Python(t *testing.T) {
 				t.Errorf("Expected no error, got: %v", err)
 			}
 			if result != "python" {
-				t.Errorf("Expected 'python', got: %q", result)
+				t.Errorf("Expected 'python', got %q", result)
 			}
 		})
 	}
@@ -378,7 +561,6 @@ func TestDetectCollector_CollectorNotRegistered(t *testing.T) {
 		t.Fatalf("Failed to create indicator file: %v", err)
 	}
 
-	// Temporarily clear the registry so "go" is not registered.
 	saved := collectors
 	collectors = map[string]collector.Collector{}
 	defer func() { collectors = saved }()
@@ -411,7 +593,85 @@ func TestDetectCollector_FirstMatchWins(t *testing.T) {
 	}
 
 	if result != "java" {
-		t.Errorf("Expected 'java' (first match), got: %q", result)
+		t.Errorf("Expected 'java' (first match), got %q", result)
+	}
+}
+
+func TestMaskValue(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"short", "****"},
+		{"PMAK-12345678-abcdef", "PMAK****cdef"},
+		{"123456789", "1234****6789"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := maskValue(tt.input)
+			if result != tt.expected {
+				t.Errorf("maskValue(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+type mockFormatter struct {
+	name         string
+	formatOutput []byte
+	formatError  error
+}
+
+func (m *mockFormatter) Name() string {
+	return m.name
+}
+
+func (m *mockFormatter) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	return m.formatOutput, m.formatError
+}
+
+type mockFormatterWithSettings struct {
+	name string
+}
+
+func (m *mockFormatterWithSettings) Name() string {
+	return m.name
+}
+
+func (m *mockFormatterWithSettings) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	return []byte("ok"), nil
+}
+
+func (m *mockFormatterWithSettings) RequiredSettings() []formatter.SettingDef {
+	return []formatter.SettingDef{
+		{
+			Key:         "test.key",
+			Description: "A test setting",
+			Required:    false,
+		},
+	}
+}
+
+type mockFormatterWithRequiredSetting struct {
+	name string
+}
+
+func (m *mockFormatterWithRequiredSetting) Name() string {
+	return m.name
+}
+
+func (m *mockFormatterWithRequiredSetting) Format(endpoints []collector.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
+	return []byte("ok"), nil
+}
+
+func (m *mockFormatterWithRequiredSetting) RequiredSettings() []formatter.SettingDef {
+	return []formatter.SettingDef{
+		{
+			Key:         "required.key",
+			Description: "A required setting",
+			Required:    true,
+		},
 	}
 }
 

--- a/api-master/engine/registry.go
+++ b/api-master/engine/registry.go
@@ -12,6 +12,11 @@ var (
 	formatters = map[string]formatter.Formatter{}
 )
 
+func ResetRegistry() {
+	collectors = map[string]collector.Collector{}
+	formatters = map[string]formatter.Formatter{}
+}
+
 // RegisterCollector adds a Collector to the in-process registry.
 func RegisterCollector(c collector.Collector) {
 	collectors[c.Name()] = c

--- a/api-master/engine/registry.go
+++ b/api-master/engine/registry.go
@@ -57,3 +57,15 @@ func ListFormatters() []string {
 	}
 	return out
 }
+
+// ListFormatterSettings returns all settings declared by registered formatters
+// that implement the SettingsProvider interface.
+func ListFormatterSettings() []formatter.SettingDef {
+	var all []formatter.SettingDef
+	for _, f := range formatters {
+		if sp, ok := f.(formatter.SettingsProvider); ok {
+			all = append(all, sp.RequiredSettings()...)
+		}
+	}
+	return all
+}

--- a/apilot-cli/integration_test.go
+++ b/apilot-cli/integration_test.go
@@ -165,7 +165,7 @@ func TestGoProjectWithPostmanFormatter(t *testing.T) {
 }
 
 func TestMissingSourcePath(t *testing.T) {
-	output, exitCode := runCLIWithExitCode()
+	output, exitCode := runCLIWithExitCode("--collector", "go")
 	if exitCode != 1 {
 		t.Fatalf("expected exit code 1 for missing source path, got %d, output: %s", exitCode, output)
 	}


### PR DESCRIPTION
## Changes

- Add settings.go for persistent settings storage
- Add PostmanClient for Postman API integration
- Refactor config directory handling with APILOT_CONFIG_DIR env var
- Enhance engine with settings support
- Add comprehensive tests for new functionality

## Files Changed

- `api-master/config/settings.go` - New settings management module
- `api-master/config/settings_test.go` - Tests for settings
- `api-formatter-postman/client.go` - Postman API client
- `api-formatter-postman/client_test.go` - Tests for client
- `api-master/config/defaults.go` - Refactored config directory handling
- `api-formatter-postman/formatter.go` - Enhanced formatter
- `api-formatter/formatter.go` - Updated formatter interface
- `api-master/engine/engine.go` - Engine enhancements
- `api-master/engine/engine_test.go` - Engine tests
- `api-master/engine/registry.go` - Registry updates