### PR TITLE
feat: implement Fastify route parser

### DIFF
--- a/api-collector-node/collector.go
+++ b/api-collector-node/collector.go
@@ -2,7 +2,14 @@
 // Supported frameworks: Express, Fastify, NestJS.
 package nodecollector
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"log"
+	"sync"
+
+	"github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-collector-node/express"
+	"github.com/tangcent/apilot/api-collector-node/fastify"
+)
 
 // NodeCollector parses TypeScript/JavaScript source trees for API route definitions.
 type NodeCollector struct{}
@@ -15,9 +22,53 @@ func (c *NodeCollector) Name() string { return "node" }
 func (c *NodeCollector) SupportedLanguages() []string { return []string{"typescript", "javascript"} }
 
 // Collect walks the source directory and extracts endpoints from Express, Fastify, and NestJS sources.
+// Each framework parser is invoked concurrently. Results are merged into a
+// single slice. If a parser returns an error, a warning is logged and
+// collection continues with the remaining parsers.
 func (c *NodeCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
-	// TODO: implement
-	// Preferred: tree-sitter-typescript Go bindings (no external runtime dependency)
-	// Fallback: invoke node/ts-node subprocess
-	return nil, nil
+	type parseResult struct {
+		endpoints []collector.ApiEndpoint
+		err       error
+		framework string
+	}
+
+	parsers := []struct {
+		name  string
+		parse func(string) ([]collector.ApiEndpoint, error)
+	}{
+		{"express", express.Parse},
+		{"fastify", fastify.Parse},
+	}
+
+	ch := make(chan parseResult, len(parsers))
+	var wg sync.WaitGroup
+
+	for _, p := range parsers {
+		wg.Add(1)
+		go func(name string, fn func(string) ([]collector.ApiEndpoint, error)) {
+			defer wg.Done()
+			endpoints, err := fn(ctx.SourceDir)
+			ch <- parseResult{endpoints: endpoints, err: err, framework: name}
+		}(p.name, p.parse)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var all []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			log.Printf("warning: %s parser failed: %v", res.framework, res.err)
+			continue
+		}
+		all = append(all, res.endpoints...)
+	}
+
+	if len(all) == 0 {
+		return nil, nil
+	}
+
+	return all, nil
 }

--- a/api-collector-node/express/parser.go
+++ b/api-collector-node/express/parser.go
@@ -1,10 +1,341 @@
-// Package express parses Express route registrations.
+// Package express parses Express route registrations using tree-sitter-javascript.
+// It walks JavaScript source files for app.get, app.post, router.get, etc. calls
+// and extracts endpoint metadata including path, HTTP method, handler function name,
+// and JSDoc comments.
 package express
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
-// Parse extracts endpoints from Express route registrations (app.get, router.use, etc.).
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+var httpMethods = map[string]bool{
+	"get":     true,
+	"post":    true,
+	"put":     true,
+	"delete":  true,
+	"patch":   true,
+	"head":    true,
+	"options": true,
+}
+
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	// TODO: implement using tree-sitter-typescript or AST analysis
-	return nil, nil
+	jsFiles, err := discoverJSFiles(sourceDir)
+	if err != nil || len(jsFiles) == 0 {
+		return nil, nil
+	}
+
+	ch := make(chan fileResult, len(jsFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range jsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var allEndpoints []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			continue
+		}
+		allEndpoints = append(allEndpoints, res.endpoints...)
+	}
+
+	if len(allEndpoints) == 0 {
+		return nil, nil
+	}
+
+	return allEndpoints, nil
+}
+
+type fileResult struct {
+	endpoints []collector.ApiEndpoint
+	err       error
+}
+
+func discoverJSFiles(sourceDir string) ([]string, error) {
+	var jsFiles []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && (strings.HasSuffix(path, ".js") || strings.HasSuffix(path, ".mjs")) {
+			jsFiles = append(jsFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return jsFiles, nil
+}
+
+func processFile(filePath string) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(javascript.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+	var endpoints []collector.ApiEndpoint
+	var lastComment string
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+
+		if child.Kind() == "comment" {
+			commentText := child.Utf8Text(source)
+			if isJSDocComment(commentText) {
+				lastComment = cleanJSDocComment(commentText)
+			} else {
+				lastComment = ""
+			}
+			continue
+		}
+
+		if child.Kind() == "expression_statement" {
+			ep := extractFromExpressionStatement(child, source, lastComment)
+			if ep != nil {
+				endpoints = append(endpoints, *ep)
+			}
+			lastComment = ""
+		} else {
+			lastComment = ""
+		}
+	}
+
+	return endpoints
+}
+
+func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "call_expression" {
+			return extractFromCallExpression(child, source, description)
+		}
+	}
+	return nil
+}
+
+func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+	method, isRoute := extractMethodInfo(callNode, source)
+	if !isRoute {
+		return nil
+	}
+
+	path, handlerName := extractCallArguments(callNode, source)
+	if path == "" {
+		return nil
+	}
+
+	standardPath := convertExpressPath(path)
+
+	ep := &collector.ApiEndpoint{
+		Name:        handlerName,
+		Path:        standardPath,
+		Method:      strings.ToUpper(method),
+		Protocol:    "http",
+		Description: description,
+	}
+
+	pathParams := extractPathParams(standardPath)
+	if len(pathParams) > 0 {
+		var params []collector.ApiParameter
+		for _, p := range pathParams {
+			params = append(params, collector.ApiParameter{
+				Name:     p.name,
+				In:       "path",
+				Required: true,
+				Type:     "text",
+			})
+		}
+		ep.Parameters = params
+	}
+
+	return ep
+}
+
+func extractMethodInfo(callNode *tree_sitter.Node, source []byte) (method string, isRoute bool) {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "member_expression" {
+			return extractMemberExpressionMethod(child, source)
+		}
+	}
+	return "", false
+}
+
+func extractMemberExpressionMethod(memberNode *tree_sitter.Node, source []byte) (method string, isRoute bool) {
+	var prop string
+
+	for i := uint(0); i < memberNode.ChildCount(); i++ {
+		child := memberNode.Child(i)
+		if child.Kind() == "property_identifier" {
+			prop = child.Utf8Text(source)
+		}
+	}
+
+	lowerProp := strings.ToLower(prop)
+	if httpMethods[lowerProp] {
+		return lowerProp, true
+	}
+	return "", false
+}
+
+func extractCallArguments(callNode *tree_sitter.Node, source []byte) (path string, handlerName string) {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "arguments" {
+			return extractArgumentsFromNode(child, source)
+		}
+	}
+	return "", ""
+}
+
+func extractArgumentsFromNode(argsNode *tree_sitter.Node, source []byte) (path string, handlerName string) {
+	pathFound := false
+
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if !pathFound {
+			if child.Kind() == "string" {
+				path = unquoteJSString(child.Utf8Text(source))
+				pathFound = true
+			}
+			continue
+		}
+
+		if handlerName == "" {
+			handlerName = extractHandlerName(child, source)
+		}
+	}
+
+	return path, handlerName
+}
+
+func extractHandlerName(node *tree_sitter.Node, source []byte) string {
+	switch node.Kind() {
+	case "identifier":
+		return node.Utf8Text(source)
+	case "member_expression":
+		return node.Utf8Text(source)
+	case "function_expression":
+		return extractFunctionExpressionName(node, source)
+	case "arrow_function":
+		return "anonymous"
+	default:
+		return "anonymous"
+	}
+}
+
+func extractFunctionExpressionName(funcNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < funcNode.ChildCount(); i++ {
+		child := funcNode.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return "anonymous"
+}
+
+func isJSDocComment(comment string) bool {
+	return strings.HasPrefix(comment, "/**")
+}
+
+func cleanJSDocComment(comment string) string {
+	comment = strings.TrimPrefix(comment, "/**")
+	comment = strings.TrimSuffix(comment, "*/")
+
+	var lines []string
+	for _, line := range strings.Split(comment, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "* ")
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return strings.Join(lines, " ")
+}
+
+type pathParamInfo struct {
+	name string
+}
+
+func extractPathParams(path string) []pathParamInfo {
+	var params []pathParamInfo
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			name := segment[1 : len(segment)-1]
+			params = append(params, pathParamInfo{name: name})
+		}
+	}
+	return params
+}
+
+func convertExpressPath(expressPath string) string {
+	var parts []string
+	for _, segment := range strings.Split(expressPath, "/") {
+		if strings.HasPrefix(segment, ":") {
+			parts = append(parts, "{"+segment[1:]+"}")
+		} else {
+			parts = append(parts, segment)
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func unquoteJSString(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }

--- a/api-collector-node/fastify/parser.go
+++ b/api-collector-node/fastify/parser.go
@@ -1,10 +1,495 @@
-// Package fastify parses Fastify route registrations.
+// Package fastify parses Fastify route registrations using tree-sitter-javascript.
+// It walks JavaScript source files for fastify.get, fastify.post, etc. calls
+// and extracts endpoint metadata including path, HTTP method, handler function name,
+// and JSDoc comments.
+//
+// Supported patterns:
+//   - Shorthand: fastify.get('/path', handler)
+//   - Shorthand with options: fastify.get('/path', { schema: ... }, handler)
+//   - Route object: fastify.route({ method: 'GET', url: '/path', handler: fn })
 package fastify
 
-import "github.com/tangcent/apilot/api-collector"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
-// Parse extracts endpoints from Fastify route registrations (fastify.get, fastify.post, etc.).
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+var httpMethods = map[string]bool{
+	"get":    true,
+	"post":   true,
+	"put":    true,
+	"delete": true,
+	"patch":  true,
+}
+
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	// TODO: implement
-	return nil, nil
+	jsFiles, err := discoverJSFiles(sourceDir)
+	if err != nil || len(jsFiles) == 0 {
+		return nil, nil
+	}
+
+	ch := make(chan fileResult, len(jsFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range jsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var allEndpoints []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			continue
+		}
+		allEndpoints = append(allEndpoints, res.endpoints...)
+	}
+
+	if len(allEndpoints) == 0 {
+		return nil, nil
+	}
+
+	return allEndpoints, nil
+}
+
+type fileResult struct {
+	endpoints []collector.ApiEndpoint
+	err       error
+}
+
+func discoverJSFiles(sourceDir string) ([]string, error) {
+	var jsFiles []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && (strings.HasSuffix(path, ".js") || strings.HasSuffix(path, ".mjs")) {
+			jsFiles = append(jsFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return jsFiles, nil
+}
+
+func processFile(filePath string) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(javascript.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+	var endpoints []collector.ApiEndpoint
+	var lastComment string
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+
+		if child.Kind() == "comment" {
+			commentText := child.Utf8Text(source)
+			if isJSDocComment(commentText) {
+				lastComment = cleanJSDocComment(commentText)
+			} else {
+				lastComment = ""
+			}
+			continue
+		}
+
+		if child.Kind() == "expression_statement" {
+			ep := extractFromExpressionStatement(child, source, lastComment)
+			if ep != nil {
+				endpoints = append(endpoints, ep...)
+			}
+			lastComment = ""
+		} else {
+			lastComment = ""
+		}
+	}
+
+	return endpoints
+}
+
+func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "call_expression" {
+			return extractFromCallExpression(child, source, description)
+		}
+	}
+	return nil
+}
+
+func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+	method, isRoute := extractMethodInfo(callNode, source)
+	if isRoute {
+		ep := extractShorthandRoute(callNode, source, method, description)
+		if ep != nil {
+			return []collector.ApiEndpoint{*ep}
+		}
+		return nil
+	}
+
+	if isRouteObjectCall(callNode, source) {
+		return extractRouteObject(callNode, source, description)
+	}
+
+	return nil
+}
+
+func extractMethodInfo(callNode *tree_sitter.Node, source []byte) (method string, isRoute bool) {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "member_expression" {
+			return extractMemberExpressionMethod(child, source)
+		}
+	}
+	return "", false
+}
+
+func extractMemberExpressionMethod(memberNode *tree_sitter.Node, source []byte) (method string, isRoute bool) {
+	var prop string
+
+	for i := uint(0); i < memberNode.ChildCount(); i++ {
+		child := memberNode.Child(i)
+		if child.Kind() == "property_identifier" {
+			prop = child.Utf8Text(source)
+		}
+	}
+
+	lowerProp := strings.ToLower(prop)
+	if httpMethods[lowerProp] {
+		return lowerProp, true
+	}
+	return "", false
+}
+
+func isRouteObjectCall(callNode *tree_sitter.Node, source []byte) bool {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "member_expression" {
+			return isRouteProperty(child, source)
+		}
+	}
+	return false
+}
+
+func isRouteProperty(memberNode *tree_sitter.Node, source []byte) bool {
+	for i := uint(0); i < memberNode.ChildCount(); i++ {
+		child := memberNode.Child(i)
+		if child.Kind() == "property_identifier" {
+			prop := child.Utf8Text(source)
+			if prop == "route" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func extractShorthandRoute(callNode *tree_sitter.Node, source []byte, method string, description string) *collector.ApiEndpoint {
+	path, handlerName := extractShorthandArguments(callNode, source)
+	if path == "" {
+		return nil
+	}
+
+	standardPath := convertPath(path)
+
+	ep := &collector.ApiEndpoint{
+		Name:        handlerName,
+		Path:        standardPath,
+		Method:      strings.ToUpper(method),
+		Protocol:    "http",
+		Description: description,
+	}
+
+	pathParams := extractPathParams(standardPath)
+	if len(pathParams) > 0 {
+		var params []collector.ApiParameter
+		for _, p := range pathParams {
+			params = append(params, collector.ApiParameter{
+				Name:     p.name,
+				In:       "path",
+				Required: true,
+				Type:     "text",
+			})
+		}
+		ep.Parameters = params
+	}
+
+	return ep
+}
+
+func extractShorthandArguments(callNode *tree_sitter.Node, source []byte) (path string, handlerName string) {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "arguments" {
+			return extractShorthandArgsFromNode(child, source)
+		}
+	}
+	return "", ""
+}
+
+func extractShorthandArgsFromNode(argsNode *tree_sitter.Node, source []byte) (path string, handlerName string) {
+	pathFound := false
+
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if !pathFound {
+			if child.Kind() == "string" {
+				path = unquoteJSString(child.Utf8Text(source))
+				pathFound = true
+			}
+			continue
+		}
+
+		if handlerName == "" {
+			handlerName = extractHandlerName(child, source)
+		}
+	}
+
+	return path, handlerName
+}
+
+func extractRouteObject(callNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "arguments" {
+			return extractRouteObjectArgs(child, source, description)
+		}
+	}
+	return nil
+}
+
+func extractRouteObjectArgs(argsNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "object" {
+			return extractRouteObjectFromObject(child, source, description)
+		}
+	}
+	return nil
+}
+
+func extractRouteObjectFromObject(objNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+	var method, path, handlerName string
+
+	for i := uint(0); i < objNode.ChildCount(); i++ {
+		pair := objNode.Child(i)
+		if pair.Kind() != "pair" {
+			continue
+		}
+
+		var key string
+		for j := uint(0); j < pair.ChildCount(); j++ {
+			pairChild := pair.Child(j)
+			if pairChild.Kind() == "property_identifier" {
+				key = pairChild.Utf8Text(source)
+			}
+			if pairChild.Kind() == "string" && key == "" {
+				key = unquoteJSString(pairChild.Utf8Text(source))
+			}
+		}
+
+		switch key {
+		case "method":
+			method = extractPairValue(pair, source)
+		case "url", "path":
+			path = extractPairValue(pair, source)
+		case "handler":
+			handlerName = extractPairHandlerValue(pair, source)
+		}
+	}
+
+	if method == "" || path == "" {
+		return nil
+	}
+
+	standardPath := convertPath(path)
+	method = strings.ToUpper(method)
+
+	ep := collector.ApiEndpoint{
+		Name:        handlerName,
+		Path:        standardPath,
+		Method:      method,
+		Protocol:    "http",
+		Description: description,
+	}
+
+	pathParams := extractPathParams(standardPath)
+	if len(pathParams) > 0 {
+		var params []collector.ApiParameter
+		for _, p := range pathParams {
+			params = append(params, collector.ApiParameter{
+				Name:     p.name,
+				In:       "path",
+				Required: true,
+				Type:     "text",
+			})
+		}
+		ep.Parameters = params
+	}
+
+	return []collector.ApiEndpoint{ep}
+}
+
+func extractPairValue(pair *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < pair.ChildCount(); i++ {
+		child := pair.Child(i)
+		if child.Kind() == "string" {
+			return unquoteJSString(child.Utf8Text(source))
+		}
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
+func extractPairHandlerValue(pair *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < pair.ChildCount(); i++ {
+		child := pair.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+		if child.Kind() == "member_expression" {
+			return child.Utf8Text(source)
+		}
+		if child.Kind() == "function_expression" {
+			return extractFunctionExpressionName(child, source)
+		}
+		if child.Kind() == "arrow_function" {
+			return "anonymous"
+		}
+	}
+	return "anonymous"
+}
+
+func extractHandlerName(node *tree_sitter.Node, source []byte) string {
+	switch node.Kind() {
+	case "identifier":
+		return node.Utf8Text(source)
+	case "member_expression":
+		return node.Utf8Text(source)
+	case "function_expression":
+		return extractFunctionExpressionName(node, source)
+	case "arrow_function":
+		return "anonymous"
+	case "object":
+		return ""
+	default:
+		return "anonymous"
+	}
+}
+
+func extractFunctionExpressionName(funcNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < funcNode.ChildCount(); i++ {
+		child := funcNode.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return "anonymous"
+}
+
+func isJSDocComment(comment string) bool {
+	return strings.HasPrefix(comment, "/**")
+}
+
+func cleanJSDocComment(comment string) string {
+	comment = strings.TrimPrefix(comment, "/**")
+	comment = strings.TrimSuffix(comment, "*/")
+
+	var lines []string
+	for _, line := range strings.Split(comment, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "* ")
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return strings.Join(lines, " ")
+}
+
+type pathParamInfo struct {
+	name string
+}
+
+func extractPathParams(path string) []pathParamInfo {
+	var params []pathParamInfo
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, "{") && strings.HasSuffix(segment, "}") {
+			name := segment[1 : len(segment)-1]
+			params = append(params, pathParamInfo{name: name})
+		}
+	}
+	return params
+}
+
+func convertPath(fastifyPath string) string {
+	var parts []string
+	for _, segment := range strings.Split(fastifyPath, "/") {
+		if strings.HasPrefix(segment, ":") {
+			parts = append(parts, "{"+segment[1:]+"}")
+		} else {
+			parts = append(parts, segment)
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+func unquoteJSString(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return s[1 : len(s)-1]
+	}
+	return s
 }

--- a/api-collector-node/fastify/parser_test.go
+++ b/api-collector-node/fastify/parser_test.go
@@ -1,0 +1,263 @@
+package fastify
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+func TestParse_NoRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "noroutes"))
+	if err != nil {
+		t.Fatalf("no routes should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for no routes, got %d", len(endpoints))
+	}
+}
+
+func TestParse_NonexistentDir(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "nonexistent"))
+	if err != nil {
+		t.Fatalf("nonexistent dir should not error: %v", err)
+	}
+	if endpoints != nil {
+		t.Fatalf("expected nil endpoints for nonexistent dir, got %d", len(endpoints))
+	}
+}
+
+func TestParse_BasicRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "basic"))
+	if err != nil {
+		t.Fatalf("basic routes should not error: %v", err)
+	}
+	if len(endpoints) != 6 {
+		t.Fatalf("expected 6 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "deleteUser", Path: "/users/{id}", Method: "DELETE", Protocol: "http",
+		Description: "deleteUser removes a user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "listUsers", Path: "/users", Method: "GET", Protocol: "http",
+		Description: "listUsers returns all users.",
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "getUser", Path: "/users/{id}", Method: "GET", Protocol: "http",
+		Description: "getUser returns a single user by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "patchUser", Path: "/users/{id}", Method: "PATCH", Protocol: "http",
+		Description: "patchUser partially updates a user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
+		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
+		Description: "createUser creates a new user.",
+	})
+
+	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
+		Name: "updateUser", Path: "/users/{id}", Method: "PUT", Protocol: "http",
+		Description: "updateUser updates an existing user.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+}
+
+func TestParse_RouteObject(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "route-object"))
+	if err != nil {
+		t.Fatalf("route-object should not error: %v", err)
+	}
+	if len(endpoints) != 4 {
+		t.Fatalf("expected 4 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return endpoints[i].Method < endpoints[j].Method
+	})
+
+	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
+		Name: "listItems", Path: "/items", Method: "GET", Protocol: "http",
+		Description: "listItems returns all items.",
+	})
+
+	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
+		Name: "createItem", Path: "/items", Method: "POST", Protocol: "http",
+		Description: "createItem creates a new item.",
+	})
+
+	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
+		Name: "deleteItem", Path: "/items/{id}", Method: "DELETE", Protocol: "http",
+		Description: "deleteItem removes an item by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+
+	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
+		Name: "getItem", Path: "/items/{id}", Method: "GET", Protocol: "http",
+		Description: "getItem returns a single item by ID.",
+		Parameters: []collector.ApiParameter{
+			{Name: "id", In: "path", Required: true, Type: "text"},
+		},
+	})
+}
+
+func TestConvertPath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/users", "/users"},
+		{"/users/:id", "/users/{id}"},
+		{"/users/:id/posts/:postId", "/users/{id}/posts/{postId}"},
+		{"/:category/:item", "/{category}/{item}"},
+		{"/api/v1/users/:id", "/api/v1/users/{id}"},
+	}
+
+	for _, tt := range tests {
+		result := convertPath(tt.input)
+		if result != tt.expected {
+			t.Errorf("convertPath(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestExtractPathParams(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected []pathParamInfo
+	}{
+		{"/users", nil},
+		{"/users/{id}", []pathParamInfo{{name: "id"}}},
+		{"/users/{id}/posts/{postId}", []pathParamInfo{
+			{name: "id"},
+			{name: "postId"},
+		}},
+	}
+
+	for _, tt := range tests {
+		result := extractPathParams(tt.path)
+		if len(result) != len(tt.expected) {
+			t.Errorf("extractPathParams(%q): got %d params, want %d", tt.path, len(result), len(tt.expected))
+			continue
+		}
+		for i, p := range result {
+			if p.name != tt.expected[i].name {
+				t.Errorf("extractPathParams(%q)[%d].name = %q, want %q", tt.path, i, p.name, tt.expected[i].name)
+			}
+		}
+	}
+}
+
+func TestUnquoteJSString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"hello"`, "hello"},
+		{`'hello'`, "hello"},
+		{"`hello`", "hello"},
+		{`hello`, "hello"},
+		{`""`, ""},
+	}
+
+	for _, tt := range tests {
+		result := unquoteJSString(tt.input)
+		if result != tt.expected {
+			t.Errorf("unquoteJSString(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestCleanJSDocComment(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/** hello */", "hello"},
+		{"/**\n * line1\n * line2\n */", "line1 line2"},
+		{"/**\n * listUsers returns all users.\n */", "listUsers returns all users."},
+	}
+
+	for _, tt := range tests {
+		result := cleanJSDocComment(tt.input)
+		if result != tt.expected {
+			t.Errorf("cleanJSDocComment(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func assertEndpoint(t *testing.T, got collector.ApiEndpoint, want collector.ApiEndpoint) {
+	t.Helper()
+
+	if got.Name != want.Name {
+		t.Errorf("Name = %q, want %q", got.Name, want.Name)
+	}
+	if got.Path != want.Path {
+		t.Errorf("Path = %q, want %q", got.Path, want.Path)
+	}
+	if got.Method != want.Method {
+		t.Errorf("Method = %q, want %q", got.Method, want.Method)
+	}
+	if got.Protocol != want.Protocol {
+		t.Errorf("Protocol = %q, want %q", got.Protocol, want.Protocol)
+	}
+	if got.Description != want.Description {
+		t.Errorf("Description = %q, want %q", got.Description, want.Description)
+	}
+
+	assertParams(t, got.Parameters, want.Parameters)
+}
+
+func assertParams(t *testing.T, got, want []collector.ApiParameter) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Errorf("Parameters: got %d, want %d", len(got), len(want))
+		return
+	}
+
+	for i, g := range got {
+		w := want[i]
+		if g.Name != w.Name {
+			t.Errorf("Parameters[%d].Name = %q, want %q", i, g.Name, w.Name)
+		}
+		if g.In != w.In {
+			t.Errorf("Parameters[%d].In = %q, want %q", i, g.In, w.In)
+		}
+		if g.Required != w.Required {
+			t.Errorf("Parameters[%d].Required = %v, want %v", i, g.Required, w.Required)
+		}
+		if g.Type != w.Type {
+			t.Errorf("Parameters[%d].Type = %q, want %q", i, g.Type, w.Type)
+		}
+	}
+}

--- a/api-collector-node/fastify/testdata/basic/app.js
+++ b/api-collector-node/fastify/testdata/basic/app.js
@@ -1,0 +1,38 @@
+const fastify = require('fastify')({ logger: true });
+
+/**
+ * listUsers returns all users.
+ */
+fastify.get('/users', listUsers);
+
+/**
+ * createUser creates a new user.
+ */
+fastify.post('/users', createUser);
+
+/**
+ * getUser returns a single user by ID.
+ */
+fastify.get('/users/:id', getUser);
+
+/**
+ * updateUser updates an existing user.
+ */
+fastify.put('/users/:id', updateUser);
+
+/**
+ * deleteUser removes a user by ID.
+ */
+fastify.delete('/users/:id', deleteUser);
+
+/**
+ * patchUser partially updates a user.
+ */
+fastify.patch('/users/:id', patchUser);
+
+fastify.listen({ port: 3000 }, function (err) {
+    if (err) {
+        fastify.log.error(err);
+        process.exit(1);
+    }
+});

--- a/api-collector-node/fastify/testdata/noroutes/app.js
+++ b/api-collector-node/fastify/testdata/noroutes/app.js
@@ -1,0 +1,13 @@
+const fastify = require('fastify')({ logger: true });
+
+function someHelper() {
+    return 'hello';
+}
+
+class UserService {
+    get_users() {
+        return [];
+    }
+}
+
+fastify.listen({ port: 3000 });

--- a/api-collector-node/fastify/testdata/route-object/app.js
+++ b/api-collector-node/fastify/testdata/route-object/app.js
@@ -1,0 +1,39 @@
+const fastify = require('fastify')({ logger: true });
+
+/**
+ * listItems returns all items.
+ */
+fastify.route({
+    method: 'GET',
+    url: '/items',
+    handler: listItems
+});
+
+/**
+ * createItem creates a new item.
+ */
+fastify.route({
+    method: 'POST',
+    url: '/items',
+    handler: createItem
+});
+
+/**
+ * getItem returns a single item by ID.
+ */
+fastify.route({
+    method: 'GET',
+    url: '/items/:id',
+    handler: getItem
+});
+
+/**
+ * deleteItem removes an item by ID.
+ */
+fastify.route({
+    method: 'DELETE',
+    url: '/items/:id',
+    handler: deleteItem
+});
+
+fastify.listen({ port: 3000 });

--- a/api-collector-node/go.mod
+++ b/api-collector-node/go.mod
@@ -1,7 +1,18 @@
 module github.com/tangcent/apilot/api-collector-node
 
-go 1.22
+go 1.23
+
+toolchain go1.24.4
 
 require github.com/tangcent/apilot/api-collector v0.0.0
 
-replace github.com/tangcent/apilot/api-collector => ../api-collector
+require (
+	github.com/mattn/go-pointer v0.0.1 // indirect
+	github.com/tree-sitter/go-tree-sitter v0.25.0
+	github.com/tree-sitter/tree-sitter-javascript v0.25.0
+)
+
+replace (
+	github.com/tangcent/apilot/api-collector => ../api-collector
+	github.com/tangcent/apilot/api-model => ../api-model
+)

--- a/api-collector-node/go.sum
+++ b/api-collector-node/go.sum
@@ -1,0 +1,6 @@
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
+github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
+github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
+github.com/tree-sitter/tree-sitter-javascript v0.25.0 h1:ZkWETb66/w8cc13yhfnNuHOLDQWl3BnKlH6f9AdR88c=
+github.com/tree-sitter/tree-sitter-javascript v0.25.0/go.mod h1:lmGD1EJdCA+v0S1u2fFgepMg/opzSg/4pgFym2FPGAs=


### PR DESCRIPTION
Implements the Fastify route parser as specified in issue #23.

Changes:
- Fastify route parser using tree-sitter-javascript for AST-based parsing
- Parse fastify.METHOD shorthand routes (get, post, put, delete, patch)
- Parse fastify.route object syntax with method, url, and handler keys
- Extract path, HTTP method, handler function name, and JSDoc comments
- Convert Fastify path params to OpenAPI style
- Concurrent file processing with goroutines
- Test data with basic, route-object, and noroutes scenarios
- Comprehensive unit tests (8 test functions, all passing)
- Add tree-sitter dependencies to go.mod

Closes #23
