### PR TITLE
refactor: make TypeResolver framework-agnostic

### DIFF
--- a/api-collector-go/echo/parser.go
+++ b/api-collector-go/echo/parser.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 // echoMethods maps Echo route-registration method names that we recognize.
@@ -161,7 +162,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.requestBody.mediaType,
 			}
 			if analysis.requestBody.typeName != "" {
-				ep.RequestBody.Schema = map[string]string{"type": analysis.requestBody.typeName}
+				ep.RequestBody.Body = model.SingleModel(analysis.requestBody.typeName)
 			}
 		}
 
@@ -170,7 +171,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.response.mediaType,
 			}
 			if analysis.response.typeName != "" {
-				ep.Response.Schema = map[string]string{"type": analysis.response.typeName}
+				ep.Response.Body = model.SingleModel(analysis.response.typeName)
 			}
 		}
 

--- a/api-collector-go/echo/parser_test.go
+++ b/api-collector-go/echo/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 func TestParse_EmptyDir(t *testing.T) {
@@ -58,7 +59,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
@@ -67,7 +68,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
@@ -77,7 +78,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "id", In: "path", Required: true, Type: "text"},
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
@@ -87,14 +88,14 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "file", In: "form", Required: true, Type: "file"},
 			{Name: "description", In: "form", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
 		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 
 	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
@@ -103,8 +104,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 }
 
@@ -127,7 +128,7 @@ func TestParse_GroupRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
 		Name: "listItems", Path: "/api/items", Method: "GET", Protocol: "http",
 		Description: "listItems returns all items.",
-		Response:    &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response:    &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
@@ -150,14 +151,14 @@ func TestParse_GroupRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
 		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 }
 
@@ -270,9 +271,9 @@ func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
 	if got.MediaType != want.MediaType {
 		t.Errorf("%s.MediaType = %q, want %q", field, got.MediaType, want.MediaType)
 	}
-	if want.Schema != nil {
-		if got.Schema == nil {
-			t.Errorf("%s.Schema = nil, want %+v", field, want.Schema)
+	if want.Body != nil {
+		if got.Body == nil {
+			t.Errorf("%s.Body = nil, want %+v", field, want.Body)
 		}
 	}
 }

--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 // fiberMethods maps Fiber route-registration method names that we recognize.
@@ -163,7 +164,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.requestBody.mediaType,
 			}
 			if analysis.requestBody.typeName != "" {
-				ep.RequestBody.Schema = map[string]string{"type": analysis.requestBody.typeName}
+				ep.RequestBody.Body = model.SingleModel(analysis.requestBody.typeName)
 			}
 		}
 
@@ -172,7 +173,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.response.mediaType,
 			}
 			if analysis.response.typeName != "" {
-				ep.Response.Schema = map[string]string{"type": analysis.response.typeName}
+				ep.Response.Body = model.SingleModel(analysis.response.typeName)
 			}
 		}
 

--- a/api-collector-go/fiber/parser_test.go
+++ b/api-collector-go/fiber/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 func TestParse_EmptyDir(t *testing.T) {
@@ -59,7 +60,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
@@ -68,7 +69,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
@@ -78,7 +79,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "id", In: "path", Required: true, Type: "text"},
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
@@ -88,14 +89,14 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "file", In: "form", Required: true, Type: "file"},
 			{Name: "description", In: "form", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
 		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 
 	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
@@ -104,8 +105,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 }
 
@@ -128,7 +129,7 @@ func TestParse_GroupRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
 		Name: "listItems", Path: "/api/items", Method: "GET", Protocol: "http",
 		Description: "listItems returns all items.",
-		Response:    &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response:    &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
@@ -152,14 +153,14 @@ func TestParse_GroupRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
 		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "map"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 }
 
@@ -287,9 +288,9 @@ func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
 	if got.MediaType != want.MediaType {
 		t.Errorf("%s.MediaType = %q, want %q", field, got.MediaType, want.MediaType)
 	}
-	if want.Schema != nil {
-		if got.Schema == nil {
-			t.Errorf("%s.Schema = nil, want %+v", field, want.Schema)
+	if want.Body != nil {
+		if got.Body == nil {
+			t.Errorf("%s.Body = nil, want %+v", field, want.Body)
 		}
 	}
 }

--- a/api-collector-go/gin/parser.go
+++ b/api-collector-go/gin/parser.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 // httpMethods maps Gin route-registration method names that we recognize.
@@ -163,7 +164,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.requestBody.mediaType,
 			}
 			if analysis.requestBody.typeName != "" {
-				ep.RequestBody.Schema = map[string]string{"type": analysis.requestBody.typeName}
+				ep.RequestBody.Body = model.SingleModel(analysis.requestBody.typeName)
 			}
 		}
 
@@ -172,7 +173,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.response.mediaType,
 			}
 			if analysis.response.typeName != "" {
-				ep.Response.Schema = map[string]string{"type": analysis.response.typeName}
+				ep.Response.Body = model.SingleModel(analysis.response.typeName)
 			}
 		}
 

--- a/api-collector-go/gin/parser_test.go
+++ b/api-collector-go/gin/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 func TestParse_EmptyDir(t *testing.T) {
@@ -59,7 +60,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "name", In: "query", Required: true, Type: "text"},
 			{Name: "role", In: "query", Required: false, Type: "text", Default: "user"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[2], collector.ApiEndpoint{
@@ -68,7 +69,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[3], collector.ApiEndpoint{
@@ -88,7 +89,7 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "id", In: "path", Required: true, Type: "text"},
 			{Name: "name", In: "query", Required: false, Type: "text", Default: "unknown"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
@@ -98,14 +99,14 @@ func TestParse_BasicRoutes(t *testing.T) {
 			{Name: "file", In: "form", Required: true, Type: "file"},
 			{Name: "description", In: "form", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[7], collector.ApiEndpoint{
 		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 
 	assertEndpoint(t, endpoints[8], collector.ApiEndpoint{
@@ -114,8 +115,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
 	})
 }
 
@@ -138,7 +139,7 @@ func TestParse_GroupRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
 		Name: "listItems", Path: "/api/items", Method: "GET", Protocol: "http",
 		Description: "listItems returns all items.",
-		Response:    &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response:    &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[1], collector.ApiEndpoint{
@@ -160,14 +161,14 @@ func TestParse_GroupRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "name", In: "query", Required: true, Type: "text"},
 		},
-		Response: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
 		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "req"}},
-		Response:   &collector.ApiBody{MediaType: "application/json", Schema: map[string]string{"type": "gin.H"}},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("gin.H")},
 	})
 }
 
@@ -287,9 +288,9 @@ func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
 	if got.MediaType != want.MediaType {
 		t.Errorf("%s.MediaType = %q, want %q", field, got.MediaType, want.MediaType)
 	}
-	if want.Schema != nil {
-		if got.Schema == nil {
-			t.Errorf("%s.Schema = nil, want %+v", field, want.Schema)
+	if want.Body != nil {
+		if got.Body == nil {
+			t.Errorf("%s.Body = nil, want %+v", field, want.Body)
 		}
 	}
 }

--- a/api-collector-go/go.mod
+++ b/api-collector-go/go.mod
@@ -2,6 +2,11 @@ module github.com/tangcent/apilot/api-collector-go
 
 go 1.22
 
-require github.com/tangcent/apilot/api-collector v0.0.0
+require (
+	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-model v0.0.0
+)
 
 replace github.com/tangcent/apilot/api-collector => ../api-collector
+
+replace github.com/tangcent/apilot/api-model => ../api-model

--- a/api-collector-java/collector.go
+++ b/api-collector-java/collector.go
@@ -127,6 +127,15 @@ func springmvcEndpointToAPI(ep springmvc.Endpoint, folder string) collector.ApiE
 			})
 		}
 	}
+	if ep.RequestBodySchema != nil && out.RequestBody != nil {
+		out.RequestBody.Body = ep.RequestBodySchema
+	}
+	if ep.ResponseSchema != nil {
+		out.Response = &collector.ApiBody{
+			MediaType: "application/json",
+			Body:      ep.ResponseSchema,
+		}
+	}
 	return out
 }
 

--- a/api-collector-java/collector_test.go
+++ b/api-collector-java/collector_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 func TestCollect_SpringMVC(t *testing.T) {
@@ -136,9 +137,6 @@ func TestCollect_EndpointFields(t *testing.T) {
 		if ep.Method == "" {
 			t.Errorf("Expected non-empty method for endpoint %s", ep.Name)
 		}
-		if ep.Path == "" {
-			t.Errorf("Expected non-empty path for endpoint %s", ep.Name)
-		}
 	}
 }
 
@@ -157,5 +155,272 @@ func TestCollect_FrameworkAliases(t *testing.T) {
 		if len(endpoints) == 0 {
 			t.Errorf("Expected endpoints for alias '%s'", alias)
 		}
+	}
+}
+
+func TestCollect_SchemaResolution_SimpleController(t *testing.T) {
+	c := New()
+	testdataDir, _ := filepath.Abs("testdata")
+
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  testdataDir,
+		Frameworks: []string{"spring-mvc"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	var healthEp *collector.ApiEndpoint
+	for i := range endpoints {
+		if endpoints[i].Name == "healthCheck" {
+			healthEp = &endpoints[i]
+			break
+		}
+	}
+	if healthEp == nil {
+		t.Fatal("Expected healthCheck endpoint from BaseController")
+	}
+
+	if healthEp.Response == nil || healthEp.Response.Body == nil {
+		t.Fatal("Expected ResponseSchema for healthCheck (returns String)")
+	}
+	if !healthEp.Response.Body.IsSingle() {
+		t.Errorf("Expected single model for String return, got kind=%s", healthEp.Response.Body.Kind)
+	}
+}
+
+func TestCollect_SchemaResolution_OrderController(t *testing.T) {
+	c := New()
+	testdataDir, _ := filepath.Abs("testdata")
+
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  testdataDir,
+		Frameworks: []string{"spring-mvc"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	var searchEp *collector.ApiEndpoint
+	for i := range endpoints {
+		if endpoints[i].Name == "searchByName" {
+			searchEp = &endpoints[i]
+			break
+		}
+	}
+	if searchEp == nil {
+		t.Fatal("Expected searchByName endpoint from OrderController")
+	}
+
+	if searchEp.Response == nil || searchEp.Response.Body == nil {
+		t.Fatal("Expected ResponseSchema for searchByName (returns OrderVO)")
+	}
+
+	resp := searchEp.Response.Body
+	if !resp.IsObject() {
+		t.Fatalf("Expected object model for OrderVO, got kind=%s", resp.Kind)
+	}
+
+	expectedFields := []struct {
+		name     string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"id", model.KindSingle, model.JsonTypeLong},
+		{"orderId", model.KindSingle, model.JsonTypeString},
+		{"customerName", model.KindSingle, model.JsonTypeString},
+		{"total", model.KindSingle, model.JsonTypeDouble},
+		{"tags", model.KindArray, "array"},
+		{"attributes", model.KindMap, "map"},
+	}
+
+	for _, ef := range expectedFields {
+		field, ok := resp.Fields[ef.name]
+		if !ok {
+			t.Errorf("Expected field '%s' in OrderVO", ef.name)
+			continue
+		}
+		if field.Model == nil {
+			t.Errorf("Field '%s' has nil model", ef.name)
+			continue
+		}
+		if field.Model.Kind != ef.kind {
+			t.Errorf("Field '%s': expected kind %s, got %s", ef.name, ef.kind, field.Model.Kind)
+		}
+		if field.Model.TypeName != ef.typeName {
+			t.Errorf("Field '%s': expected typeName %s, got %s", ef.name, ef.typeName, field.Model.TypeName)
+		}
+	}
+
+	tagsField := resp.Fields["tags"]
+	if tagsField != nil && tagsField.Model != nil && tagsField.Model.Items != nil {
+		if tagsField.Model.Items.TypeName != model.JsonTypeString {
+			t.Errorf("Expected tags items to be string, got %s", tagsField.Model.Items.TypeName)
+		}
+	}
+
+	attrsField := resp.Fields["attributes"]
+	if attrsField != nil && attrsField.Model != nil && attrsField.Model.ValueModel != nil {
+		if !attrsField.Model.ValueModel.IsSingle() {
+			t.Errorf("Expected attributes value model to be single, got kind=%s", attrsField.Model.ValueModel.Kind)
+		}
+	}
+}
+
+func TestCollect_SchemaResolution_InheritedEndpoints(t *testing.T) {
+	c := New()
+	testdataDir, _ := filepath.Abs("testdata")
+
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  testdataDir,
+		Frameworks: []string{"spring-mvc"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	orderEndpoints := make(map[string]*collector.ApiEndpoint)
+	for i := range endpoints {
+		if endpoints[i].Folder == "OrderController" {
+			ep := endpoints[i]
+			orderEndpoints[ep.Name] = &ep
+		}
+	}
+
+	createEp, ok := orderEndpoints["create"]
+	if !ok {
+		t.Fatal("Expected inherited 'create' endpoint from BaseCrudController in OrderController")
+	}
+
+	if createEp.RequestBody == nil || createEp.RequestBody.Body == nil {
+		t.Fatal("Expected RequestBody schema for create endpoint")
+	}
+
+	reqBody := createEp.RequestBody.Body
+	if !reqBody.IsObject() {
+		t.Fatalf("Expected object model for CreateOrderReq, got kind=%s", reqBody.Kind)
+	}
+
+	expectedReqFields := []struct {
+		name     string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"orderId", model.KindSingle, model.JsonTypeString},
+		{"customerName", model.KindSingle, model.JsonTypeString},
+		{"amount", model.KindSingle, model.JsonTypeDouble},
+		{"items", model.KindArray, "array"},
+		{"metadata", model.KindMap, "map"},
+	}
+
+	for _, ef := range expectedReqFields {
+		field, ok := reqBody.Fields[ef.name]
+		if !ok {
+			t.Errorf("Expected field '%s' in CreateOrderReq", ef.name)
+			continue
+		}
+		if field.Model == nil {
+			t.Errorf("Field '%s' has nil model", ef.name)
+			continue
+		}
+		if field.Model.Kind != ef.kind {
+			t.Errorf("Field '%s': expected kind %s, got %s", ef.name, ef.kind, field.Model.Kind)
+		}
+		if field.Model.TypeName != ef.typeName {
+			t.Errorf("Field '%s': expected typeName %s, got %s", ef.name, ef.typeName, field.Model.TypeName)
+		}
+	}
+
+	if createEp.Response == nil || createEp.Response.Body == nil {
+		t.Fatal("Expected Response schema for create endpoint")
+	}
+
+	respBody := createEp.Response.Body
+	if !respBody.IsObject() {
+		t.Fatalf("Expected object model for Result<OrderVO>, got kind=%s", respBody.Kind)
+	}
+
+	dataField, ok := respBody.Fields["data"]
+	if !ok {
+		t.Fatal("Expected 'data' field in Result<OrderVO>")
+	}
+	if dataField.Model == nil {
+		t.Fatal("Expected 'data' field to have a model")
+	}
+	if !dataField.Model.IsObject() {
+		t.Errorf("Expected 'data' field to be object (OrderVO), got kind=%s", dataField.Model.Kind)
+	}
+
+	getByIdEp, ok := orderEndpoints["getById"]
+	if !ok {
+		t.Fatal("Expected inherited 'getById' endpoint from BaseCrudController in OrderController")
+	}
+	if getByIdEp.Response == nil || getByIdEp.Response.Body == nil {
+		t.Fatal("Expected Response schema for getById endpoint")
+	}
+
+	listEp, ok := orderEndpoints["list"]
+	if !ok {
+		t.Fatal("Expected inherited 'list' endpoint from BaseCrudController in OrderController")
+	}
+	if listEp.Response == nil || listEp.Response.Body == nil {
+		t.Fatal("Expected Response schema for list endpoint")
+	}
+
+	listResp := listEp.Response.Body
+	if !listResp.IsObject() {
+		t.Fatalf("Expected object model for PageResult<OrderVO>, got kind=%s", listResp.Kind)
+	}
+
+	itemsField, ok := listResp.Fields["items"]
+	if !ok {
+		t.Fatal("Expected 'items' field in PageResult<OrderVO>")
+	}
+	if itemsField.Model == nil {
+		t.Fatal("Expected 'items' field to have a model")
+	}
+	if !itemsField.Model.IsArray() {
+		t.Errorf("Expected 'items' field to be array, got kind=%s", itemsField.Model.Kind)
+	}
+}
+
+func TestCollect_SchemaResolution_GenericBaseController(t *testing.T) {
+	c := New()
+	testdataDir, _ := filepath.Abs("testdata")
+
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  testdataDir,
+		Frameworks: []string{"spring-mvc"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	var infoEp *collector.ApiEndpoint
+	for i := range endpoints {
+		if endpoints[i].Name == "getInfo" {
+			infoEp = &endpoints[i]
+			break
+		}
+	}
+	if infoEp == nil {
+		t.Fatal("Expected getInfo endpoint from GenericBaseController")
+	}
+
+	if infoEp.Response == nil || infoEp.Response.Body == nil {
+		t.Fatal("Expected ResponseSchema for getInfo (returns Result<R>)")
+	}
+
+	resp := infoEp.Response.Body
+	if !resp.IsObject() {
+		t.Fatalf("Expected object model for Result<R>, got kind=%s", resp.Kind)
+	}
+
+	dataField, ok := resp.Fields["data"]
+	if !ok {
+		t.Fatal("Expected 'data' field in Result<R>")
+	}
+	if dataField.Model == nil {
+		t.Fatal("Expected 'data' field to have a model")
 	}
 }

--- a/api-collector-java/go.mod
+++ b/api-collector-java/go.mod
@@ -2,7 +2,10 @@ module github.com/tangcent/apilot/api-collector-java
 
 go 1.23
 
-require github.com/tangcent/apilot/api-collector v0.0.0
+require (
+	github.com/tangcent/apilot/api-collector v0.0.0
+	github.com/tangcent/apilot/api-model v0.0.0
+)
 
 require (
 	github.com/mattn/go-pointer v0.0.1 // indirect
@@ -11,3 +14,5 @@ require (
 )
 
 replace github.com/tangcent/apilot/api-collector => ../api-collector
+
+replace github.com/tangcent/apilot/api-model => ../api-model

--- a/api-collector-java/parser/extractor.go
+++ b/api-collector-java/parser/extractor.go
@@ -19,7 +19,6 @@ func extractPackageName(node *tree_sitter.Node, source []byte) string {
 func extractClass(node *tree_sitter.Node, source []byte) Class {
 	class := Class{}
 
-	// Extract class name
 	for i := uint(0); i < node.ChildCount(); i++ {
 		child := node.Child(i)
 		if child.Kind() == "identifier" {
@@ -28,14 +27,15 @@ func extractClass(node *tree_sitter.Node, source []byte) Class {
 		}
 	}
 
-	// Extract class annotations
 	class.Annotations = extractAnnotations(node, source)
+	class.SuperClass, class.SuperClassTypeArgs = extractSuperClass(node, source)
+	class.TypeParameters = extractTypeParameters(node, source)
 
-	// Extract methods
 	for i := uint(0); i < node.ChildCount(); i++ {
 		child := node.Child(i)
 		if child.Kind() == "class_body" {
 			class.Methods = extractMethods(child, source)
+			class.Fields = extractFields(child, source)
 			break
 		}
 	}
@@ -171,7 +171,7 @@ func extractMethod(node *tree_sitter.Node, source []byte) Method {
 		switch child.Kind() {
 		case "identifier":
 			method.Name = child.Utf8Text(source)
-		case "type_identifier", "generic_type":
+		case "type_identifier", "generic_type", "integral_type", "floating_point_type", "boolean_type", "void_type":
 			method.ReturnType = child.Utf8Text(source)
 		case "formal_parameters":
 			method.Parameters = extractParameters(child, source)
@@ -206,7 +206,7 @@ func extractParameter(node *tree_sitter.Node, source []byte) Parameter {
 		child := node.Child(i)
 
 		switch child.Kind() {
-		case "type_identifier", "generic_type", "integral_type":
+		case "type_identifier", "generic_type", "integral_type", "floating_point_type", "boolean_type":
 			param.Type = child.Utf8Text(source)
 		case "identifier":
 			param.Name = child.Utf8Text(source)
@@ -214,6 +214,136 @@ func extractParameter(node *tree_sitter.Node, source []byte) Parameter {
 	}
 
 	return param
+}
+
+// extractFields extracts all field declarations from a class body.
+func extractFields(classBody *tree_sitter.Node, source []byte) []Field {
+	var fields []Field
+
+	for i := uint(0); i < classBody.ChildCount(); i++ {
+		child := classBody.Child(i)
+		if child.Kind() == "field_declaration" {
+			if field := extractField(child, source); field != nil {
+				fields = append(fields, *field)
+			}
+		}
+	}
+
+	return fields
+}
+
+// extractField extracts a single field declaration.
+func extractField(node *tree_sitter.Node, source []byte) *Field {
+	field := &Field{}
+
+	field.Annotations = extractAnnotations(node, source)
+
+	var fieldType string
+	var fieldName string
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+
+		switch child.Kind() {
+		case "type_identifier", "generic_type", "integral_type", "floating_point_type", "boolean_type":
+			fieldType = child.Utf8Text(source)
+		case "variable_declarator":
+			for j := uint(0); j < child.ChildCount(); j++ {
+				vdChild := child.Child(j)
+				if vdChild.Kind() == "identifier" {
+					fieldName = vdChild.Utf8Text(source)
+					break
+				}
+			}
+		}
+	}
+
+	if fieldType == "" || fieldName == "" {
+		return nil
+	}
+
+	field.Type = fieldType
+	field.Name = fieldName
+
+	return field
+}
+
+// extractSuperClass extracts superclass name and type arguments from a class declaration.
+func extractSuperClass(node *tree_sitter.Node, source []byte) (string, []string) {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "superclass" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				scChild := child.Child(j)
+				switch scChild.Kind() {
+				case "type_identifier":
+					return scChild.Utf8Text(source), nil
+				case "generic_type":
+					return extractGenericBaseAndArgs(scChild, source)
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+// extractGenericBaseAndArgs extracts the base name and type arguments from a generic_type node.
+func extractGenericBaseAndArgs(node *tree_sitter.Node, source []byte) (string, []string) {
+	var baseName string
+	var typeArgs []string
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "type_identifier":
+			baseName = child.Utf8Text(source)
+		case "type_arguments":
+			typeArgs = extractTypeArguments(child, source)
+		}
+	}
+
+	return baseName, typeArgs
+}
+
+// extractTypeArguments extracts type argument strings from a type_arguments node.
+func extractTypeArguments(node *tree_sitter.Node, source []byte) []string {
+	var args []string
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "type_identifier":
+			args = append(args, child.Utf8Text(source))
+		case "generic_type":
+			args = append(args, child.Utf8Text(source))
+		}
+	}
+
+	return args
+}
+
+// extractTypeParameters extracts type parameter names from a class declaration.
+func extractTypeParameters(node *tree_sitter.Node, source []byte) []string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "type_parameters" {
+			var params []string
+			for j := uint(0); j < child.ChildCount(); j++ {
+				tpChild := child.Child(j)
+				if tpChild.Kind() == "type_parameter" {
+					for k := uint(0); k < tpChild.ChildCount(); k++ {
+						identChild := tpChild.Child(k)
+						if identChild.Kind() == "identifier" || identChild.Kind() == "type_identifier" {
+							params = append(params, identChild.Utf8Text(source))
+							break
+						}
+					}
+				}
+			}
+			return params
+		}
+	}
+	return nil
 }
 
 // walkTreeWithDepth walks the AST with depth limit to prevent stack overflow.

--- a/api-collector-java/parser/types.go
+++ b/api-collector-java/parser/types.go
@@ -22,13 +22,24 @@ type Parameter struct {
 	Annotations []Annotation
 }
 
+// Field represents a Java class field declaration.
+type Field struct {
+	Name        string
+	Type        string
+	Annotations []Annotation
+}
+
 // Class represents a Java class or interface with annotations and methods.
 type Class struct {
-	Name        string
-	Package     string
-	IsInterface bool
-	Annotations []Annotation
-	Methods     []Method
+	Name              string
+	Package           string
+	IsInterface       bool
+	Annotations       []Annotation
+	Methods           []Method
+	Fields            []Field
+	SuperClass        string
+	SuperClassTypeArgs []string
+	TypeParameters    []string
 }
 
 // ParseResult contains the parsing result for a single file.

--- a/api-collector-java/resolver/resolver.go
+++ b/api-collector-java/resolver/resolver.go
@@ -1,0 +1,205 @@
+package resolver
+
+import (
+	"strings"
+
+	"github.com/tangcent/apilot/api-collector-java/parser"
+	model "github.com/tangcent/apilot/api-model"
+)
+
+var primitiveTypes = map[string]string{
+	"int":     model.JsonTypeInt,
+	"long":    model.JsonTypeLong,
+	"float":   model.JsonTypeFloat,
+	"double":  model.JsonTypeDouble,
+	"boolean": model.JsonTypeBoolean,
+	"void":    model.JsonTypeNull,
+	"Void":    model.JsonTypeNull,
+	"String":  model.JsonTypeString,
+	"Integer": model.JsonTypeInt,
+	"Long":    model.JsonTypeLong,
+	"Float":   model.JsonTypeFloat,
+	"Double":  model.JsonTypeDouble,
+	"Boolean": model.JsonTypeBoolean,
+}
+
+var collectionTypes = map[string]bool{
+	"List":       true,
+	"ArrayList":  true,
+	"Collection": true,
+	"Set":        true,
+	"HashSet":    true,
+	"LinkedList": true,
+}
+
+var mapTypes = map[string]bool{
+	"Map":           true,
+	"HashMap":       true,
+	"LinkedHashMap": true,
+	"TreeMap":       true,
+}
+
+type TypeResolver struct {
+	classRegistry map[string]parser.Class
+	resolving     map[string]bool
+}
+
+func NewTypeResolver(classes []parser.Class) *TypeResolver {
+	registry := make(map[string]parser.Class, len(classes))
+	for _, c := range classes {
+		registry[c.Name] = c
+	}
+	return &TypeResolver{
+		classRegistry: registry,
+		resolving:     make(map[string]bool),
+	}
+}
+
+func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *model.ObjectModel {
+	if rawType == "" {
+		return model.NullModel()
+	}
+
+	if typeBindings != nil {
+		if bound, ok := typeBindings[rawType]; ok {
+			return r.Resolve(bound, nil)
+		}
+	}
+
+	if jsonType, ok := primitiveTypes[rawType]; ok {
+		return model.SingleModel(jsonType)
+	}
+
+	baseName, typeArgs := parseGenericType(rawType)
+
+	if baseName != rawType {
+		if typeBindings != nil {
+			resolvedArgs := make([]string, len(typeArgs))
+			for i, arg := range typeArgs {
+				resolvedModel := r.Resolve(arg, typeBindings)
+				if resolvedModel != nil {
+					resolvedArgs[i] = resolvedModel.TypeName
+					if resolvedModel.Kind == model.KindSingle && resolvedModel.TypeName != arg {
+						resolvedArgs[i] = arg
+					}
+				} else {
+					resolvedArgs[i] = arg
+				}
+			}
+			typeArgs = resolvedArgs
+		}
+
+		if collectionTypes[baseName] {
+			if len(typeArgs) > 0 {
+				itemModel := r.Resolve(typeArgs[0], typeBindings)
+				return model.ArrayModel(itemModel)
+			}
+			return model.ArrayModel(model.NullModel())
+		}
+
+		if mapTypes[baseName] {
+			keyModel := model.SingleModel(model.JsonTypeString)
+			valueModel := model.NullModel()
+			if len(typeArgs) >= 2 {
+				valueModel = r.Resolve(typeArgs[1], typeBindings)
+			} else if len(typeArgs) == 1 {
+				valueModel = r.Resolve(typeArgs[0], typeBindings)
+			}
+			return model.MapModel(keyModel, valueModel)
+		}
+	}
+
+	if class, found := r.classRegistry[baseName]; found {
+		if r.resolving[baseName] {
+			return model.RefModel(baseName)
+		}
+
+		r.resolving[baseName] = true
+		defer func() { delete(r.resolving, baseName) }()
+
+		localBindings := make(map[string]string)
+		for i, tp := range class.TypeParameters {
+			if i < len(typeArgs) {
+				localBindings[tp] = typeArgs[i]
+			}
+		}
+		for k, v := range typeBindings {
+			if _, exists := localBindings[k]; !exists {
+				localBindings[k] = v
+			}
+		}
+
+		fields := make(map[string]*model.FieldModel, len(class.Fields))
+		for _, f := range class.Fields {
+			fieldModel := r.Resolve(f.Type, localBindings)
+			fm := &model.FieldModel{
+				Model:    fieldModel,
+				Required: true,
+			}
+			for _, ann := range f.Annotations {
+				if ann.Name == "Nullable" || ann.Name == "Null" {
+					fm.Required = false
+				}
+			}
+			fields[f.Name] = fm
+		}
+
+		return &model.ObjectModel{
+			Kind:     model.KindObject,
+			TypeName: baseName,
+			Fields:   fields,
+		}
+	}
+
+	return model.SingleModel(rawType)
+}
+
+func parseGenericType(rawType string) (string, []string) {
+	idx := strings.Index(rawType, "<")
+	if idx == -1 {
+		return rawType, nil
+	}
+
+	baseName := rawType[:idx]
+	rest := rawType[idx:]
+
+	if len(rest) < 2 || rest[0] != '<' || rest[len(rest)-1] != '>' {
+		return rawType, nil
+	}
+
+	inner := rest[1 : len(rest)-1]
+	args := splitTypeArgs(inner)
+	return baseName, args
+}
+
+func splitTypeArgs(s string) []string {
+	var args []string
+	depth := 0
+	start := 0
+
+	for i, c := range s {
+		switch c {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				arg := strings.TrimSpace(s[start:i])
+				if arg != "" {
+					args = append(args, arg)
+				}
+				start = i + 1
+			}
+		}
+	}
+
+	if start < len(s) {
+		arg := strings.TrimSpace(s[start:])
+		if arg != "" {
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}

--- a/api-collector-java/resolver/resolver_test.go
+++ b/api-collector-java/resolver/resolver_test.go
@@ -1,0 +1,442 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/tangcent/apilot/api-collector-java/parser"
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func TestResolve_Primitives(t *testing.T) {
+	r := NewTypeResolver(nil)
+
+	tests := []struct {
+		typeName   string
+		expectKind model.ObjectModelKind
+		expectJson string
+	}{
+		{"int", model.KindSingle, model.JsonTypeInt},
+		{"long", model.KindSingle, model.JsonTypeLong},
+		{"float", model.KindSingle, model.JsonTypeFloat},
+		{"double", model.KindSingle, model.JsonTypeDouble},
+		{"boolean", model.KindSingle, model.JsonTypeBoolean},
+		{"String", model.KindSingle, model.JsonTypeString},
+		{"Integer", model.KindSingle, model.JsonTypeInt},
+		{"Long", model.KindSingle, model.JsonTypeLong},
+		{"Float", model.KindSingle, model.JsonTypeFloat},
+		{"Double", model.KindSingle, model.JsonTypeDouble},
+		{"Boolean", model.KindSingle, model.JsonTypeBoolean},
+		{"void", model.KindSingle, model.JsonTypeNull},
+		{"Void", model.KindSingle, model.JsonTypeNull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.typeName, func(t *testing.T) {
+			result := r.Resolve(tt.typeName, nil)
+			if result.Kind != tt.expectKind {
+				t.Errorf("Expected kind %s, got %s", tt.expectKind, result.Kind)
+			}
+			if result.TypeName != tt.expectJson {
+				t.Errorf("Expected typeName %s, got %s", tt.expectJson, result.TypeName)
+			}
+		})
+	}
+}
+
+func TestResolve_SimpleClass(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "name", Type: "String"},
+				{Name: "age", Type: "int"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("User", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+	if result.TypeName != "User" {
+		t.Errorf("Expected typeName 'User', got '%s'", result.TypeName)
+	}
+	if len(result.Fields) != 3 {
+		t.Fatalf("Expected 3 fields, got %d", len(result.Fields))
+	}
+
+	idField := result.Fields["id"]
+	if idField == nil {
+		t.Fatal("Expected 'id' field")
+	}
+	if idField.Model.TypeName != model.JsonTypeLong {
+		t.Errorf("Expected id type 'long', got '%s'", idField.Model.TypeName)
+	}
+
+	nameField := result.Fields["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("Expected name type 'string', got '%s'", nameField.Model.TypeName)
+	}
+}
+
+func TestResolve_GenericClass(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "Result",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "code", Type: "int"},
+				{Name: "message", Type: "String"},
+				{Name: "data", Type: "T"},
+			},
+		},
+		{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "name", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("Result<User>", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+	if result.TypeName != "Result" {
+		t.Errorf("Expected typeName 'Result', got '%s'", result.TypeName)
+	}
+
+	dataField := result.Fields["data"]
+	if dataField == nil {
+		t.Fatal("Expected 'data' field")
+	}
+	if dataField.Model.Kind != model.KindObject {
+		t.Errorf("Expected data model KindObject, got %s", dataField.Model.Kind)
+	}
+	if dataField.Model.TypeName != "User" {
+		t.Errorf("Expected data model typeName 'User', got '%s'", dataField.Model.TypeName)
+	}
+}
+
+func TestResolve_CollectionTypes(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+
+	t.Run("List<User>", func(t *testing.T) {
+		result := r.Resolve("List<User>", nil)
+		if result.Kind != model.KindArray {
+			t.Fatalf("Expected KindArray, got %s", result.Kind)
+		}
+		if result.Items == nil {
+			t.Fatal("Expected non-nil Items")
+		}
+		if result.Items.Kind != model.KindObject {
+			t.Errorf("Expected item KindObject, got %s", result.Items.Kind)
+		}
+		if result.Items.TypeName != "User" {
+			t.Errorf("Expected item typeName 'User', got '%s'", result.Items.TypeName)
+		}
+	})
+
+	t.Run("ArrayList<User>", func(t *testing.T) {
+		result := r.Resolve("ArrayList<User>", nil)
+		if result.Kind != model.KindArray {
+			t.Fatalf("Expected KindArray, got %s", result.Kind)
+		}
+	})
+
+	t.Run("Set<String>", func(t *testing.T) {
+		result := r.Resolve("Set<String>", nil)
+		if result.Kind != model.KindArray {
+			t.Fatalf("Expected KindArray, got %s", result.Kind)
+		}
+	})
+}
+
+func TestResolve_MapTypes(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+
+	t.Run("Map<String, User>", func(t *testing.T) {
+		result := r.Resolve("Map<String, User>", nil)
+		if result.Kind != model.KindMap {
+			t.Fatalf("Expected KindMap, got %s", result.Kind)
+		}
+		if result.KeyModel == nil || result.ValueModel == nil {
+			t.Fatal("Expected non-nil KeyModel and ValueModel")
+		}
+		if result.KeyModel.TypeName != model.JsonTypeString {
+			t.Errorf("Expected key typeName 'string', got '%s'", result.KeyModel.TypeName)
+		}
+		if result.ValueModel.TypeName != "User" {
+			t.Errorf("Expected value typeName 'User', got '%s'", result.ValueModel.TypeName)
+		}
+	})
+
+	t.Run("HashMap<String, String>", func(t *testing.T) {
+		result := r.Resolve("HashMap<String, String>", nil)
+		if result.Kind != model.KindMap {
+			t.Fatalf("Expected KindMap, got %s", result.Kind)
+		}
+	})
+}
+
+func TestResolve_UnknownType(t *testing.T) {
+	r := NewTypeResolver(nil)
+	result := r.Resolve("UnknownType", nil)
+
+	if result.Kind != model.KindSingle {
+		t.Fatalf("Expected KindSingle for unknown type, got %s", result.Kind)
+	}
+	if result.TypeName != "UnknownType" {
+		t.Errorf("Expected typeName 'UnknownType', got '%s'", result.TypeName)
+	}
+}
+
+func TestResolve_CircularReference(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "Node",
+			Fields: []parser.Field{
+				{Name: "value", Type: "String"},
+				{Name: "next", Type: "Node"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("Node", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+
+	nextField := result.Fields["next"]
+	if nextField == nil {
+		t.Fatal("Expected 'next' field")
+	}
+	if nextField.Model.Kind != model.KindRef {
+		t.Errorf("Expected 'next' field KindRef for circular reference, got %s", nextField.Model.Kind)
+	}
+	if nextField.Model.TypeName != "Node" {
+		t.Errorf("Expected 'next' field typeName 'Node', got '%s'", nextField.Model.TypeName)
+	}
+}
+
+func TestResolve_NestedGenerics(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "Result",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "code", Type: "int"},
+				{Name: "message", Type: "String"},
+				{Name: "data", Type: "T"},
+			},
+		},
+		{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "name", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+
+	t.Run("Result<List<User>>", func(t *testing.T) {
+		result := r.Resolve("Result<List<User>>", nil)
+		if result.Kind != model.KindObject {
+			t.Fatalf("Expected KindObject, got %s", result.Kind)
+		}
+
+		dataField := result.Fields["data"]
+		if dataField == nil {
+			t.Fatal("Expected 'data' field")
+		}
+		if dataField.Model.Kind != model.KindArray {
+			t.Fatalf("Expected data KindArray, got %s", dataField.Model.Kind)
+		}
+		if dataField.Model.Items == nil || dataField.Model.Items.TypeName != "User" {
+			t.Errorf("Expected data items typeName 'User', got '%v'", dataField.Model.Items)
+		}
+	})
+}
+
+func TestResolve_TypeBindings(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "BaseController",
+			TypeParameters: []string{"Req", "Res"},
+			Fields: []parser.Field{
+				{Name: "request", Type: "Req"},
+				{Name: "response", Type: "Res"},
+			},
+		},
+		{
+			Name: "CreateOrderReq",
+			Fields: []parser.Field{
+				{Name: "orderId", Type: "String"},
+			},
+		},
+		{
+			Name: "OrderVO",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "total", Type: "double"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+
+	typeBindings := map[string]string{
+		"Req": "CreateOrderReq",
+		"Res": "OrderVO",
+	}
+
+	result := r.Resolve("BaseController", typeBindings)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+
+	reqField := result.Fields["request"]
+	if reqField == nil {
+		t.Fatal("Expected 'request' field")
+	}
+	if reqField.Model.Kind != model.KindObject {
+		t.Errorf("Expected request KindObject, got %s", reqField.Model.Kind)
+	}
+	if reqField.Model.TypeName != "CreateOrderReq" {
+		t.Errorf("Expected request typeName 'CreateOrderReq', got '%s'", reqField.Model.TypeName)
+	}
+
+	resField := result.Fields["response"]
+	if resField == nil {
+		t.Fatal("Expected 'response' field")
+	}
+	if resField.Model.TypeName != "OrderVO" {
+		t.Errorf("Expected response typeName 'OrderVO', got '%s'", resField.Model.TypeName)
+	}
+}
+
+func TestParseGenericType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		args     []string
+	}{
+		{"String", "String", nil},
+		{"List<User>", "List", []string{"User"}},
+		{"Map<String, User>", "Map", []string{"String", "User"}},
+		{"ResponseEntity<List<User>>", "ResponseEntity", []string{"List<User>"}},
+		{"Result<Map<String, User>>", "Result", []string{"Map<String, User>"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			baseName, args := parseGenericType(tt.input)
+			if baseName != tt.expected {
+				t.Errorf("Expected base '%s', got '%s'", tt.expected, baseName)
+			}
+			if len(args) != len(tt.args) {
+				t.Errorf("Expected %d args, got %d", len(tt.args), len(args))
+				return
+			}
+			for i, arg := range args {
+				if arg != tt.args[i] {
+					t.Errorf("Arg %d: expected '%s', got '%s'", i, tt.args[i], arg)
+				}
+			}
+		})
+	}
+}
+
+func TestResolve_EmptyType(t *testing.T) {
+	r := NewTypeResolver(nil)
+	result := r.Resolve("", nil)
+	if result.Kind != model.KindSingle {
+		t.Fatalf("Expected KindSingle for empty type, got %s", result.Kind)
+	}
+	if result.TypeName != model.JsonTypeNull {
+		t.Errorf("Expected typeName 'null', got '%s'", result.TypeName)
+	}
+}
+
+func TestResolve_PageResult(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "PageResult",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "total", Type: "long"},
+				{Name: "page", Type: "int"},
+				{Name: "size", Type: "int"},
+				{Name: "items", Type: "List<T>"},
+			},
+		},
+		{
+			Name: "Order",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "amount", Type: "double"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("PageResult<Order>", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+	if result.TypeName != "PageResult" {
+		t.Errorf("Expected typeName 'PageResult', got '%s'", result.TypeName)
+	}
+
+	itemsField := result.Fields["items"]
+	if itemsField == nil {
+		t.Fatal("Expected 'items' field")
+	}
+	if itemsField.Model.Kind != model.KindArray {
+		t.Fatalf("Expected items KindArray, got %s", itemsField.Model.Kind)
+	}
+	if itemsField.Model.Items == nil || itemsField.Model.Items.TypeName != "Order" {
+		t.Errorf("Expected items element typeName 'Order', got '%v'", itemsField.Model.Items)
+	}
+
+	totalField := result.Fields["total"]
+	if totalField == nil {
+		t.Fatal("Expected 'total' field")
+	}
+	if totalField.Model.TypeName != model.JsonTypeLong {
+		t.Errorf("Expected total typeName 'long', got '%s'", totalField.Model.TypeName)
+	}
+}

--- a/api-collector-java/springmvc/parser.go
+++ b/api-collector-java/springmvc/parser.go
@@ -5,18 +5,19 @@ import (
 	"strings"
 
 	"github.com/tangcent/apilot/api-collector-java/parser"
+	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
-// Parser extracts Spring MVC endpoints from parsed Java classes
 type Parser struct{}
 
-// NewParser creates a new Spring MVC parser
 func NewParser() *Parser {
 	return &Parser{}
 }
 
-// ExtractControllers extracts Spring MVC controllers from parse results
 func (p *Parser) ExtractControllers(results []parser.ParseResult) []Controller {
+	classRegistry := buildClassRegistry(results)
+	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
+
 	var controllers []Controller
 
 	for _, result := range results {
@@ -25,7 +26,7 @@ func (p *Parser) ExtractControllers(results []parser.ParseResult) []Controller {
 		}
 
 		for _, class := range result.Classes {
-			if controller := p.extractController(class); controller != nil {
+			if controller := p.extractController(class, typeResolver, classRegistry); controller != nil {
 				controllers = append(controllers, *controller)
 			}
 		}
@@ -34,20 +35,48 @@ func (p *Parser) ExtractControllers(results []parser.ParseResult) []Controller {
 	return controllers
 }
 
-// extractController extracts a controller if the class has @RestController or @Controller
-func (p *Parser) extractController(class parser.Class) *Controller {
+func buildClassRegistry(results []parser.ParseResult) map[string]parser.Class {
+	registry := make(map[string]parser.Class)
+	for _, result := range results {
+		if result.Error != nil {
+			continue
+		}
+		for _, class := range result.Classes {
+			registry[class.Name] = class
+		}
+	}
+	return registry
+}
+
+func flattenClasses(results []parser.ParseResult) []parser.Class {
+	var classes []parser.Class
+	for _, result := range results {
+		if result.Error != nil {
+			continue
+		}
+		classes = append(classes, result.Classes...)
+	}
+	return classes
+}
+
+func (p *Parser) extractController(class parser.Class, typeResolver *resolver.TypeResolver, classRegistry map[string]parser.Class) *Controller {
 	if !p.isController(class) {
 		return nil
 	}
 
 	basePath := p.extractBasePath(class.Annotations)
 
+	typeBindings := buildTypeBindings(class, classRegistry)
+
 	var endpoints []Endpoint
 	for _, method := range class.Methods {
-		if endpoint := p.extractEndpoint(method, basePath, class); endpoint != nil {
+		if endpoint := p.extractEndpoint(method, basePath, class, typeResolver, typeBindings); endpoint != nil {
 			endpoints = append(endpoints, *endpoint)
 		}
 	}
+
+	inheritedEndpoints := p.extractInheritedEndpoints(class, basePath, typeResolver, classRegistry, typeBindings)
+	endpoints = append(endpoints, inheritedEndpoints...)
 
 	return &Controller{
 		Name:      class.Name,
@@ -57,7 +86,97 @@ func (p *Parser) extractController(class parser.Class) *Controller {
 	}
 }
 
-// isController checks if a class is a Spring MVC controller
+func buildTypeBindings(class parser.Class, classRegistry map[string]parser.Class) map[string]string {
+	if class.SuperClass == "" {
+		return nil
+	}
+
+	superClass, found := classRegistry[class.SuperClass]
+	if !found {
+		return nil
+	}
+
+	bindings := make(map[string]string)
+	for i, tp := range superClass.TypeParameters {
+		if i < len(class.SuperClassTypeArgs) {
+			bindings[tp] = class.SuperClassTypeArgs[i]
+		}
+	}
+
+	return bindings
+}
+
+func (p *Parser) extractInheritedEndpoints(class parser.Class, basePath string, typeResolver *resolver.TypeResolver, classRegistry map[string]parser.Class, typeBindings map[string]string) []Endpoint {
+	if class.SuperClass == "" {
+		return nil
+	}
+
+	superClass, found := classRegistry[class.SuperClass]
+	if !found {
+		return nil
+	}
+
+	parentTypeBindings := buildTypeBindings(superClass, classRegistry)
+	mergedBindings := mergeBindings(parentTypeBindings, typeBindings)
+
+	var inherited []Endpoint
+
+	parentBasePath := p.extractBasePath(superClass.Annotations)
+	effectiveBasePath := basePath
+	if effectiveBasePath == "" && parentBasePath != "" {
+		effectiveBasePath = parentBasePath
+	}
+
+	for _, method := range superClass.Methods {
+		if !p.isEndpointMethod(method) {
+			continue
+		}
+
+		if p.isMethodOverridden(method.Name, class) {
+			continue
+		}
+
+		if endpoint := p.extractEndpoint(method, effectiveBasePath, class, typeResolver, mergedBindings); endpoint != nil {
+			inherited = append(inherited, *endpoint)
+		}
+	}
+
+	grandparentEndpoints := p.extractInheritedEndpoints(superClass, effectiveBasePath, typeResolver, classRegistry, mergedBindings)
+	inherited = append(inherited, grandparentEndpoints...)
+
+	return inherited
+}
+
+func mergeBindings(parent, child map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range parent {
+		merged[k] = v
+	}
+	for k, v := range child {
+		merged[k] = v
+	}
+	return merged
+}
+
+func (p *Parser) isEndpointMethod(method parser.Method) bool {
+	for _, ann := range method.Annotations {
+		switch ann.Name {
+		case "GetMapping", "PostMapping", "PutMapping", "DeleteMapping", "PatchMapping", "RequestMapping":
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Parser) isMethodOverridden(methodName string, class parser.Class) bool {
+	for _, m := range class.Methods {
+		if m.Name == methodName {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Parser) isController(class parser.Class) bool {
 	for _, ann := range class.Annotations {
 		if ann.Name == "RestController" || ann.Name == "Controller" {
@@ -67,7 +186,6 @@ func (p *Parser) isController(class parser.Class) bool {
 	return false
 }
 
-// extractBasePath extracts the base path from @RequestMapping on the class
 func (p *Parser) extractBasePath(annotations []parser.Annotation) string {
 	for _, ann := range annotations {
 		if ann.Name == "RequestMapping" {
@@ -82,8 +200,7 @@ func (p *Parser) extractBasePath(annotations []parser.Annotation) string {
 	return ""
 }
 
-// extractEndpoint extracts an endpoint from a method
-func (p *Parser) extractEndpoint(method parser.Method, basePath string, class parser.Class) *Endpoint {
+func (p *Parser) extractEndpoint(method parser.Method, basePath string, class parser.Class, typeResolver *resolver.TypeResolver, typeBindings map[string]string) *Endpoint {
 	httpMethod, methodPath := p.extractMethodInfo(method.Annotations)
 	if httpMethod == "" {
 		return nil
@@ -92,13 +209,17 @@ func (p *Parser) extractEndpoint(method parser.Method, basePath string, class pa
 	fullPath := p.combinePaths(basePath, methodPath)
 
 	var params []EndpointParameter
+	var requestBodyType string
 	for _, param := range method.Parameters {
 		if ep := p.extractParameter(param); ep != nil {
 			params = append(params, *ep)
+			if ep.ParamType == "body" {
+				requestBodyType = param.Type
+			}
 		}
 	}
 
-	return &Endpoint{
+	endpoint := &Endpoint{
 		Path:       fullPath,
 		Method:     httpMethod,
 		MethodName: method.Name,
@@ -107,9 +228,19 @@ func (p *Parser) extractEndpoint(method parser.Method, basePath string, class pa
 		ClassName:  class.Name,
 		Package:    class.Package,
 	}
+
+	if requestBodyType != "" {
+		endpoint.RequestBodySchema = typeResolver.Resolve(requestBodyType, typeBindings)
+	}
+
+	if method.ReturnType != "" && method.ReturnType != "void" && method.ReturnType != "Void" {
+		resolvedType := unwrapSpringResponseType(method.ReturnType)
+		endpoint.ResponseSchema = typeResolver.Resolve(resolvedType, typeBindings)
+	}
+
+	return endpoint
 }
 
-// extractMethodInfo extracts HTTP method and path from method annotations
 func (p *Parser) extractMethodInfo(annotations []parser.Annotation) (HTTPMethod, string) {
 	for _, ann := range annotations {
 		switch ann.Name {
@@ -132,7 +263,6 @@ func (p *Parser) extractMethodInfo(annotations []parser.Annotation) (HTTPMethod,
 	return "", ""
 }
 
-// extractPathFromMapping extracts path from mapping annotation
 func (p *Parser) extractPathFromMapping(ann parser.Annotation) string {
 	if value, ok := ann.Params["value"]; ok {
 		return p.normalizePath(value)
@@ -143,7 +273,6 @@ func (p *Parser) extractPathFromMapping(ann parser.Annotation) string {
 	return ""
 }
 
-// extractHTTPMethodFromRequestMapping extracts HTTP method from @RequestMapping
 func (p *Parser) extractHTTPMethodFromRequestMapping(ann parser.Annotation) HTTPMethod {
 	if method, ok := ann.Params["method"]; ok {
 		method = strings.TrimPrefix(method, "RequestMethod.")
@@ -160,10 +289,9 @@ func (p *Parser) extractHTTPMethodFromRequestMapping(ann parser.Annotation) HTTP
 			return PATCH
 		}
 	}
-	return GET // Default to GET if not specified
+	return GET
 }
 
-// extractParameter extracts parameter information
 func (p *Parser) extractParameter(param parser.Parameter) *EndpointParameter {
 	paramType := p.detectParameterType(param.Annotations)
 	if paramType == "" {
@@ -174,10 +302,9 @@ func (p *Parser) extractParameter(param parser.Parameter) *EndpointParameter {
 		Name:      param.Name,
 		Type:      param.Type,
 		ParamType: paramType,
-		Required:  true, // Default to required
+		Required:  true,
 	}
 
-	// Extract additional info from annotations
 	for _, ann := range param.Annotations {
 		switch ann.Name {
 		case "RequestParam":
@@ -194,7 +321,6 @@ func (p *Parser) extractParameter(param parser.Parameter) *EndpointParameter {
 	return ep
 }
 
-// detectParameterType detects parameter type from annotations
 func (p *Parser) detectParameterType(annotations []parser.Annotation) string {
 	for _, ann := range annotations {
 		switch ann.Name {
@@ -211,13 +337,10 @@ func (p *Parser) detectParameterType(annotations []parser.Annotation) string {
 	return ""
 }
 
-// normalizePath normalizes a path string
 func (p *Parser) normalizePath(pathStr string) string {
-	// Remove quotes
 	pathStr = strings.Trim(pathStr, "\"")
 	pathStr = strings.Trim(pathStr, "'")
 
-	// Ensure leading slash
 	if pathStr != "" && !strings.HasPrefix(pathStr, "/") {
 		pathStr = "/" + pathStr
 	}
@@ -225,7 +348,6 @@ func (p *Parser) normalizePath(pathStr string) string {
 	return pathStr
 }
 
-// combinePaths combines base path and method path
 func (p *Parser) combinePaths(basePath, methodPath string) string {
 	if basePath == "" {
 		return methodPath
@@ -234,4 +356,11 @@ func (p *Parser) combinePaths(basePath, methodPath string) string {
 		return basePath
 	}
 	return path.Join(basePath, methodPath)
+}
+
+func unwrapSpringResponseType(rawType string) string {
+	if strings.HasPrefix(rawType, "ResponseEntity<") && strings.HasSuffix(rawType, ">") {
+		return rawType[len("ResponseEntity<") : len(rawType)-1]
+	}
+	return rawType
 }

--- a/api-collector-java/springmvc/parser_test.go
+++ b/api-collector-java/springmvc/parser_test.go
@@ -292,3 +292,30 @@ func TestParser_NonControllerClass(t *testing.T) {
 		t.Errorf("Expected 0 controllers, got %d", len(controllers))
 	}
 }
+
+func TestUnwrapSpringResponseType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"ResponseEntity<User>", "ResponseEntity<User>", "User"},
+		{"ResponseEntity<List<User>>", "ResponseEntity<List<User>>", "List<User>"},
+		{"ResponseEntity<Void>", "ResponseEntity<Void>", "Void"},
+		{"ResponseEntity<Map<String, Object>>", "ResponseEntity<Map<String, Object>>", "Map<String, Object>"},
+		{"non-ResponseEntity type", "User", "User"},
+		{"List<User>", "List<User>", "List<User>"},
+		{"plain String", "String", "String"},
+		{"ResponseEntity without generics", "ResponseEntity", "ResponseEntity"},
+		{"incomplete ResponseEntity", "ResponseEntity<User", "ResponseEntity<User"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unwrapSpringResponseType(tt.input)
+			if result != tt.expected {
+				t.Errorf("unwrapSpringResponseType(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/api-collector-java/springmvc/types.go
+++ b/api-collector-java/springmvc/types.go
@@ -1,6 +1,8 @@
 // Package springmvc provides Spring MVC specific API extraction.
 package springmvc
 
+import model "github.com/tangcent/apilot/api-model"
+
 // HTTPMethod represents HTTP methods
 type HTTPMethod string
 
@@ -14,22 +16,24 @@ const (
 
 // EndpointParameter represents a parameter in an API endpoint
 type EndpointParameter struct {
-	Name        string
-	Type        string
-	ParamType   string // path, query, body, header
-	Required    bool
+	Name         string
+	Type         string
+	ParamType    string
+	Required     bool
 	DefaultValue string
 }
 
 // Endpoint represents a REST API endpoint
 type Endpoint struct {
-	Path       string
-	Method     HTTPMethod
-	MethodName string
-	Parameters []EndpointParameter
-	ReturnType string
-	ClassName  string
-	Package    string
+	Path              string
+	Method            HTTPMethod
+	MethodName        string
+	Parameters        []EndpointParameter
+	ReturnType        string
+	ClassName         string
+	Package           string
+	RequestBodySchema *model.ObjectModel
+	ResponseSchema    *model.ObjectModel
 }
 
 // Controller represents a Spring MVC controller with its endpoints

--- a/api-collector-java/testdata/BaseController.java
+++ b/api-collector-java/testdata/BaseController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/base")
+public class BaseController {
+
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "OK";
+    }
+}

--- a/api-collector-java/testdata/BaseCrudController.java
+++ b/api-collector-java/testdata/BaseCrudController.java
@@ -1,0 +1,35 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.demo.model.Result;
+import com.example.demo.model.PageResult;
+
+@RestController
+public class BaseCrudController<Req, Res> {
+
+    @PostMapping
+    public Result<Res> create(@RequestBody Req request) {
+        return new Result<>();
+    }
+
+    @GetMapping("/{id}")
+    public Result<Res> getById(@PathVariable Long id) {
+        return new Result<>();
+    }
+
+    @GetMapping
+    public PageResult<Res> list(@RequestParam(defaultValue = "0") int page,
+                                @RequestParam(defaultValue = "10") int size) {
+        return new PageResult<>();
+    }
+
+    @PutMapping("/{id}")
+    public Result<Res> update(@PathVariable Long id, @RequestBody Req request) {
+        return new Result<>();
+    }
+
+    @DeleteMapping("/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        return new Result<>();
+    }
+}

--- a/api-collector-java/testdata/CreateOrderReq.java
+++ b/api-collector-java/testdata/CreateOrderReq.java
@@ -1,0 +1,23 @@
+package com.example.demo.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class CreateOrderReq {
+    private String orderId;
+    private String customerName;
+    private double amount;
+    private List<String> items;
+    private Map<String, String> metadata;
+
+    public String getOrderId() { return orderId; }
+    public void setOrderId(String orderId) { this.orderId = orderId; }
+    public String getCustomerName() { return customerName; }
+    public void setCustomerName(String customerName) { this.customerName = customerName; }
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+    public List<String> getItems() { return items; }
+    public void setItems(List<String> items) { this.items = items; }
+    public Map<String, String> getMetadata() { return metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+}

--- a/api-collector-java/testdata/GenericBaseController.java
+++ b/api-collector-java/testdata/GenericBaseController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.demo.model.Result;
+
+@RestController
+public class GenericBaseController<R> {
+
+    @GetMapping("/info")
+    public Result<R> getInfo() {
+        return new Result<>();
+    }
+}

--- a/api-collector-java/testdata/OrderController.java
+++ b/api-collector-java/testdata/OrderController.java
@@ -1,0 +1,15 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.demo.model.CreateOrderReq;
+import com.example.demo.model.OrderVO;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController extends BaseCrudController<CreateOrderReq, OrderVO> {
+
+    @GetMapping("/search")
+    public OrderVO searchByName(@RequestParam String name) {
+        return new OrderVO();
+    }
+}

--- a/api-collector-java/testdata/OrderVO.java
+++ b/api-collector-java/testdata/OrderVO.java
@@ -1,0 +1,26 @@
+package com.example.demo.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class OrderVO {
+    private Long id;
+    private String orderId;
+    private String customerName;
+    private double total;
+    private List<String> tags;
+    private Map<String, Object> attributes;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getOrderId() { return orderId; }
+    public void setOrderId(String orderId) { this.orderId = orderId; }
+    public String getCustomerName() { return customerName; }
+    public void setCustomerName(String customerName) { this.customerName = customerName; }
+    public double getTotal() { return total; }
+    public void setTotal(double total) { this.total = total; }
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags = tags; }
+    public Map<String, Object> getAttributes() { return attributes; }
+    public void setAttributes(Map<String, Object> attributes) { this.attributes = attributes; }
+}

--- a/api-collector-java/testdata/PageResult.java
+++ b/api-collector-java/testdata/PageResult.java
@@ -1,0 +1,19 @@
+package com.example.demo.model;
+
+import java.util.List;
+
+public class PageResult<T> {
+    private long total;
+    private int page;
+    private int size;
+    private List<T> items;
+
+    public long getTotal() { return total; }
+    public void setTotal(long total) { this.total = total; }
+    public int getPage() { return page; }
+    public void setPage(int page) { this.page = page; }
+    public int getSize() { return size; }
+    public void setSize(int size) { this.size = size; }
+    public List<T> getItems() { return items; }
+    public void setItems(List<T> items) { this.items = items; }
+}

--- a/api-collector-java/testdata/Result.java
+++ b/api-collector-java/testdata/Result.java
@@ -1,0 +1,14 @@
+package com.example.demo.model;
+
+public class Result<T> {
+    private int code;
+    private String message;
+    private T data;
+
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public T getData() { return data; }
+    public void setData(T data) { this.data = data; }
+}

--- a/api-formatter-markdown/formatter_test.go
+++ b/api-formatter-markdown/formatter_test.go
@@ -308,12 +308,9 @@ func TestFormat_AllFields(t *testing.T) {
 			},
 			RequestBody: &model.ApiBody{
 				MediaType: "application/json",
-				Schema: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"name": map[string]string{"type": "string"},
-					},
-				},
+				Body: model.ObjectModelFrom(map[string]*model.FieldModel{
+					"name": {Model: model.SingleModel(model.JsonTypeString)},
+				}),
 				Example: map[string]interface{}{"name": "Updated Name"},
 			},
 			Response: &model.ApiBody{

--- a/api-model/model.go
+++ b/api-model/model.go
@@ -10,8 +10,8 @@ type ApiEndpoint struct {
 	Description string         `json:"description,omitempty"`
 	Tags        []string       `json:"tags,omitempty"`
 	Path        string         `json:"path"`
-	Method      string         `json:"method,omitempty"`   // empty for non-HTTP protocols
-	Protocol    string         `json:"protocol"`           // "http", "grpc", "websocket", etc.
+	Method      string         `json:"method,omitempty"` // empty for non-HTTP protocols
+	Protocol    string         `json:"protocol"`         // "http", "grpc", "websocket", etc.
 	Parameters  []ApiParameter `json:"parameters,omitempty"`
 	Headers     []ApiHeader    `json:"headers,omitempty"`
 	RequestBody *ApiBody       `json:"requestBody,omitempty"`
@@ -23,9 +23,9 @@ type ApiEndpoint struct {
 // ApiParameter describes a single input parameter of an endpoint.
 type ApiParameter struct {
 	Name        string   `json:"name"`
-	Type        string   `json:"type"`              // "text" | "file"
+	Type        string   `json:"type"` // "text" | "file"
 	Required    bool     `json:"required"`
-	In          string   `json:"in"`                // "query" | "path" | "header" | "cookie" | "body" | "form"
+	In          string   `json:"in"` // "query" | "path" | "header" | "cookie" | "body" | "form"
 	Default     string   `json:"default,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Example     string   `json:"example,omitempty"`
@@ -41,9 +41,172 @@ type ApiHeader struct {
 	Required    bool   `json:"required"`
 }
 
+// ObjectModelKind represents the kind of type model.
+type ObjectModelKind string
+
+const (
+	KindSingle ObjectModelKind = "single"
+	KindObject ObjectModelKind = "object"
+	KindArray  ObjectModelKind = "array"
+	KindMap    ObjectModelKind = "map"
+	KindRef    ObjectModelKind = "ref"
+)
+
+const (
+	JsonTypeString  = "string"
+	JsonTypeInt     = "int"
+	JsonTypeLong    = "long"
+	JsonTypeFloat   = "float"
+	JsonTypeDouble  = "double"
+	JsonTypeBoolean = "boolean"
+	JsonTypeNull    = "null"
+)
+
+type ObjectModel struct {
+	Kind       ObjectModelKind        `json:"kind"`
+	TypeName   string                 `json:"typeName"`
+	Fields     map[string]*FieldModel `json:"fields,omitempty"`
+	Items      *ObjectModel           `json:"items,omitempty"`
+	KeyModel   *ObjectModel           `json:"keyModel,omitempty"`
+	ValueModel *ObjectModel           `json:"valueModel,omitempty"`
+}
+
+type FieldModel struct {
+	Model        *ObjectModel   `json:"model"`
+	Comment      string         `json:"comment,omitempty"`
+	Required     bool           `json:"required"`
+	DefaultValue string         `json:"defaultValue,omitempty"`
+	Options      []FieldOption  `json:"options,omitempty"`
+	Demo         string         `json:"demo,omitempty"`
+	Advanced     map[string]any `json:"advanced,omitempty"`
+	Generic      bool           `json:"generic,omitempty"`
+}
+
+type FieldOption struct {
+	Value any    `json:"value"`
+	Desc  string `json:"desc,omitempty"`
+}
+
+func SingleModel(typeName string) *ObjectModel {
+	return &ObjectModel{Kind: KindSingle, TypeName: typeName}
+}
+
+func ObjectModelFrom(fields map[string]*FieldModel) *ObjectModel {
+	return &ObjectModel{Kind: KindObject, TypeName: "object", Fields: fields}
+}
+
+func ArrayModel(item *ObjectModel) *ObjectModel {
+	return &ObjectModel{Kind: KindArray, TypeName: "array", Items: item}
+}
+
+func MapModel(key, value *ObjectModel) *ObjectModel {
+	return &ObjectModel{Kind: KindMap, TypeName: "map", KeyModel: key, ValueModel: value}
+}
+
+func RefModel(typeName string) *ObjectModel {
+	return &ObjectModel{Kind: KindRef, TypeName: typeName}
+}
+
+func NullModel() *ObjectModel {
+	return SingleModel(JsonTypeNull)
+}
+
+func EmptyObject() *ObjectModel {
+	return &ObjectModel{Kind: KindObject, TypeName: "object", Fields: map[string]*FieldModel{}}
+}
+
+func (m *ObjectModel) IsSingle() bool { return m != nil && m.Kind == KindSingle }
+func (m *ObjectModel) IsObject() bool { return m != nil && m.Kind == KindObject }
+func (m *ObjectModel) IsArray() bool  { return m != nil && m.Kind == KindArray }
+func (m *ObjectModel) IsMap() bool    { return m != nil && m.Kind == KindMap }
+func (m *ObjectModel) IsRef() bool    { return m != nil && m.Kind == KindRef }
+
+type FieldOpt func(*FieldModel)
+
+func WithComment(c string) FieldOpt {
+	return func(f *FieldModel) { f.Comment = c }
+}
+
+func WithRequired(r bool) FieldOpt {
+	return func(f *FieldModel) { f.Required = r }
+}
+
+func WithDefault(d string) FieldOpt {
+	return func(f *FieldModel) { f.DefaultValue = d }
+}
+
+func WithDemo(d string) FieldOpt {
+	return func(f *FieldModel) { f.Demo = d }
+}
+
+func WithGeneric(g bool) FieldOpt {
+	return func(f *FieldModel) { f.Generic = g }
+}
+
+type ObjectModelBuilder struct {
+	fields map[string]*FieldModel
+}
+
+func NewObjectModelBuilder() *ObjectModelBuilder {
+	return &ObjectModelBuilder{fields: make(map[string]*FieldModel)}
+}
+
+func (b *ObjectModelBuilder) Field(name string, model *ObjectModel, opts ...FieldOpt) *ObjectModelBuilder {
+	fm := &FieldModel{Model: model}
+	for _, opt := range opts {
+		opt(fm)
+	}
+	b.fields[name] = fm
+	return b
+}
+
+func (b *ObjectModelBuilder) StringField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeString), opts...)
+}
+
+func (b *ObjectModelBuilder) IntField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeInt), opts...)
+}
+
+func (b *ObjectModelBuilder) LongField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeLong), opts...)
+}
+
+func (b *ObjectModelBuilder) FloatField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeFloat), opts...)
+}
+
+func (b *ObjectModelBuilder) DoubleField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeDouble), opts...)
+}
+
+func (b *ObjectModelBuilder) BoolField(name string, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, SingleModel(JsonTypeBoolean), opts...)
+}
+
+func (b *ObjectModelBuilder) ArrayField(name string, itemType *ObjectModel, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, ArrayModel(itemType), opts...)
+}
+
+func (b *ObjectModelBuilder) ObjectField(name string, obj *ObjectModel, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, obj, opts...)
+}
+
+func (b *ObjectModelBuilder) MapField(name string, key, value *ObjectModel, opts ...FieldOpt) *ObjectModelBuilder {
+	return b.Field(name, MapModel(key, value), opts...)
+}
+
+func (b *ObjectModelBuilder) Build() *ObjectModel {
+	fields := make(map[string]*FieldModel, len(b.fields))
+	for k, v := range b.fields {
+		fields[k] = v
+	}
+	return &ObjectModel{Kind: KindObject, TypeName: "object", Fields: fields}
+}
+
 // ApiBody describes the request or response body of an endpoint.
 type ApiBody struct {
-	MediaType string `json:"mediaType,omitempty"` // e.g. "application/json"
-	Schema    any    `json:"schema,omitempty"`    // JSON Schema object
-	Example   any    `json:"example,omitempty"`
+	MediaType string       `json:"mediaType,omitempty"`
+	Body      *ObjectModel `json:"body,omitempty"`
+	Example   any          `json:"example,omitempty"`
 }

--- a/api-model/model_test.go
+++ b/api-model/model_test.go
@@ -1,0 +1,604 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestSingleModel(t *testing.T) {
+	tests := []struct {
+		typeName     string
+		expectedKind ObjectModelKind
+	}{
+		{JsonTypeString, KindSingle},
+		{JsonTypeInt, KindSingle},
+		{JsonTypeLong, KindSingle},
+		{JsonTypeFloat, KindSingle},
+		{JsonTypeDouble, KindSingle},
+		{JsonTypeBoolean, KindSingle},
+		{JsonTypeNull, KindSingle},
+		{"CustomType", KindSingle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.typeName, func(t *testing.T) {
+			m := SingleModel(tt.typeName)
+			if m.Kind != tt.expectedKind {
+				t.Errorf("Expected kind %s, got %s", tt.expectedKind, m.Kind)
+			}
+			if m.TypeName != tt.typeName {
+				t.Errorf("Expected typeName %s, got %s", tt.typeName, m.TypeName)
+			}
+			if m.Fields != nil {
+				t.Errorf("Expected nil Fields, got %v", m.Fields)
+			}
+			if m.Items != nil {
+				t.Errorf("Expected nil Items, got %v", m.Items)
+			}
+		})
+	}
+}
+
+func TestObjectModelFrom(t *testing.T) {
+	fields := map[string]*FieldModel{
+		"id":   {Model: SingleModel(JsonTypeLong)},
+		"name": {Model: SingleModel(JsonTypeString)},
+	}
+
+	m := ObjectModelFrom(fields)
+
+	if m.Kind != KindObject {
+		t.Errorf("Expected kind %s, got %s", KindObject, m.Kind)
+	}
+	if m.TypeName != "object" {
+		t.Errorf("Expected typeName 'object', got %s", m.TypeName)
+	}
+	if len(m.Fields) != 2 {
+		t.Errorf("Expected 2 fields, got %d", len(m.Fields))
+	}
+	if m.Fields["id"] == nil || m.Fields["name"] == nil {
+		t.Error("Expected id and name fields to be present")
+	}
+}
+
+func TestObjectModelFrom_Empty(t *testing.T) {
+	m := ObjectModelFrom(nil)
+
+	if m.Kind != KindObject {
+		t.Errorf("Expected kind %s, got %s", KindObject, m.Kind)
+	}
+	if m.Fields != nil {
+		t.Errorf("Expected nil Fields for nil input, got %v", m.Fields)
+	}
+}
+
+func TestArrayModel(t *testing.T) {
+	item := SingleModel(JsonTypeString)
+	m := ArrayModel(item)
+
+	if m.Kind != KindArray {
+		t.Errorf("Expected kind %s, got %s", KindArray, m.Kind)
+	}
+	if m.TypeName != "array" {
+		t.Errorf("Expected typeName 'array', got %s", m.TypeName)
+	}
+	if m.Items != item {
+		t.Error("Expected Items to be the provided item model")
+	}
+	if m.Fields != nil {
+		t.Errorf("Expected nil Fields, got %v", m.Fields)
+	}
+}
+
+func TestArrayModel_NilItem(t *testing.T) {
+	m := ArrayModel(nil)
+
+	if m.Kind != KindArray {
+		t.Errorf("Expected kind %s, got %s", KindArray, m.Kind)
+	}
+	if m.Items != nil {
+		t.Errorf("Expected nil Items, got %v", m.Items)
+	}
+}
+
+func TestMapModel(t *testing.T) {
+	key := SingleModel(JsonTypeString)
+	value := SingleModel(JsonTypeInt)
+	m := MapModel(key, value)
+
+	if m.Kind != KindMap {
+		t.Errorf("Expected kind %s, got %s", KindMap, m.Kind)
+	}
+	if m.TypeName != "map" {
+		t.Errorf("Expected typeName 'map', got %s", m.TypeName)
+	}
+	if m.KeyModel != key {
+		t.Error("Expected KeyModel to be the provided key model")
+	}
+	if m.ValueModel != value {
+		t.Error("Expected ValueModel to be the provided value model")
+	}
+}
+
+func TestRefModel(t *testing.T) {
+	m := RefModel("User")
+
+	if m.Kind != KindRef {
+		t.Errorf("Expected kind %s, got %s", KindRef, m.Kind)
+	}
+	if m.TypeName != "User" {
+		t.Errorf("Expected typeName 'User', got %s", m.TypeName)
+	}
+}
+
+func TestNullModel(t *testing.T) {
+	m := NullModel()
+
+	if m.Kind != KindSingle {
+		t.Errorf("Expected kind %s, got %s", KindSingle, m.Kind)
+	}
+	if m.TypeName != JsonTypeNull {
+		t.Errorf("Expected typeName %s, got %s", JsonTypeNull, m.TypeName)
+	}
+}
+
+func TestEmptyObject(t *testing.T) {
+	m := EmptyObject()
+
+	if m.Kind != KindObject {
+		t.Errorf("Expected kind %s, got %s", KindObject, m.Kind)
+	}
+	if m.TypeName != "object" {
+		t.Errorf("Expected typeName 'object', got %s", m.TypeName)
+	}
+	if m.Fields == nil {
+		t.Error("Expected non-nil Fields for EmptyObject")
+	}
+	if len(m.Fields) != 0 {
+		t.Errorf("Expected 0 fields, got %d", len(m.Fields))
+	}
+}
+
+func TestObjectModel_IsMethods(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    *ObjectModel
+		isSingle bool
+		isObject bool
+		isArray  bool
+		isMap    bool
+		isRef    bool
+	}{
+		{"single", SingleModel("string"), true, false, false, false, false},
+		{"object", EmptyObject(), false, true, false, false, false},
+		{"array", ArrayModel(SingleModel("int")), false, false, true, false, false},
+		{"map", MapModel(SingleModel("string"), SingleModel("int")), false, false, false, true, false},
+		{"ref", RefModel("User"), false, false, false, false, true},
+		{"nil", nil, false, false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.model.IsSingle() != tt.isSingle {
+				t.Errorf("IsSingle() = %v, want %v", tt.model.IsSingle(), tt.isSingle)
+			}
+			if tt.model.IsObject() != tt.isObject {
+				t.Errorf("IsObject() = %v, want %v", tt.model.IsObject(), tt.isObject)
+			}
+			if tt.model.IsArray() != tt.isArray {
+				t.Errorf("IsArray() = %v, want %v", tt.model.IsArray(), tt.isArray)
+			}
+			if tt.model.IsMap() != tt.isMap {
+				t.Errorf("IsMap() = %v, want %v", tt.model.IsMap(), tt.isMap)
+			}
+			if tt.model.IsRef() != tt.isRef {
+				t.Errorf("IsRef() = %v, want %v", tt.model.IsRef(), tt.isRef)
+			}
+		})
+	}
+}
+
+func TestFieldOpts(t *testing.T) {
+	t.Run("WithComment", func(t *testing.T) {
+		fm := &FieldModel{}
+		WithComment("test comment")(fm)
+		if fm.Comment != "test comment" {
+			t.Errorf("Expected comment 'test comment', got %s", fm.Comment)
+		}
+	})
+
+	t.Run("WithRequired", func(t *testing.T) {
+		fm := &FieldModel{}
+		WithRequired(true)(fm)
+		if fm.Required != true {
+			t.Errorf("Expected Required true, got %v", fm.Required)
+		}
+		WithRequired(false)(fm)
+		if fm.Required != false {
+			t.Errorf("Expected Required false, got %v", fm.Required)
+		}
+	})
+
+	t.Run("WithDefault", func(t *testing.T) {
+		fm := &FieldModel{}
+		WithDefault("default_value")(fm)
+		if fm.DefaultValue != "default_value" {
+			t.Errorf("Expected DefaultValue 'default_value', got %s", fm.DefaultValue)
+		}
+	})
+
+	t.Run("WithDemo", func(t *testing.T) {
+		fm := &FieldModel{}
+		WithDemo("demo_value")(fm)
+		if fm.Demo != "demo_value" {
+			t.Errorf("Expected Demo 'demo_value', got %s", fm.Demo)
+		}
+	})
+
+	t.Run("WithGeneric", func(t *testing.T) {
+		fm := &FieldModel{}
+		WithGeneric(true)(fm)
+		if fm.Generic != true {
+			t.Errorf("Expected Generic true, got %v", fm.Generic)
+		}
+		WithGeneric(false)(fm)
+		if fm.Generic != false {
+			t.Errorf("Expected Generic false, got %v", fm.Generic)
+		}
+	})
+}
+
+func TestObjectModelBuilder(t *testing.T) {
+	t.Run("basic field", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.Field("custom", SingleModel("CustomType"))
+		m := b.Build()
+
+		if m.Kind != KindObject {
+			t.Errorf("Expected kind %s, got %s", KindObject, m.Kind)
+		}
+		if len(m.Fields) != 1 {
+			t.Errorf("Expected 1 field, got %d", len(m.Fields))
+		}
+		if m.Fields["custom"] == nil {
+			t.Fatal("Expected 'custom' field")
+		}
+		if m.Fields["custom"].Model.TypeName != "CustomType" {
+			t.Errorf("Expected typeName 'CustomType', got %s", m.Fields["custom"].Model.TypeName)
+		}
+	})
+
+	t.Run("StringField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.StringField("name")
+		m := b.Build()
+
+		if m.Fields["name"] == nil {
+			t.Fatal("Expected 'name' field")
+		}
+		if m.Fields["name"].Model.Kind != KindSingle {
+			t.Errorf("Expected KindSingle, got %s", m.Fields["name"].Model.Kind)
+		}
+		if m.Fields["name"].Model.TypeName != JsonTypeString {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeString, m.Fields["name"].Model.TypeName)
+		}
+	})
+
+	t.Run("IntField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.IntField("age")
+		m := b.Build()
+
+		if m.Fields["age"].Model.TypeName != JsonTypeInt {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeInt, m.Fields["age"].Model.TypeName)
+		}
+	})
+
+	t.Run("LongField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.LongField("id")
+		m := b.Build()
+
+		if m.Fields["id"].Model.TypeName != JsonTypeLong {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeLong, m.Fields["id"].Model.TypeName)
+		}
+	})
+
+	t.Run("FloatField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.FloatField("price")
+		m := b.Build()
+
+		if m.Fields["price"].Model.TypeName != JsonTypeFloat {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeFloat, m.Fields["price"].Model.TypeName)
+		}
+	})
+
+	t.Run("DoubleField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.DoubleField("amount")
+		m := b.Build()
+
+		if m.Fields["amount"].Model.TypeName != JsonTypeDouble {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeDouble, m.Fields["amount"].Model.TypeName)
+		}
+	})
+
+	t.Run("BoolField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.BoolField("active")
+		m := b.Build()
+
+		if m.Fields["active"].Model.TypeName != JsonTypeBoolean {
+			t.Errorf("Expected typeName %s, got %s", JsonTypeBoolean, m.Fields["active"].Model.TypeName)
+		}
+	})
+
+	t.Run("ArrayField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.ArrayField("tags", SingleModel(JsonTypeString))
+		m := b.Build()
+
+		if m.Fields["tags"].Model.Kind != KindArray {
+			t.Errorf("Expected KindArray, got %s", m.Fields["tags"].Model.Kind)
+		}
+		if m.Fields["tags"].Model.Items == nil {
+			t.Fatal("Expected non-nil Items")
+		}
+		if m.Fields["tags"].Model.Items.TypeName != JsonTypeString {
+			t.Errorf("Expected Items typeName %s, got %s", JsonTypeString, m.Fields["tags"].Model.Items.TypeName)
+		}
+	})
+
+	t.Run("ObjectField", func(t *testing.T) {
+		nested := NewObjectModelBuilder().
+			StringField("street").
+			StringField("city").
+			Build()
+
+		b := NewObjectModelBuilder()
+		b.ObjectField("address", nested)
+		m := b.Build()
+
+		if m.Fields["address"].Model.Kind != KindObject {
+			t.Errorf("Expected KindObject, got %s", m.Fields["address"].Model.Kind)
+		}
+		if len(m.Fields["address"].Model.Fields) != 2 {
+			t.Errorf("Expected 2 nested fields, got %d", len(m.Fields["address"].Model.Fields))
+		}
+	})
+
+	t.Run("MapField", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.MapField("metadata", SingleModel(JsonTypeString), SingleModel(JsonTypeString))
+		m := b.Build()
+
+		if m.Fields["metadata"].Model.Kind != KindMap {
+			t.Errorf("Expected KindMap, got %s", m.Fields["metadata"].Model.Kind)
+		}
+		if m.Fields["metadata"].Model.KeyModel.TypeName != JsonTypeString {
+			t.Errorf("Expected KeyModel typeName %s, got %s", JsonTypeString, m.Fields["metadata"].Model.KeyModel.TypeName)
+		}
+		if m.Fields["metadata"].Model.ValueModel.TypeName != JsonTypeString {
+			t.Errorf("Expected ValueModel typeName %s, got %s", JsonTypeString, m.Fields["metadata"].Model.ValueModel.TypeName)
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.StringField("name", WithComment("user name"), WithRequired(true), WithDemo("John"))
+		m := b.Build()
+
+		f := m.Fields["name"]
+		if f.Comment != "user name" {
+			t.Errorf("Expected comment 'user name', got %s", f.Comment)
+		}
+		if f.Required != true {
+			t.Errorf("Expected Required true, got %v", f.Required)
+		}
+		if f.Demo != "John" {
+			t.Errorf("Expected Demo 'John', got %s", f.Demo)
+		}
+	})
+
+	t.Run("multiple fields", func(t *testing.T) {
+		m := NewObjectModelBuilder().
+			LongField("id").
+			StringField("name", WithComment("user name")).
+			BoolField("active", WithDefault("true")).
+			ArrayField("tags", SingleModel(JsonTypeString)).
+			Build()
+
+		if len(m.Fields) != 4 {
+			t.Errorf("Expected 4 fields, got %d", len(m.Fields))
+		}
+	})
+
+	t.Run("build returns copy", func(t *testing.T) {
+		b := NewObjectModelBuilder()
+		b.StringField("name")
+		m1 := b.Build()
+		b.StringField("email")
+		m2 := b.Build()
+
+		if len(m1.Fields) != 1 {
+			t.Errorf("First build should have 1 field, got %d", len(m1.Fields))
+		}
+		if len(m2.Fields) != 2 {
+			t.Errorf("Second build should have 2 fields, got %d", len(m2.Fields))
+		}
+	})
+}
+
+func TestFieldModel(t *testing.T) {
+	t.Run("all fields", func(t *testing.T) {
+		fm := &FieldModel{
+			Model:        SingleModel(JsonTypeString),
+			Comment:      "test comment",
+			Required:     true,
+			DefaultValue: "default",
+			Options: []FieldOption{
+				{Value: "opt1", Desc: "option 1"},
+				{Value: "opt2", Desc: "option 2"},
+			},
+			Demo:     "demo",
+			Advanced: map[string]any{"key": "value"},
+			Generic:  true,
+		}
+
+		if fm.Model == nil {
+			t.Error("Expected non-nil Model")
+		}
+		if fm.Comment != "test comment" {
+			t.Errorf("Expected comment 'test comment', got %s", fm.Comment)
+		}
+		if !fm.Required {
+			t.Error("Expected Required true")
+		}
+		if fm.DefaultValue != "default" {
+			t.Errorf("Expected DefaultValue 'default', got %s", fm.DefaultValue)
+		}
+		if len(fm.Options) != 2 {
+			t.Errorf("Expected 2 options, got %d", len(fm.Options))
+		}
+		if fm.Demo != "demo" {
+			t.Errorf("Expected Demo 'demo', got %s", fm.Demo)
+		}
+		if fm.Advanced["key"] != "value" {
+			t.Error("Expected Advanced key=value")
+		}
+		if !fm.Generic {
+			t.Error("Expected Generic true")
+		}
+	})
+}
+
+func TestApiBody(t *testing.T) {
+	t.Run("with body", func(t *testing.T) {
+		body := &ApiBody{
+			MediaType: "application/json",
+			Body:      SingleModel("User"),
+			Example:   map[string]string{"id": "1", "name": "test"},
+		}
+
+		if body.MediaType != "application/json" {
+			t.Errorf("Expected MediaType 'application/json', got %s", body.MediaType)
+		}
+		if body.Body == nil {
+			t.Error("Expected non-nil Body")
+		}
+		if body.Body.TypeName != "User" {
+			t.Errorf("Expected Body typeName 'User', got %s", body.Body.TypeName)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		body := &ApiBody{}
+
+		if body.MediaType != "" {
+			t.Errorf("Expected empty MediaType, got %s", body.MediaType)
+		}
+		if body.Body != nil {
+			t.Error("Expected nil Body")
+		}
+	})
+}
+
+func TestApiEndpoint(t *testing.T) {
+	ep := ApiEndpoint{
+		Name:        "getUser",
+		Folder:      "UserController",
+		Description: "Get user by ID",
+		Tags:        []string{"user", "read"},
+		Path:        "/users/{id}",
+		Method:      "GET",
+		Protocol:    "http",
+		Parameters: []ApiParameter{
+			{Name: "id", Type: "text", Required: true, In: "path"},
+		},
+		Headers: []ApiHeader{
+			{Name: "Authorization", Value: "Bearer token", Required: true},
+		},
+		RequestBody: &ApiBody{MediaType: "application/json"},
+		Response:    &ApiBody{MediaType: "application/json", Body: SingleModel("User")},
+		Metadata:    map[string]any{"version": "1.0"},
+	}
+
+	if ep.Name != "getUser" {
+		t.Errorf("Expected Name 'getUser', got %s", ep.Name)
+	}
+	if len(ep.Tags) != 2 {
+		t.Errorf("Expected 2 tags, got %d", len(ep.Tags))
+	}
+	if len(ep.Parameters) != 1 {
+		t.Errorf("Expected 1 parameter, got %d", len(ep.Parameters))
+	}
+	if len(ep.Headers) != 1 {
+		t.Errorf("Expected 1 header, got %d", len(ep.Headers))
+	}
+	if ep.Metadata["version"] != "1.0" {
+		t.Error("Expected Metadata version=1.0")
+	}
+}
+
+func TestApiParameter(t *testing.T) {
+	p := ApiParameter{
+		Name:        "id",
+		Type:        "text",
+		Required:    true,
+		In:          "path",
+		Default:     "1",
+		Description: "User ID",
+		Example:     "123",
+		Enum:        []string{"1", "2", "3"},
+	}
+
+	if p.Name != "id" {
+		t.Errorf("Expected Name 'id', got %s", p.Name)
+	}
+	if p.Type != "text" {
+		t.Errorf("Expected Type 'text', got %s", p.Type)
+	}
+	if !p.Required {
+		t.Error("Expected Required true")
+	}
+	if p.In != "path" {
+		t.Errorf("Expected In 'path', got %s", p.In)
+	}
+	if len(p.Enum) != 3 {
+		t.Errorf("Expected 3 enum values, got %d", len(p.Enum))
+	}
+}
+
+func TestApiHeader(t *testing.T) {
+	h := ApiHeader{
+		Name:        "Authorization",
+		Value:       "Bearer token",
+		Description: "Auth header",
+		Example:     "Bearer xxx",
+		Required:    true,
+	}
+
+	if h.Name != "Authorization" {
+		t.Errorf("Expected Name 'Authorization', got %s", h.Name)
+	}
+	if h.Value != "Bearer token" {
+		t.Errorf("Expected Value 'Bearer token', got %s", h.Value)
+	}
+	if !h.Required {
+		t.Error("Expected Required true")
+	}
+}
+
+func TestFieldOption(t *testing.T) {
+	opt := FieldOption{
+		Value: "active",
+		Desc:  "Active status",
+	}
+
+	if opt.Value != "active" {
+		t.Errorf("Expected Value 'active', got %v", opt.Value)
+	}
+	if opt.Desc != "Active status" {
+		t.Errorf("Expected Desc 'Active status', got %s", opt.Desc)
+	}
+}

--- a/samples/java-springmvc/src/main/java/com/example/controller/BaseController.java
+++ b/samples/java-springmvc/src/main/java/com/example/controller/BaseController.java
@@ -1,0 +1,13 @@
+package com.example.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/base")
+public class BaseController {
+
+    @GetMapping("/health")
+    public String healthCheck() {
+        return "OK";
+    }
+}

--- a/samples/java-springmvc/src/main/java/com/example/controller/BaseCrudController.java
+++ b/samples/java-springmvc/src/main/java/com/example/controller/BaseCrudController.java
@@ -1,0 +1,35 @@
+package com.example.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.model.Result;
+import com.example.model.PageResult;
+
+@RestController
+public class BaseCrudController<Req, Res> {
+
+    @PostMapping
+    public Result<Res> create(@RequestBody Req request) {
+        return new Result<>();
+    }
+
+    @GetMapping("/{id}")
+    public Result<Res> getById(@PathVariable Long id) {
+        return new Result<>();
+    }
+
+    @GetMapping
+    public PageResult<Res> list(@RequestParam(defaultValue = "0") int page,
+                                @RequestParam(defaultValue = "10") int size) {
+        return new PageResult<>();
+    }
+
+    @PutMapping("/{id}")
+    public Result<Res> update(@PathVariable Long id, @RequestBody Req request) {
+        return new Result<>();
+    }
+
+    @DeleteMapping("/{id}")
+    public Result<Void> delete(@PathVariable Long id) {
+        return new Result<>();
+    }
+}

--- a/samples/java-springmvc/src/main/java/com/example/controller/GenericBaseController.java
+++ b/samples/java-springmvc/src/main/java/com/example/controller/GenericBaseController.java
@@ -1,0 +1,13 @@
+package com.example.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.model.Result;
+
+@RestController
+public class GenericBaseController<R> {
+
+    @GetMapping("/info")
+    public Result<R> getInfo() {
+        return new Result<>();
+    }
+}

--- a/samples/java-springmvc/src/main/java/com/example/controller/OrderController.java
+++ b/samples/java-springmvc/src/main/java/com/example/controller/OrderController.java
@@ -1,0 +1,15 @@
+package com.example.controller;
+
+import org.springframework.web.bind.annotation.*;
+import com.example.model.CreateOrderReq;
+import com.example.model.OrderVO;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController extends BaseCrudController<CreateOrderReq, OrderVO> {
+
+    @GetMapping("/search")
+    public OrderVO searchByName(@RequestParam String name) {
+        return new OrderVO();
+    }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/CreateOrderReq.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/CreateOrderReq.java
@@ -1,0 +1,23 @@
+package com.example.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class CreateOrderReq {
+    private String orderId;
+    private String customerName;
+    private double amount;
+    private List<String> items;
+    private Map<String, String> metadata;
+
+    public String getOrderId() { return orderId; }
+    public void setOrderId(String orderId) { this.orderId = orderId; }
+    public String getCustomerName() { return customerName; }
+    public void setCustomerName(String customerName) { this.customerName = customerName; }
+    public double getAmount() { return amount; }
+    public void setAmount(double amount) { this.amount = amount; }
+    public List<String> getItems() { return items; }
+    public void setItems(List<String> items) { this.items = items; }
+    public Map<String, String> getMetadata() { return metadata; }
+    public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/OrderVO.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/OrderVO.java
@@ -1,0 +1,26 @@
+package com.example.model;
+
+import java.util.List;
+import java.util.Map;
+
+public class OrderVO {
+    private Long id;
+    private String orderId;
+    private String customerName;
+    private double total;
+    private List<String> tags;
+    private Map<String, Object> attributes;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getOrderId() { return orderId; }
+    public void setOrderId(String orderId) { this.orderId = orderId; }
+    public String getCustomerName() { return customerName; }
+    public void setCustomerName(String customerName) { this.customerName = customerName; }
+    public double getTotal() { return total; }
+    public void setTotal(double total) { this.total = total; }
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags = tags; }
+    public Map<String, Object> getAttributes() { return attributes; }
+    public void setAttributes(Map<String, Object> attributes) { this.attributes = attributes; }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/PageResult.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/PageResult.java
@@ -1,0 +1,19 @@
+package com.example.model;
+
+import java.util.List;
+
+public class PageResult<T> {
+    private long total;
+    private int page;
+    private int size;
+    private List<T> items;
+
+    public long getTotal() { return total; }
+    public void setTotal(long total) { this.total = total; }
+    public int getPage() { return page; }
+    public void setPage(int page) { this.page = page; }
+    public int getSize() { return size; }
+    public void setSize(int size) { this.size = size; }
+    public List<T> getItems() { return items; }
+    public void setItems(List<T> items) { this.items = items; }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/Result.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/Result.java
@@ -1,0 +1,14 @@
+package com.example.model;
+
+public class Result<T> {
+    private int code;
+    private String message;
+    private T data;
+
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public T getData() { return data; }
+    public void setData(T data) { this.data = data; }
+}


### PR DESCRIPTION
## Changes

- Remove ResponseEntity handling from generic TypeResolver
- Add unwrapSpringResponseType to Spring MVC parser for framework-specific handling
- Introduce ObjectModel type system for rich type representation
- Add comprehensive tests for api-model and resolver packages
- Update Go collectors (echo, fiber, gin) to use new ObjectModel

## Summary

This PR refactors the TypeResolver to be framework-agnostic by removing Spring-specific ResponseEntity handling from the generic resolver. The framework-specific type unwrapping is now handled at the parser layer where it belongs.

### Key Changes:
1. **TypeResolver is now framework-agnostic** - Only handles primitive types, collections, maps, and custom class resolution
2. **Spring MVC parser handles ResponseEntity** - Added \`unwrapSpringResponseType\` function for framework-specific handling
3. **New ObjectModel type system** - Rich, recursive type model for representing complex types
4. **Comprehensive test coverage** - Added tests for api-model and resolver packages