### PR TITLE
chore: split integration tests by framework using matrix strategy

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,11 +33,13 @@ jobs:
   integration-test:
     needs: check-skip
     if: ${{ github.event_name != 'pull_request' || needs.check-skip.outputs.should-skip != 'true' }}
-    name: "Integration Tests on ${{ matrix.os }}"
+    name: "${{ matrix.framework }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        framework: [ Go, Java, Node.js, Python ]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +57,7 @@ jobs:
         run: go build -o apilot.exe ./apilot-cli
         if: runner.os == 'Windows'
 
-      - name: Run integration tests
+      - name: Run ${{ matrix.framework }} integration tests
         shell: bash
         run: |
           # Make apilot accessible in PATH
@@ -66,6 +68,6 @@ jobs:
             sudo mv apilot /usr/local/bin/
           fi
           
-          # Run integration tests
+          # Run integration tests for specific framework
           cd samples
-          bash run_all_tests.sh
+          bash run_all_tests.sh "${{ matrix.framework }}"

--- a/samples/run_all_tests.sh
+++ b/samples/run_all_tests.sh
@@ -2,47 +2,119 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+FRAMEWORK_FILTER="${1:-all}"
+
 echo "========================================="
 echo "Running APilot Integration Tests"
+if [ "$FRAMEWORK_FILTER" != "all" ]; then
+    echo "Framework Filter: $FRAMEWORK_FILTER"
+fi
 echo "========================================="
 echo ""
 
-# Track results
-TOTAL=0
-PASSED=0
-FAILED=0
+declare -A FRAMEWORK_RESULTS
+declare -a FRAMEWORK_ORDER
 
-# Run tests for each sample project
-for dir in "$SCRIPT_DIR"/*/; do
-    if [ -f "$dir/test.sh" ]; then
-        SAMPLE_NAME=$(basename "$dir")
-        echo "----------------------------------------"
-        echo "Testing: $SAMPLE_NAME"
-        echo "----------------------------------------"
-        
-        TOTAL=$((TOTAL + 1))
-        
-        if bash "$dir/test.sh"; then
-            PASSED=$((PASSED + 1))
-        else
-            FAILED=$((FAILED + 1))
-            echo "✗ $SAMPLE_NAME FAILED"
+run_framework_tests() {
+    local framework_name=$1
+    shift
+    local samples=("$@")
+    
+    echo "========================================="
+    echo "Framework: $framework_name"
+    echo "========================================="
+    
+    local total=0
+    local passed=0
+    local failed=0
+    local failed_samples=()
+    
+    for sample in "${samples[@]}"; do
+        local dir="$SCRIPT_DIR/$sample"
+        if [ -f "$dir/test.sh" ]; then
+            echo "----------------------------------------"
+            echo "Testing: $sample"
+            echo "----------------------------------------"
+            
+            total=$((total + 1))
+            
+            if bash "$dir/test.sh"; then
+                passed=$((passed + 1))
+                echo "✓ $sample PASSED"
+            else
+                failed=$((failed + 1))
+                failed_samples+=("$sample")
+                echo "✗ $sample FAILED"
+            fi
+            echo ""
         fi
-        echo ""
+    done
+    
+    echo "----------------------------------------"
+    echo "$framework_name Summary: $passed/$total passed"
+    if [ $failed -gt 0 ]; then
+        echo "Failed samples: ${failed_samples[*]}"
     fi
+    echo "----------------------------------------"
+    echo ""
+    
+    FRAMEWORK_RESULTS["$framework_name"]="$passed/$total"
+    FRAMEWORK_ORDER+=("$framework_name")
+    
+    return $failed
+}
+
+GO_SAMPLES=("go-echo" "go-fiber" "go-gin")
+JAVA_SAMPLES=("java-feign" "java-jaxrs" "java-springmvc")
+NODE_SAMPLES=("node-express" "node-fastify" "node-nestjs")
+PYTHON_SAMPLES=("python-django" "python-fastapi" "python-flask")
+
+TOTAL_FRAMEWORKS=0
+PASSED_FRAMEWORKS=0
+FAILED_FRAMEWORKS=0
+
+run_if_matching() {
+    local framework_name=$1
+    shift
+    local samples=("$@")
+    
+    if [ "$FRAMEWORK_FILTER" = "all" ] || [ "$FRAMEWORK_FILTER" = "$framework_name" ]; then
+        run_framework_tests "$framework_name" "${samples[@]}"
+        if [ $? -eq 0 ]; then
+            PASSED_FRAMEWORKS=$((PASSED_FRAMEWORKS + 1))
+        else
+            FAILED_FRAMEWORKS=$((FAILED_FRAMEWORKS + 1))
+        fi
+        TOTAL_FRAMEWORKS=$((TOTAL_FRAMEWORKS + 1))
+    fi
+}
+
+run_if_matching "Go" "${GO_SAMPLES[@]}"
+run_if_matching "Java" "${JAVA_SAMPLES[@]}"
+run_if_matching "Node.js" "${NODE_SAMPLES[@]}"
+run_if_matching "Python" "${PYTHON_SAMPLES[@]}"
+
+if [ "$FRAMEWORK_FILTER" != "all" ] && [ $TOTAL_FRAMEWORKS -eq 0 ]; then
+    echo "Error: Unknown framework '$FRAMEWORK_FILTER'"
+    echo "Valid frameworks: Go, Java, Node.js, Python, all"
+    exit 1
+fi
+
+echo "========================================="
+echo "Overall Integration Test Summary"
+echo "========================================="
+echo ""
+echo "Framework Results:"
+for framework in "${FRAMEWORK_ORDER[@]}"; do
+    echo "  $framework: ${FRAMEWORK_RESULTS[$framework]}"
 done
-
-# Print summary
-echo "========================================="
-echo "Integration Test Summary"
-echo "========================================="
-echo "Total:  $TOTAL"
-echo "Passed: $PASSED"
-echo "Failed: $FAILED"
+echo ""
+echo "Total Frameworks:  $TOTAL_FRAMEWORKS"
+echo "Passed Frameworks: $PASSED_FRAMEWORKS"
+echo "Failed Frameworks: $FAILED_FRAMEWORKS"
 echo "========================================="
 
-# Exit with error if any test failed
-if [ $FAILED -gt 0 ]; then
+if [ $FAILED_FRAMEWORKS -gt 0 ]; then
     exit 1
 fi
 


### PR DESCRIPTION
## Changes

- Split integration tests by framework using matrix strategy in CI

## Details

- Added framework dimension to the CI matrix (Go, Java, Node.js, Python)
- Each framework runs as a separate parallel job across all OS platforms
- Set fail-fast: false so one framework failure does not stop others
- Updated run_all_tests.sh to accept an optional framework parameter (e.g. bash run_all_tests.sh Go)
- Job names now show framework and OS for easy identification (e.g. Go on ubuntu-latest)

## Benefits

- Clear visibility: immediately see which frameworks pass/fail in GitHub Actions
- Parallel execution: all frameworks run simultaneously, reducing total CI time
- Better isolation: a failure in one framework does not affect others
- Flexible local testing: can test specific frameworks or all at once