### PR TITLE
fix: support Netflix Feign interfaces without @FeignClient annotation

### DIFF
--- a/api-collector-java/feign/parser.go
+++ b/api-collector-java/feign/parser.go
@@ -35,29 +35,55 @@ func (p *Parser) ExtractClients(results []parser.ParseResult) []FeignClient {
 
 func (p *Parser) extractClient(class parser.Class) *FeignClient {
 	ann := findAnnotation(class.Annotations, "FeignClient")
-	if ann == nil {
-		return nil
-	}
+	if ann != nil {
+		name := ann.Params["name"]
+		if name == "" {
+			name = ann.Params["value"]
+		}
 
-	name := ann.Params["name"]
-	if name == "" {
-		name = ann.Params["value"]
-	}
+		var endpoints []Endpoint
+		for _, method := range class.Methods {
+			if ep := p.extractEndpoint(method, class); ep != nil {
+				endpoints = append(endpoints, *ep)
+			}
+		}
 
-	var endpoints []Endpoint
-	for _, method := range class.Methods {
-		if ep := p.extractEndpoint(method, class); ep != nil {
-			endpoints = append(endpoints, *ep)
+		return &FeignClient{
+			Name:        class.Name,
+			Package:     class.Package,
+			ServiceName: name,
+			URL:         ann.Params["url"],
+			Endpoints:   endpoints,
 		}
 	}
 
-	return &FeignClient{
-		Name:        class.Name,
-		Package:     class.Package,
-		ServiceName: name,
-		URL:         ann.Params["url"],
-		Endpoints:   endpoints,
+	if class.IsInterface && p.hasRequestLineMethods(class) {
+		var endpoints []Endpoint
+		for _, method := range class.Methods {
+			if ep := p.extractEndpoint(method, class); ep != nil {
+				endpoints = append(endpoints, *ep)
+			}
+		}
+
+		if len(endpoints) > 0 {
+			return &FeignClient{
+				Name:      class.Name,
+				Package:   class.Package,
+				Endpoints: endpoints,
+			}
+		}
 	}
+
+	return nil
+}
+
+func (p *Parser) hasRequestLineMethods(class parser.Class) bool {
+	for _, method := range class.Methods {
+		if findAnnotation(method.Annotations, "RequestLine") != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Parser) extractEndpoint(method parser.Method, class parser.Class) *Endpoint {
@@ -172,7 +198,7 @@ func (p *Parser) extractRequestLineEndpoint(method parser.Method, class parser.C
 
 	var params []EndpointParameter
 	for _, param := range method.Parameters {
-		if ep := p.extractFeignParam(param); ep != nil {
+		if ep := p.extractFeignParam(param, methodPath); ep != nil {
 			params = append(params, *ep)
 		}
 	}
@@ -213,17 +239,37 @@ func parseRequestLine(value string) (HTTPMethod, string) {
 	}
 }
 
-func (p *Parser) extractFeignParam(param parser.Parameter) *EndpointParameter {
-	// Netflix Feign uses @Param for path/query variables
+func (p *Parser) extractFeignParam(param parser.Parameter, methodPath string) *EndpointParameter {
 	ann := findAnnotation(param.Annotations, "Param")
 	if ann == nil {
+		if param.Type != "" && !isJavaPrimitive(param.Type) {
+			return &EndpointParameter{Name: param.Name, Type: param.Type, ParamType: "body", Required: true}
+		}
 		return nil
 	}
 	name := ann.Params["value"]
 	if name == "" {
 		name = param.Name
 	}
-	return &EndpointParameter{Name: name, Type: param.Type, ParamType: "query", Required: false}
+	paramType := "query"
+	pathPart := methodPath
+	if idx := strings.Index(methodPath, "?"); idx >= 0 {
+		pathPart = methodPath[:idx]
+	}
+	if strings.Contains(pathPart, "{"+name+"}") {
+		paramType = "path"
+	}
+	return &EndpointParameter{Name: name, Type: param.Type, ParamType: paramType, Required: paramType == "path"}
+}
+
+func isJavaPrimitive(typ string) bool {
+	switch typ {
+	case "byte", "short", "int", "long", "float", "double", "boolean", "char",
+		"Byte", "Short", "Integer", "Long", "Float", "Double", "Boolean", "Character",
+		"String", "void", "Void":
+		return true
+	}
+	return false
 }
 
 func findAnnotation(annotations []parser.Annotation, name string) *parser.Annotation {

--- a/api-collector-java/feign/parser_test.go
+++ b/api-collector-java/feign/parser_test.go
@@ -171,10 +171,136 @@ func TestParser_NetflixFeignRequestLine(t *testing.T) {
 	if ep0.Path != "/orders/{id}" {
 		t.Errorf("Expected '/orders/{id}', got '%s'", ep0.Path)
 	}
+	if len(ep0.Parameters) != 1 || ep0.Parameters[0].ParamType != "path" {
+		t.Errorf("Expected path parameter, got %v", ep0.Parameters)
+	}
 
 	ep1 := client.Endpoints[1]
 	if ep1.Method != DELETE {
 		t.Errorf("Expected DELETE, got %s", ep1.Method)
+	}
+	if len(ep1.Parameters) != 1 || ep1.Parameters[0].ParamType != "path" {
+		t.Errorf("Expected path parameter, got %v", ep1.Parameters)
+	}
+}
+
+func TestParser_NetflixFeignWithoutFeignClientAnnotation(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			FilePath: "UserClient.java",
+			Classes: []parser.Class{
+				{
+					Name:        "UserClient",
+					Package:     "com.example",
+					IsInterface: true,
+					Annotations: []parser.Annotation{},
+					Methods: []parser.Method{
+						{
+							Name: "listUsers",
+							Annotations: []parser.Annotation{
+								{Name: "RequestLine", Params: map[string]string{"value": "GET /users?name={name}&role={role}"}},
+							},
+							Parameters: []parser.Parameter{
+								{
+									Name: "name",
+									Type: "String",
+									Annotations: []parser.Annotation{
+										{Name: "Param", Params: map[string]string{"value": "name"}},
+									},
+								},
+								{
+									Name: "role",
+									Type: "String",
+									Annotations: []parser.Annotation{
+										{Name: "Param", Params: map[string]string{"value": "role"}},
+									},
+								},
+							},
+							ReturnType: "String",
+						},
+						{
+							Name: "createUser",
+							Annotations: []parser.Annotation{
+								{Name: "RequestLine", Params: map[string]string{"value": "POST /users"}},
+							},
+							Parameters: []parser.Parameter{
+								{
+									Name: "req",
+									Type: "CreateUserReq",
+									Annotations: []parser.Annotation{},
+								},
+							},
+							ReturnType: "String",
+						},
+						{
+							Name: "getUser",
+							Annotations: []parser.Annotation{
+								{Name: "RequestLine", Params: map[string]string{"value": "GET /users/{id}"}},
+							},
+							Parameters: []parser.Parameter{
+								{
+									Name: "id",
+									Type: "String",
+									Annotations: []parser.Annotation{
+										{Name: "Param", Params: map[string]string{"value": "id"}},
+									},
+								},
+							},
+							ReturnType: "String",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 {
+		t.Fatalf("Expected 1 client, got %d", len(clients))
+	}
+
+	client := clients[0]
+	if client.Name != "UserClient" {
+		t.Errorf("Expected 'UserClient', got '%s'", client.Name)
+	}
+	if client.ServiceName != "" {
+		t.Errorf("Expected empty service name, got '%s'", client.ServiceName)
+	}
+	if len(client.Endpoints) != 3 {
+		t.Fatalf("Expected 3 endpoints, got %d", len(client.Endpoints))
+	}
+
+	ep0 := client.Endpoints[0]
+	if ep0.Method != GET {
+		t.Errorf("Expected GET, got %s", ep0.Method)
+	}
+	if len(ep0.Parameters) != 2 {
+		t.Errorf("Expected 2 query params, got %d", len(ep0.Parameters))
+	} else {
+		if ep0.Parameters[0].ParamType != "query" {
+			t.Errorf("Expected query param, got %s", ep0.Parameters[0].ParamType)
+		}
+		if ep0.Parameters[1].ParamType != "query" {
+			t.Errorf("Expected query param, got %s", ep0.Parameters[1].ParamType)
+		}
+	}
+
+	ep1 := client.Endpoints[1]
+	if ep1.Method != POST {
+		t.Errorf("Expected POST, got %s", ep1.Method)
+	}
+	if len(ep1.Parameters) != 1 || ep1.Parameters[0].ParamType != "body" {
+		t.Errorf("Expected body parameter, got %v", ep1.Parameters)
+	}
+
+	ep2 := client.Endpoints[2]
+	if ep2.Method != GET {
+		t.Errorf("Expected GET, got %s", ep2.Method)
+	}
+	if len(ep2.Parameters) != 1 || ep2.Parameters[0].ParamType != "path" {
+		t.Errorf("Expected path parameter, got %v", ep2.Parameters)
 	}
 }
 


### PR DESCRIPTION
## Problem

The java-feign integration test was failing because the sample UserClient.java uses Netflix Feign style (`@RequestLine` + `@Param`) without a `@FeignClient` class annotation. The parser only recognized interfaces annotated with `@FeignClient`, so no endpoints were extracted — resulting in empty output.

## Changes

### `api-collector-java/feign/parser.go`

- **Detect Netflix Feign interfaces**: `extractClient` now recognizes interfaces with `@RequestLine`-annotated methods even without `@FeignClient` annotation
- **Body param inference**: Parameters without `@Param` but with non-primitive types (e.g., `CreateUserReq req`) are treated as body params instead of being silently dropped
- **Path vs query param classification**: `@Param` parameters whose name appears in the URL path template (before `?`) are correctly marked as `path` instead of always `query`
- Added `hasRequestLineMethods()` helper
- Added `isJavaPrimitive()` helper

### `api-collector-java/feign/parser_test.go`

- Added `TestParser_NetflixFeignWithoutFeignClientAnnotation` covering query, body, and path params
- Enhanced `TestParser_NetflixFeignRequestLine` with path param assertions

## Test Results

- All unit tests pass (`go test ./api-collector-java/...`)
- java-feign integration test passes (`bash ./samples/java-feign/test.sh`)