### PR TITLE
feat: implement maven-indexer-cli dependency resolver

### DIFF
--- a/api-collector-java/collector.go
+++ b/api-collector-java/collector.go
@@ -4,10 +4,12 @@ package javacollector
 
 import (
 	"fmt"
+	"log"
 
 	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/feign"
 	"github.com/tangcent/apilot/api-collector-java/jaxrs"
+	"github.com/tangcent/apilot/api-collector-java/maven"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	"github.com/tangcent/apilot/api-collector-java/springmvc"
 )
@@ -23,7 +25,18 @@ func (c *JavaCollector) Name() string { return "java" }
 func (c *JavaCollector) SupportedLanguages() []string { return []string{"java", "kotlin"} }
 
 // Collect walks the source directory and extracts endpoints from Spring MVC, JAX-RS, and Feign sources.
+// When maven-indexer-cli is available and a build file (pom.xml/build.gradle) is present,
+// it attempts to resolve dependency JARs for improved type analysis.
 func (c *JavaCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	if maven.HasBuildFile(ctx.SourceDir) && maven.IsAvailable() {
+		jarPaths, err := maven.Resolve(ctx.SourceDir)
+		if err != nil {
+			log.Printf("[maven] dependency resolution skipped: %v", err)
+		} else if len(jarPaths) > 0 {
+			log.Printf("[maven] resolved %d dependency JARs", len(jarPaths))
+		}
+	}
+
 	p, err := parser.NewParser(parser.ParserOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create java parser: %w", err)

--- a/api-collector-java/maven/resolver.go
+++ b/api-collector-java/maven/resolver.go
@@ -2,13 +2,298 @@
 // See: https://github.com/tangcent/maven-indexer-cli
 package maven
 
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const cliName = "maven-indexer-cli"
+
+// Dependency represents a Maven/Gradle dependency coordinate.
+type Dependency struct {
+	GroupID    string
+	ArtifactID string
+	Version    string
+}
+
+// Artifact represents a resolved artifact from maven-indexer-cli.
+type Artifact struct {
+	GroupID    string `json:"groupId"`
+	ArtifactID string `json:"artifactId"`
+	Version    string `json:"version"`
+	AbsPath    string `json:"abspath"`
+	HasSource  bool   `json:"hasSource"`
+}
+
 // Resolve attempts to resolve Maven/Gradle dependency coordinates in sourceDir
 // by invoking maven-indexer-cli as a subprocess.
 // Returns the list of resolved JAR paths for type analysis.
+// If maven-indexer-cli is not available, returns nil without error.
 func Resolve(sourceDir string) ([]string, error) {
-	// TODO: implement
-	// 1. Detect pom.xml or build.gradle in sourceDir
-	// 2. Invoke maven-indexer-cli with the project coordinates
-	// 3. Return the list of downloaded JAR paths
+	if !isCLIAvailable() {
+		return nil, nil
+	}
+
+	deps, err := detectDependencies(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect dependencies: %w", err)
+	}
+
+	if len(deps) == 0 {
+		return nil, nil
+	}
+
+	return resolveDependencies(deps)
+}
+
+// isCLIAvailable checks whether maven-indexer-cli is on PATH.
+func isCLIAvailable() bool {
+	_, err := exec.LookPath(cliName)
+	return err == nil
+}
+
+// detectDependencies detects dependencies from pom.xml or build.gradle in sourceDir.
+func detectDependencies(sourceDir string) ([]Dependency, error) {
+	pomPath := filepath.Join(sourceDir, "pom.xml")
+	if _, err := os.Stat(pomPath); err == nil {
+		return parsePomXML(pomPath)
+	}
+
+	for _, gradleFile := range []string{"build.gradle", "build.gradle.kts"} {
+		gradlePath := filepath.Join(sourceDir, gradleFile)
+		if _, err := os.Stat(gradlePath); err == nil {
+			return parseGradleFile(gradlePath)
+		}
+	}
+
 	return nil, nil
+}
+
+// pomXML represents the relevant parts of a Maven pom.xml file.
+type pomXML struct {
+	Dependencies struct {
+		Dependency []pomDependency `xml:"dependency"`
+	} `xml:"dependencies"`
+}
+
+// pomDependency represents a single dependency entry in pom.xml.
+type pomDependency struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+}
+
+// parsePomXML extracts dependencies from a Maven pom.xml file.
+func parsePomXML(path string) ([]Dependency, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read pom.xml: %w", err)
+	}
+
+	var pom pomXML
+	if err := xml.Unmarshal(data, &pom); err != nil {
+		return nil, fmt.Errorf("failed to parse pom.xml: %w", err)
+	}
+
+	deps := make([]Dependency, 0, len(pom.Dependencies.Dependency))
+	for _, d := range pom.Dependencies.Dependency {
+		if d.GroupID == "" || d.ArtifactID == "" {
+			continue
+		}
+		deps = append(deps, Dependency{
+			GroupID:    d.GroupID,
+			ArtifactID: d.ArtifactID,
+			Version:    d.Version,
+		})
+	}
+
+	return deps, nil
+}
+
+var gradleDepRe = regexp.MustCompile(
+	`(?:implementation|api|compileOnly|runtimeOnly|testImplementation)\s*[( ]["']([^"':]+):([^"':]+):([^"':]+)["']`,
+)
+
+// parseGradleFile extracts dependencies from a Gradle build file.
+func parseGradleFile(path string) ([]Dependency, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gradle file: %w", err)
+	}
+
+	var deps []Dependency
+	matches := gradleDepRe.FindAllStringSubmatch(string(data), -1)
+	for _, m := range matches {
+		deps = append(deps, Dependency{
+			GroupID:    m[1],
+			ArtifactID: m[2],
+			Version:    m[3],
+		})
+	}
+
+	return deps, nil
+}
+
+// resolveDependencies resolves each dependency to its JAR path via maven-indexer-cli.
+func resolveDependencies(deps []Dependency) ([]string, error) {
+	var jarPaths []string
+	seen := make(map[string]bool)
+
+	for _, dep := range deps {
+		query := dep.ArtifactID
+		if dep.GroupID != "" {
+			query = dep.GroupID + ":" + dep.ArtifactID
+		}
+
+		artifacts, err := searchArtifacts(query)
+		if err != nil {
+			continue
+		}
+
+		matched := findBestMatch(artifacts, dep)
+		if matched == nil {
+			continue
+		}
+
+		jarPath := resolveJarPath(matched)
+		if jarPath == "" {
+			continue
+		}
+
+		if !seen[jarPath] {
+			seen[jarPath] = true
+			jarPaths = append(jarPaths, jarPath)
+		}
+	}
+
+	return jarPaths, nil
+}
+
+// searchArtifacts invokes maven-indexer-cli search-artifacts --json and parses the output.
+func searchArtifacts(query string) ([]Artifact, error) {
+	cmd := exec.Command(cliName, "search-artifacts", query, "--json", "--limit", "10")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("maven-indexer-cli search-artifacts failed: %w", err)
+	}
+
+	var artifacts []Artifact
+	if err := json.Unmarshal(output, &artifacts); err != nil {
+		return nil, fmt.Errorf("failed to parse maven-indexer-cli output: %w", err)
+	}
+
+	return artifacts, nil
+}
+
+// findBestMatch selects the best matching artifact for a given dependency.
+// It prefers exact groupId+artifactId matches and the requested version.
+func findBestMatch(artifacts []Artifact, dep Dependency) *Artifact {
+	var groupMatch *Artifact
+	var firstMatch *Artifact
+
+	for i := range artifacts {
+		a := &artifacts[i]
+		if a.GroupID == dep.GroupID && a.ArtifactID == dep.ArtifactID {
+			if dep.Version != "" && a.Version == dep.Version {
+				return a
+			}
+			if groupMatch == nil {
+				groupMatch = a
+			}
+		}
+		if firstMatch == nil {
+			firstMatch = a
+		}
+	}
+
+	if groupMatch != nil {
+		return groupMatch
+	}
+
+	return firstMatch
+}
+
+// resolveJarPath determines the JAR file path from a resolved artifact.
+// It uses the artifact's abspath (the Maven local repo directory) and
+// constructs the expected JAR filename.
+func resolveJarPath(artifact *Artifact) string {
+	if artifact.AbsPath == "" {
+		return ""
+	}
+
+	jarName := fmt.Sprintf("%s-%s.jar", artifact.ArtifactID, artifact.Version)
+	jarPath := filepath.Join(artifact.AbsPath, jarName)
+
+	if _, err := os.Stat(jarPath); err == nil {
+		return jarPath
+	}
+
+	return artifact.AbsPath
+}
+
+// HasBuildFile returns true if sourceDir contains a Maven or Gradle build file.
+func HasBuildFile(sourceDir string) bool {
+	for _, f := range []string{"pom.xml", "build.gradle", "build.gradle.kts"} {
+		if _, err := os.Stat(filepath.Join(sourceDir, f)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAvailable returns true if maven-indexer-cli is on PATH.
+func IsAvailable() bool {
+	return isCLIAvailable()
+}
+
+// ResolveClass attempts to resolve a class name via maven-indexer-cli get-class.
+// Returns the class detail output as a string, or empty string if not found.
+func ResolveClass(className string) string {
+	if !isCLIAvailable() {
+		return ""
+	}
+
+	cmd := exec.Command(cliName, "get-class", className, "--json", "--type", "signatures")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(output))
+}
+
+// SearchClasses searches for classes matching the query via maven-indexer-cli.
+func SearchClasses(query string) ([]Artifact, error) {
+	if !isCLIAvailable() {
+		return nil, nil
+	}
+
+	cmd := exec.Command(cliName, "search-classes", query, "--json", "--limit", "10")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("maven-indexer-cli search-classes failed: %w", err)
+	}
+
+	type classResult struct {
+		ClassName string     `json:"className"`
+		Artifacts []Artifact `json:"artifacts"`
+	}
+
+	var results []classResult
+	if err := json.Unmarshal(output, &results); err != nil {
+		return nil, fmt.Errorf("failed to parse maven-indexer-cli output: %w", err)
+	}
+
+	var allArtifacts []Artifact
+	for _, r := range results {
+		allArtifacts = append(allArtifacts, r.Artifacts...)
+	}
+
+	return allArtifacts, nil
 }

--- a/api-collector-java/maven/resolver_test.go
+++ b/api-collector-java/maven/resolver_test.go
@@ -1,0 +1,421 @@
+package maven
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParsePomXML(t *testing.T) {
+	deps, err := parsePomXML(filepath.Join("testdata", "pom.xml"))
+	if err != nil {
+		t.Fatalf("parsePomXML failed: %v", err)
+	}
+
+	if len(deps) != 2 {
+		t.Fatalf("Expected 2 dependencies, got %d", len(deps))
+	}
+
+	if deps[0].GroupID != "org.springframework.boot" {
+		t.Errorf("Expected groupId 'org.springframework.boot', got '%s'", deps[0].GroupID)
+	}
+	if deps[0].ArtifactID != "spring-boot-starter-web" {
+		t.Errorf("Expected artifactId 'spring-boot-starter-web', got '%s'", deps[0].ArtifactID)
+	}
+	if deps[0].Version != "3.2.0" {
+		t.Errorf("Expected version '3.2.0', got '%s'", deps[0].Version)
+	}
+
+	if deps[1].GroupID != "com.google.guava" {
+		t.Errorf("Expected groupId 'com.google.guava', got '%s'", deps[1].GroupID)
+	}
+	if deps[1].ArtifactID != "guava" {
+		t.Errorf("Expected artifactId 'guava', got '%s'", deps[1].ArtifactID)
+	}
+}
+
+func TestParsePomXML_EmptyDeps(t *testing.T) {
+	dir := t.TempDir()
+	pomPath := filepath.Join(dir, "pom.xml")
+	if err := os.WriteFile(pomPath, []byte(`<project><dependencies></dependencies></project>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := parsePomXML(pomPath)
+	if err != nil {
+		t.Fatalf("parsePomXML failed: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("Expected 0 dependencies, got %d", len(deps))
+	}
+}
+
+func TestParsePomXML_NoDepsSection(t *testing.T) {
+	dir := t.TempDir()
+	pomPath := filepath.Join(dir, "pom.xml")
+	if err := os.WriteFile(pomPath, []byte(`<project></project>`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := parsePomXML(pomPath)
+	if err != nil {
+		t.Fatalf("parsePomXML failed: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("Expected 0 dependencies, got %d", len(deps))
+	}
+}
+
+func TestParsePomXML_SkipsInvalidDeps(t *testing.T) {
+	dir := t.TempDir()
+	pomPath := filepath.Join(dir, "pom.xml")
+	content := `<project><dependencies>
+		<dependency><groupId>com.example</groupId><artifactId>valid</artifactId><version>1.0</version></dependency>
+		<dependency><groupId></groupId><artifactId>missing-group</artifactId></dependency>
+		<dependency><groupId>com.example</groupId><artifactId></artifactId></dependency>
+	</dependencies></project>`
+	if err := os.WriteFile(pomPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := parsePomXML(pomPath)
+	if err != nil {
+		t.Fatalf("parsePomXML failed: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Errorf("Expected 1 valid dependency, got %d", len(deps))
+	}
+	if deps[0].ArtifactID != "valid" {
+		t.Errorf("Expected artifactId 'valid', got '%s'", deps[0].ArtifactID)
+	}
+}
+
+func TestParseGradleFile(t *testing.T) {
+	deps, err := parseGradleFile(filepath.Join("testdata", "build.gradle"))
+	if err != nil {
+		t.Fatalf("parseGradleFile failed: %v", err)
+	}
+
+	if len(deps) != 5 {
+		t.Fatalf("Expected 5 dependencies, got %d", len(deps))
+	}
+
+	if deps[0].GroupID != "org.springframework.boot" {
+		t.Errorf("Expected groupId 'org.springframework.boot', got '%s'", deps[0].GroupID)
+	}
+	if deps[0].ArtifactID != "spring-boot-starter-web" {
+		t.Errorf("Expected artifactId 'spring-boot-starter-web', got '%s'", deps[0].ArtifactID)
+	}
+	if deps[0].Version != "3.2.0" {
+		t.Errorf("Expected version '3.2.0', got '%s'", deps[0].Version)
+	}
+
+	if deps[2].GroupID != "org.projectlombok" {
+		t.Errorf("Expected groupId 'org.projectlombok', got '%s'", deps[2].GroupID)
+	}
+	if deps[2].ArtifactID != "lombok" {
+		t.Errorf("Expected artifactId 'lombok', got '%s'", deps[2].ArtifactID)
+	}
+}
+
+func TestParseGradleFile_Kts(t *testing.T) {
+	deps, err := parseGradleFile(filepath.Join("testdata", "build.gradle.kts"))
+	if err != nil {
+		t.Fatalf("parseGradleFile failed: %v", err)
+	}
+
+	if len(deps) != 2 {
+		t.Fatalf("Expected 2 dependencies, got %d", len(deps))
+	}
+
+	if deps[0].GroupID != "org.springframework.boot" {
+		t.Errorf("Expected groupId 'org.springframework.boot', got '%s'", deps[0].GroupID)
+	}
+}
+
+func TestParseGradleFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	gradlePath := filepath.Join(dir, "build.gradle")
+	if err := os.WriteFile(gradlePath, []byte(`dependencies { }`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := parseGradleFile(gradlePath)
+	if err != nil {
+		t.Fatalf("parseGradleFile failed: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("Expected 0 dependencies, got %d", len(deps))
+	}
+}
+
+func TestDetectDependencies_PomXML(t *testing.T) {
+	deps, err := detectDependencies("testdata")
+	if err != nil {
+		t.Fatalf("detectDependencies failed: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Error("Expected dependencies from pom.xml")
+	}
+}
+
+func TestDetectDependencies_Gradle(t *testing.T) {
+	dir := t.TempDir()
+	gradlePath := filepath.Join(dir, "build.gradle")
+	content := `dependencies { implementation 'com.example:mylib:1.0.0' }`
+	if err := os.WriteFile(gradlePath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := detectDependencies(dir)
+	if err != nil {
+		t.Fatalf("detectDependencies failed: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("Expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].ArtifactID != "mylib" {
+		t.Errorf("Expected artifactId 'mylib', got '%s'", deps[0].ArtifactID)
+	}
+}
+
+func TestDetectDependencies_NoBuildFile(t *testing.T) {
+	dir := t.TempDir()
+
+	deps, err := detectDependencies(dir)
+	if err != nil {
+		t.Fatalf("detectDependencies failed: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("Expected 0 dependencies with no build file, got %d", len(deps))
+	}
+}
+
+func TestHasBuildFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(dir string)
+		expected bool
+	}{
+		{
+			name:     "no build file",
+			setup:    func(dir string) {},
+			expected: false,
+		},
+		{
+			name:     "pom.xml exists",
+			setup:    func(dir string) { os.WriteFile(filepath.Join(dir, "pom.xml"), []byte("<project/>"), 0644) },
+			expected: true,
+		},
+		{
+			name:     "build.gradle exists",
+			setup:    func(dir string) { os.WriteFile(filepath.Join(dir, "build.gradle"), []byte(""), 0644) },
+			expected: true,
+		},
+		{
+			name:     "build.gradle.kts exists",
+			setup:    func(dir string) { os.WriteFile(filepath.Join(dir, "build.gradle.kts"), []byte(""), 0644) },
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(dir)
+			result := HasBuildFile(dir)
+			if result != tt.expected {
+				t.Errorf("HasBuildFile() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasBuildFile_Testdata(t *testing.T) {
+	if !HasBuildFile("testdata") {
+		t.Error("Expected HasBuildFile to return true for testdata directory")
+	}
+}
+
+func TestFindBestMatch(t *testing.T) {
+	artifacts := []Artifact{
+		{GroupID: "org.other", ArtifactID: "spring-web", Version: "6.1.0"},
+		{GroupID: "org.springframework", ArtifactID: "spring-web", Version: "6.1.0"},
+		{GroupID: "org.springframework", ArtifactID: "spring-web", Version: "6.0.0"},
+	}
+
+	tests := []struct {
+		name     string
+		dep      Dependency
+		expected string
+	}{
+		{
+			name:     "exact version match",
+			dep:      Dependency{GroupID: "org.springframework", ArtifactID: "spring-web", Version: "6.0.0"},
+			expected: "6.0.0",
+		},
+		{
+			name:     "group match without version",
+			dep:      Dependency{GroupID: "org.springframework", ArtifactID: "spring-web"},
+			expected: "6.1.0",
+		},
+		{
+			name:     "no group match falls back to first",
+			dep:      Dependency{GroupID: "com.unknown", ArtifactID: "spring-web"},
+			expected: "6.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := findBestMatch(artifacts, tt.dep)
+			if matched == nil {
+				t.Fatal("Expected non-nil match")
+			}
+			if matched.Version != tt.expected {
+				t.Errorf("Expected version '%s', got '%s'", tt.expected, matched.Version)
+			}
+		})
+	}
+}
+
+func TestFindBestMatch_EmptyArtifacts(t *testing.T) {
+	dep := Dependency{GroupID: "com.example", ArtifactID: "mylib"}
+	matched := findBestMatch(nil, dep)
+	if matched != nil {
+		t.Error("Expected nil match for empty artifacts")
+	}
+}
+
+func TestResolveJarPath(t *testing.T) {
+	dir := t.TempDir()
+	jarName := "mylib-1.0.0.jar"
+	jarPath := filepath.Join(dir, jarName)
+	if err := os.WriteFile(jarPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	artifact := &Artifact{
+		ArtifactID: "mylib",
+		Version:    "1.0.0",
+		AbsPath:    dir,
+	}
+
+	result := resolveJarPath(artifact)
+	if result != jarPath {
+		t.Errorf("Expected '%s', got '%s'", jarPath, result)
+	}
+}
+
+func TestResolveJarPath_JarNotFound(t *testing.T) {
+	artifact := &Artifact{
+		ArtifactID: "mylib",
+		Version:    "1.0.0",
+		AbsPath:    "/nonexistent/path",
+	}
+
+	result := resolveJarPath(artifact)
+	if result != "/nonexistent/path" {
+		t.Errorf("Expected abspath fallback '/nonexistent/path', got '%s'", result)
+	}
+}
+
+func TestResolveJarPath_EmptyAbsPath(t *testing.T) {
+	artifact := &Artifact{
+		ArtifactID: "mylib",
+		Version:    "1.0.0",
+		AbsPath:    "",
+	}
+
+	result := resolveJarPath(artifact)
+	if result != "" {
+		t.Errorf("Expected empty string, got '%s'", result)
+	}
+}
+
+func TestResolve_CLIUnavailable(t *testing.T) {
+	dir := t.TempDir()
+
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", t.TempDir())
+	defer os.Setenv("PATH", originalPath)
+
+	jarPaths, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve should not error when CLI unavailable: %v", err)
+	}
+	if jarPaths != nil {
+		t.Errorf("Expected nil jarPaths when CLI unavailable, got %v", jarPaths)
+	}
+}
+
+func TestResolve_NoBuildFile(t *testing.T) {
+	dir := t.TempDir()
+
+	jarPaths, err := Resolve(dir)
+	if err != nil {
+		t.Fatalf("Resolve should not error without build file: %v", err)
+	}
+	if jarPaths != nil {
+		t.Errorf("Expected nil jarPaths without build file, got %v", jarPaths)
+	}
+}
+
+func TestArtifactJSONParsing(t *testing.T) {
+	jsonData := `[{
+		"groupId": "org.springframework",
+		"artifactId": "spring-web",
+		"version": "6.1.0",
+		"abspath": "/Users/test/.m2/repository/org/springframework/spring-web/6.1.0",
+		"hasSource": true
+	}]`
+
+	var artifacts []Artifact
+	if err := json.Unmarshal([]byte(jsonData), &artifacts); err != nil {
+		t.Fatalf("Failed to parse artifact JSON: %v", err)
+	}
+
+	if len(artifacts) != 1 {
+		t.Fatalf("Expected 1 artifact, got %d", len(artifacts))
+	}
+
+	a := artifacts[0]
+	if a.GroupID != "org.springframework" {
+		t.Errorf("Expected groupId 'org.springframework', got '%s'", a.GroupID)
+	}
+	if a.ArtifactID != "spring-web" {
+		t.Errorf("Expected artifactId 'spring-web', got '%s'", a.ArtifactID)
+	}
+	if a.Version != "6.1.0" {
+		t.Errorf("Expected version '6.1.0', got '%s'", a.Version)
+	}
+	if a.AbsPath != "/Users/test/.m2/repository/org/springframework/spring-web/6.1.0" {
+		t.Errorf("Unexpected abspath: '%s'", a.AbsPath)
+	}
+	if !a.HasSource {
+		t.Error("Expected hasSource=true")
+	}
+}
+
+func TestResolveDependencies_Deduplication(t *testing.T) {
+	deps := []Dependency{
+		{GroupID: "com.example", ArtifactID: "mylib", Version: "1.0.0"},
+		{GroupID: "com.example", ArtifactID: "mylib", Version: "1.0.0"},
+	}
+
+	seen := make(map[string]bool)
+	var jarPaths []string
+
+	for _, dep := range deps {
+		jarPath := dep.GroupID + ":" + dep.ArtifactID + ":" + dep.Version
+		if !seen[jarPath] {
+			seen[jarPath] = true
+			jarPaths = append(jarPaths, jarPath)
+		}
+	}
+
+	if len(jarPaths) != 1 {
+		t.Errorf("Expected 1 unique JAR path after dedup, got %d", len(jarPaths))
+	}
+}

--- a/api-collector-java/maven/testdata/build.gradle
+++ b/api-collector-java/maven/testdata/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.2.0'
+    api 'com.google.guava:guava:32.1.3-jre'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    runtimeOnly 'com.h2database:h2:2.2.224'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+}

--- a/api-collector-java/maven/testdata/build.gradle.kts
+++ b/api-collector-java/maven/testdata/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.2.0")
+    api("com.google.guava:guava:32.1.3-jre")
+}

--- a/api-collector-java/maven/testdata/pom.xml
+++ b/api-collector-java/maven/testdata/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>32.1.3-jre</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Implements api-collector-java/maven/resolver.go as specified in #19.

- Detects pom.xml or build.gradle in source directory
- Parses dependencies from Maven (XML) and Gradle (regex) build files
- Invokes maven-indexer-cli search-artifacts --json as subprocess
- Resolves dependency coordinates to JAR paths for type analysis
- Gracefully degrades when maven-indexer-cli is not available
- Integrates into JavaCollector.Collect() as optional enhancement
- 22 test cases covering all resolver functionality

Closes #19