### PR TITLE
feat: implement Flask route parser (#28)

### DIFF
--- a/api-collector-python/flask/parser.go
+++ b/api-collector-python/flask/parser.go
@@ -1,10 +1,512 @@
-// Package flask parses Flask route decorators.
 package flask
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
-// Parse extracts endpoints from Flask @app.route and @blueprint.route decorated functions.
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	python "github.com/tree-sitter/tree-sitter-python/bindings/go"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	// TODO: implement using tree-sitter-python
-	return nil, nil
+	pyFiles, err := discoverPythonFiles(sourceDir)
+	if err != nil || len(pyFiles) == 0 {
+		return nil, nil
+	}
+
+	ch := make(chan fileResult, len(pyFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range pyFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var allEndpoints []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			continue
+		}
+		allEndpoints = append(allEndpoints, res.endpoints...)
+	}
+
+	if len(allEndpoints) == 0 {
+		return nil, nil
+	}
+
+	return allEndpoints, nil
+}
+
+type fileResult struct {
+	endpoints []collector.ApiEndpoint
+	err       error
+}
+
+func discoverPythonFiles(sourceDir string) ([]string, error) {
+	var pyFiles []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".py") {
+			pyFiles = append(pyFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pyFiles, nil
+}
+
+func processFile(filePath string) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(python.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+	var endpoints []collector.ApiEndpoint
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+		if child.Kind() != "decorated_definition" {
+			continue
+		}
+
+		eps := extractDecoratedDefinition(child, source)
+		endpoints = append(endpoints, eps...)
+	}
+
+	return endpoints
+}
+
+func extractDecoratedDefinition(node *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+	var decorator *tree_sitter.Node
+	var funcDef *tree_sitter.Node
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "decorator":
+			decorator = child
+		case "function_definition":
+			funcDef = child
+		}
+	}
+
+	if decorator == nil || funcDef == nil {
+		return nil
+	}
+
+	routeInfo := extractDecoratorInfo(decorator, source)
+	if routeInfo.path == "" {
+		return nil
+	}
+
+	funcName := extractFunctionName(funcDef, source)
+	description := extractDocstring(funcDef, source)
+
+	var endpoints []collector.ApiEndpoint
+
+	for _, method := range routeInfo.methods {
+		path := convertFlaskPathToStandard(routeInfo.path)
+		ep := &collector.ApiEndpoint{
+			Name:        funcName,
+			Path:        path,
+			Method:      strings.ToUpper(method),
+			Protocol:    "http",
+			Description: description,
+		}
+
+		pathParams := extractPathParams(path)
+		pathParamNames := make(map[string]bool)
+		for _, p := range pathParams {
+			pathParamNames[p.name] = true
+		}
+
+		params := extractFunctionParameters(funcDef, source, path)
+
+		paramSet := make(map[string]bool)
+		var allParams []collector.ApiParameter
+
+		for _, p := range pathParams {
+			allParams = append(allParams, collector.ApiParameter{
+				Name:     p.name,
+				In:       "path",
+				Required: true,
+				Type:     "text",
+			})
+			paramSet[p.name+"|path"] = true
+		}
+
+		for _, p := range params {
+			if pathParamNames[p.name] && p.in == "query" {
+				p.in = "path"
+				p.required = true
+			}
+			key := p.name + "|" + p.in
+			if !paramSet[key] {
+				allParams = append(allParams, collector.ApiParameter{
+					Name:     p.name,
+					In:       p.in,
+					Required: p.required,
+					Type:     p.typ,
+				})
+				paramSet[key] = true
+			}
+		}
+
+		if len(allParams) > 0 {
+			ep.Parameters = allParams
+		}
+
+		endpoints = append(endpoints, *ep)
+	}
+
+	return endpoints
+}
+
+type routeInfo struct {
+	path    string
+	methods []string
+}
+
+func extractDecoratorInfo(decorator *tree_sitter.Node, source []byte) routeInfo {
+	for i := uint(0); i < decorator.ChildCount(); i++ {
+		child := decorator.Child(i)
+		if child.Kind() == "@" {
+			continue
+		}
+
+		info := resolveDecoratorCall(child, source)
+		if info.path != "" {
+			return info
+		}
+	}
+	return routeInfo{}
+}
+
+func resolveDecoratorCall(node *tree_sitter.Node, source []byte) routeInfo {
+	if node.Kind() == "call" {
+		return resolveCallExpression(node, source)
+	}
+	if node.Kind() == "attribute" {
+		return resolveAttribute(node, source)
+	}
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		info := resolveDecoratorCall(child, source)
+		if info.path != "" {
+			return info
+		}
+	}
+	return routeInfo{}
+}
+
+func resolveCallExpression(callNode *tree_sitter.Node, source []byte) routeInfo {
+	var isRoute bool
+	var path string
+	var methods []string
+
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "attribute" {
+			attr := extractAttributeName(child, source)
+			if attr == "route" {
+				isRoute = true
+			}
+		}
+		if child.Kind() == "argument_list" {
+			path, methods = extractArguments(child, source)
+		}
+	}
+
+	if !isRoute || path == "" {
+		return routeInfo{}
+	}
+
+	if len(methods) == 0 {
+		methods = []string{"GET"}
+	}
+
+	return routeInfo{path: path, methods: methods}
+}
+
+func resolveAttribute(attrNode *tree_sitter.Node, source []byte) routeInfo {
+	attr := extractAttributeName(attrNode, source)
+	if attr == "route" {
+		return routeInfo{}
+	}
+	return routeInfo{}
+}
+
+func extractAttributeName(attrNode *tree_sitter.Node, source []byte) string {
+	var attr string
+
+	for i := uint(0); i < attrNode.ChildCount(); i++ {
+		child := attrNode.Child(i)
+		if child.Kind() == "." {
+			continue
+		}
+		if child.Kind() == "identifier" {
+			attr = child.Utf8Text(source)
+		}
+	}
+
+	return attr
+}
+
+func extractArguments(argListNode *tree_sitter.Node, source []byte) (path string, methods []string) {
+	for i := uint(0); i < argListNode.ChildCount(); i++ {
+		child := argListNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if child.Kind() == "string" && path == "" {
+			path = unquotePythonString(child.Utf8Text(source))
+		}
+
+		if child.Kind() == "keyword_argument" {
+			methods = extractMethodsArgument(child, source)
+		}
+	}
+
+	return path, methods
+}
+
+func extractMethodsArgument(kwArgNode *tree_sitter.Node, source []byte) []string {
+	var methods []string
+
+	for i := uint(0); i < kwArgNode.ChildCount(); i++ {
+		child := kwArgNode.Child(i)
+		if child.Kind() == "identifier" {
+			if child.Utf8Text(source) != "methods" {
+				return nil
+			}
+		}
+		if child.Kind() == "list" {
+			methods = extractMethodList(child, source)
+		}
+	}
+
+	return methods
+}
+
+func extractMethodList(listNode *tree_sitter.Node, source []byte) []string {
+	var methods []string
+
+	for i := uint(0); i < listNode.ChildCount(); i++ {
+		child := listNode.Child(i)
+		if child.Kind() == "[" || child.Kind() == "]" || child.Kind() == "," {
+			continue
+		}
+		if child.Kind() == "string" {
+			method := unquotePythonString(child.Utf8Text(source))
+			methods = append(methods, strings.ToUpper(method))
+		}
+	}
+
+	return methods
+}
+
+func extractFunctionName(funcDef *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < funcDef.ChildCount(); i++ {
+		child := funcDef.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
+func extractDocstring(funcDef *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < funcDef.ChildCount(); i++ {
+		child := funcDef.Child(i)
+		if child.Kind() == "block" {
+			return extractDocstringFromBlock(child, source)
+		}
+	}
+	return ""
+}
+
+func extractDocstringFromBlock(blockNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < blockNode.ChildCount(); i++ {
+		child := blockNode.Child(i)
+		if child.Kind() == "expression_statement" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				subChild := child.Child(j)
+				if subChild.Kind() == "string" {
+					return unquotePythonString(subChild.Utf8Text(source))
+				}
+			}
+		}
+		break
+	}
+	return ""
+}
+
+type funcParam struct {
+	name     string
+	in       string
+	required bool
+	typ      string
+}
+
+func extractFunctionParameters(funcDef *tree_sitter.Node, source []byte, path string) []funcParam {
+	var params []funcParam
+
+	for i := uint(0); i < funcDef.ChildCount(); i++ {
+		child := funcDef.Child(i)
+		if child.Kind() == "parameters" {
+			params = extractParameters(child, source, path)
+			break
+		}
+	}
+
+	return params
+}
+
+func extractParameters(paramsNode *tree_sitter.Node, source []byte, path string) []funcParam {
+	var params []funcParam
+
+	for i := uint(0); i < paramsNode.ChildCount(); i++ {
+		child := paramsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if child.Kind() == "identifier" {
+			name := child.Utf8Text(source)
+			in := "query"
+			if isNameInPath(name, path) {
+				in = "path"
+			}
+			params = append(params, funcParam{
+				name:     name,
+				in:       in,
+				required: in == "path",
+				typ:      "text",
+			})
+		} else if child.Kind() == "typed_parameter" || child.Kind() == "default_parameter" || child.Kind() == "typed_default_parameter" {
+			param := extractSingleParameter(child, source, path)
+			if param.name != "" {
+				params = append(params, param)
+			}
+		}
+	}
+
+	return params
+}
+
+func extractSingleParameter(paramNode *tree_sitter.Node, source []byte, path string) funcParam {
+	p := funcParam{
+		in:       "query",
+		required: true,
+		typ:      "text",
+	}
+
+	for i := uint(0); i < paramNode.ChildCount(); i++ {
+		child := paramNode.Child(i)
+
+		switch child.Kind() {
+		case "identifier":
+			if p.name == "" {
+				p.name = child.Utf8Text(source)
+			}
+		case "=":
+			p.required = false
+		}
+	}
+
+	if p.name != "" && isNameInPath(p.name, path) && p.in == "query" {
+		p.in = "path"
+		p.required = true
+	}
+
+	return p
+}
+
+type pathParamInfo struct {
+	name string
+}
+
+func extractPathParams(path string) []pathParamInfo {
+	var params []pathParamInfo
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			name := segment[1 : len(segment)-1]
+			params = append(params, pathParamInfo{name: name})
+		}
+	}
+	return params
+}
+
+func isNameInPath(name string, path string) bool {
+	target := "{" + name + "}"
+	return strings.Contains(path, target)
+}
+
+func convertFlaskPathToStandard(flaskPath string) string {
+	result := flaskPath
+
+	result = strings.ReplaceAll(result, "<string:", "{")
+	result = strings.ReplaceAll(result, "<int:", "{")
+	result = strings.ReplaceAll(result, "<float:", "{")
+	result = strings.ReplaceAll(result, "<path:", "{")
+	result = strings.ReplaceAll(result, "<uuid:", "{")
+	result = strings.ReplaceAll(result, "<", "{")
+	result = strings.ReplaceAll(result, ">", "}")
+
+	return result
+}
+
+func unquotePythonString(s string) string {
+	if len(s) >= 3 && (strings.HasPrefix(s, `"""`) || strings.HasPrefix(s, `'''`)) {
+		quote := s[:3]
+		if strings.HasSuffix(s, quote) {
+			return s[3 : len(s)-3]
+		}
+	}
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/api-collector-python/flask/parser_test.go
+++ b/api-collector-python/flask/parser_test.go
@@ -1,0 +1,231 @@
+package flask
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+func TestParse_BasicRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "basic"))
+	if err != nil {
+		t.Fatalf("basic routes should not error: %v", err)
+	}
+	if len(endpoints) != 12 {
+		t.Fatalf("expected 12 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "delete_user", Path: "/users/{id}", Method: "DELETE", Protocol: "http",
+		Description: "deleteUser removes a user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "get_post", Path: "/items/{item_id}/posts/{post_id}", Method: "GET", Protocol: "http",
+		Description: "getPost returns a specific post.",
+		Parameters: []collector.ApiParameter{
+			{Name: "item_id", In: "path", Required: true, Type: "text"},
+			{Name: "post_id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "list_products", Path: "/products", Method: "GET", Protocol: "http",
+		Description: "listProducts returns all products.",
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "product_detail", Path: "/products/{id}", Method: "GET", Protocol: "http",
+		Description: "productDetail handles GET and POST for a product.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
+		Name: "list_users", Path: "/users", Method: "GET", Protocol: "http",
+		Description: "listUsers returns all users.",
+	})
+
+	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
+		Name: "get_user", Path: "/users/{id}", Method: "GET", Protocol: "http",
+		Description: "getUser returns a single user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
+		Name: "health_check", Path: "/health", Method: "HEAD", Protocol: "http",
+		Description: "healthCheck returns service health status.",
+	})
+
+	assertEndpoint(t, endpoints[7], collector.ApiEndpoint{
+		Name: "user_options", Path: "/users", Method: "OPTIONS", Protocol: "http",
+		Description: "userOptions returns allowed methods for /users.",
+	})
+
+	assertEndpoint(t, endpoints[8], collector.ApiEndpoint{
+		Name: "patch_user", Path: "/users/{id}", Method: "PATCH", Protocol: "http",
+		Description: "patchUser partially updates a user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[9], collector.ApiEndpoint{
+		Name: "product_detail", Path: "/products/{id}", Method: "POST", Protocol: "http",
+		Description: "productDetail handles GET and POST for a product.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[10], collector.ApiEndpoint{
+		Name: "create_user", Path: "/users", Method: "POST", Protocol: "http",
+		Description: "createUser creates a new user.",
+	})
+
+	assertEndpoint(t, endpoints[11], collector.ApiEndpoint{
+		Name: "update_user", Path: "/users/{id}", Method: "PUT", Protocol: "http",
+		Description: "updateUser updates an existing user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+}
+
+func TestConvertFlaskPathToStandard(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/users", "/users"},
+		{"/users/<id>", "/users/{id}"},
+		{"/users/<string:id>", "/users/{id}"},
+		{"/users/<int:id>", "/users/{id}"},
+		{"/users/<float:id>", "/users/{id}"},
+		{"/users/<path:id>", "/users/{id}"},
+		{"/users/<uuid:id>", "/users/{id}"},
+		{"/items/<item_id>/posts/<post_id>", "/items/{item_id}/posts/{post_id}"},
+	}
+
+	for _, tt := range tests {
+		result := convertFlaskPathToStandard(tt.input)
+		if result != tt.expected {
+			t.Errorf("convertFlaskPathToStandard(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestExtractPathParams(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected []pathParamInfo
+	}{
+		{"/users", nil},
+		{"/users/{id}", []pathParamInfo{{name: "id"}}},
+		{"/users/{id}/posts/{postId}", []pathParamInfo{
+			{name: "id"},
+			{name: "postId"},
+		}},
+		{"/{category}/{item}", []pathParamInfo{
+			{name: "category"},
+			{name: "item"},
+		}},
+	}
+
+	for _, tt := range tests {
+		result := extractPathParams(tt.path)
+		if len(result) != len(tt.expected) {
+			t.Errorf("extractPathParams(%q): got %d params, want %d", tt.path, len(result), len(tt.expected))
+			continue
+		}
+		for i, p := range result {
+			if p.name != tt.expected[i].name {
+				t.Errorf("extractPathParams(%q)[%d].name = %q, want %q", tt.path, i, p.name, tt.expected[i].name)
+			}
+		}
+	}
+}
+
+func TestUnquotePythonString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"hello"`, "hello"},
+		{`'hello'`, "hello"},
+		{`"""hello"""`, "hello"},
+		{`'''hello'''`, "hello"},
+		{`hello`, "hello"},
+		{`""`, ""},
+		{`"a/b/c"`, "a/b/c"},
+	}
+
+	for _, tt := range tests {
+		result := unquotePythonString(tt.input)
+		if result != tt.expected {
+			t.Errorf("unquotePythonString(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func assertEndpoint(t *testing.T, got collector.ApiEndpoint, want collector.ApiEndpoint) {
+	t.Helper()
+
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Path != want.Path {
+		t.Errorf("Path = %q, want %q", got.Path, want.Path)
+	}
+	if got.Method != want.Method {
+		t.Errorf("Method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Protocol != want.Protocol {
+		t.Errorf("Protocol = %q, want %q", got.Protocol, want.Protocol)
+	}
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
+	}
+
+	assertParams(t, got.Parameters, want.Parameters)
+}
+
+func assertParams(t *testing.T, got, want []collector.ApiParameter) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Errorf("Parameters: got %d, want %d", len(got), len(want))
+		return
+	}
+
+	for i, g := range got {
+		w := want[i]
+		if g.Name != w.Name {
+			t.Errorf("Parameters[%d].Name = %q, want %q", i, g.Name, w.Name)
+		}
+		if g.In != w.In {
+			t.Errorf("Parameters[%d].In = %q, want %q", i, g.In, w.In)
+		}
+		if g.Required != w.Required {
+			t.Errorf("Parameters[%d].Required = %v, want %v", i, g.Required, w.Required)
+		}
+		if g.Type != w.Type {
+			t.Errorf("Parameters[%d].Type = %q, want %q", i, g.Type, w.Type)
+		}
+	}
+}

--- a/api-collector-python/flask/testdata/basic/app.py
+++ b/api-collector-python/flask/testdata/basic/app.py
@@ -1,0 +1,72 @@
+from flask import Flask, Blueprint
+
+app = Flask(__name__)
+
+
+@app.route('/users')
+def list_users():
+    """listUsers returns all users."""
+    pass
+
+
+@app.route('/users', methods=['POST'])
+def create_user():
+    """createUser creates a new user."""
+    pass
+
+
+@app.route('/users/<id>', methods=['GET'])
+def get_user(id):
+    """getUser returns a single user by ID."""
+    pass
+
+
+@app.route('/users/<id>', methods=['PUT'])
+def update_user(id):
+    """updateUser updates an existing user."""
+    pass
+
+
+@app.route('/users/<id>', methods=['DELETE'])
+def delete_user(id):
+    """deleteUser removes a user by ID."""
+    pass
+
+
+@app.route('/users/<id>', methods=['PATCH'])
+def patch_user(id):
+    """patchUser partially updates a user."""
+    pass
+
+
+@app.route('/health', methods=['HEAD'])
+def health_check():
+    """healthCheck returns service health status."""
+    pass
+
+
+@app.route('/users', methods=['OPTIONS'])
+def user_options():
+    """userOptions returns allowed methods for /users."""
+    pass
+
+
+@app.route('/items/<item_id>/posts/<post_id>', methods=['GET'])
+def get_post(item_id, post_id):
+    """getPost returns a specific post."""
+    pass
+
+
+bp = Blueprint('api', __name__)
+
+
+@bp.route('/products')
+def list_products():
+    """listProducts returns all products."""
+    pass
+
+
+@bp.route('/products/<id>', methods=['GET', 'POST'])
+def product_detail(id):
+    """productDetail handles GET and POST for a product."""
+    pass

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -73,6 +73,7 @@
 - [X] Wire parsers into `collector.go` `Collect()` — discover `.py` files, delegate to framework parsers
 - [X] Write unit tests for fastapi parser with fixture Python source files
 - [X] Write unit tests for django parser with fixture Python source files
+- [X] Write unit tests for flask parser with fixture Python source files
 
 ---
 

--- a/samples/python-flask/test.sh
+++ b/samples/python-flask/test.sh
@@ -35,7 +35,7 @@ fi
 # Check if output contains expected endpoints
 if grep -q "GET /users" "$OUTPUT_DIR/api.md" && \
    grep -q "POST /users" "$OUTPUT_DIR/api.md" && \
-   grep -q "GET /users/{id}" "$OUTPUT_DIR/api.md" || grep -q "GET /users/:id" "$OUTPUT_DIR/api.md"; then
+   (grep -q "GET /users/{id}" "$OUTPUT_DIR/api.md" || grep -q "GET /users/:id" "$OUTPUT_DIR/api.md" || grep -q "GET /users/{user_id}" "$OUTPUT_DIR/api.md"); then
     echo "✓ $SAMPLE_NAME test passed"
     echo "  - Found expected endpoints in output"
     exit 0


### PR DESCRIPTION
## Summary
This PR implements the Flask route parser for api-collector-python as specified in issue #28.

## Changes
- Implemented Flask route parser in `api-collector-python/flask/parser.go`
- Parses `@app.route` and `@blueprint.route` decorated functions
- Extracts path string literals from decorator arguments
- Extracts HTTP methods from `methods` argument (defaults to GET)
- Extracts docstrings as descriptions
- Converts Flask path parameters (`<param>`) to standard format (`{param}`)
- Added comprehensive unit tests with test data
- Updated documentation in `docs/todo.md`

## Testing
- All unit tests pass
- Test coverage includes:
  - Basic routes with default GET method
  - Routes with explicit methods (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS)
  - Routes with multiple methods
  - Path parameters (simple and typed)
  - Blueprint routes
  - Docstring extraction

## Related Issue
Closes #28