### PR TITLE
fix: resolve inherited Java model fields

### DIFF
--- a/api-collector-java/collector_test.go
+++ b/api-collector-java/collector_test.go
@@ -423,4 +423,100 @@ func TestCollect_SchemaResolution_GenericBaseController(t *testing.T) {
 	if dataField.Model == nil {
 		t.Fatal("Expected 'data' field to have a model")
 	}
+	if !dataField.Generic {
+		t.Error("Expected 'data' field to be marked as Generic since R is unbound")
+	}
+}
+
+func TestCollect_SchemaResolution_InheritedModelFields(t *testing.T) {
+	c := New()
+	testdataDir, _ := filepath.Abs("testdata")
+
+	endpoints, err := c.Collect(collector.CollectContext{
+		SourceDir:  testdataDir,
+		Frameworks: []string{"spring-mvc"},
+	})
+	if err != nil {
+		t.Fatalf("Collect failed: %v", err)
+	}
+
+	var getUserEp *collector.ApiEndpoint
+	for i := range endpoints {
+		if endpoints[i].Name == "getUser" && endpoints[i].Folder == "UserController" {
+			getUserEp = &endpoints[i]
+			break
+		}
+	}
+	if getUserEp == nil {
+		t.Fatal("Expected getUser endpoint from UserController")
+	}
+
+	if getUserEp.Response == nil || getUserEp.Response.Body == nil {
+		t.Fatal("Expected Response body for getUser (returns ResponseEntity<User>)")
+	}
+
+	resp := getUserEp.Response.Body
+	if !resp.IsObject() {
+		t.Fatalf("Expected object model for User, got kind=%s", resp.Kind)
+	}
+
+	if resp.TypeName != "User" {
+		t.Errorf("Expected typeName 'User', got '%s'", resp.TypeName)
+	}
+
+	expectedOwnFields := []struct {
+		name     string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"name", model.KindSingle, model.JsonTypeString},
+		{"email", model.KindSingle, model.JsonTypeString},
+		{"active", model.KindSingle, model.JsonTypeBoolean},
+	}
+
+	for _, ef := range expectedOwnFields {
+		field, ok := resp.Fields[ef.name]
+		if !ok {
+			t.Errorf("Expected field '%s' in User", ef.name)
+			continue
+		}
+		if field.Model == nil {
+			t.Errorf("Field '%s' has nil model", ef.name)
+			continue
+		}
+		if field.Model.Kind != ef.kind {
+			t.Errorf("Field '%s': expected kind %s, got %s", ef.name, ef.kind, field.Model.Kind)
+		}
+		if field.Model.TypeName != ef.typeName {
+			t.Errorf("Field '%s': expected typeName %s, got %s", ef.name, ef.typeName, field.Model.TypeName)
+		}
+	}
+
+	expectedInheritedFields := []struct {
+		name     string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"id", model.KindSingle, model.JsonTypeLong},
+		{"createdAt", model.KindSingle, "LocalDateTime"},
+		{"updatedAt", model.KindSingle, "LocalDateTime"},
+	}
+
+	for _, ef := range expectedInheritedFields {
+		field, ok := resp.Fields[ef.name]
+		if !ok {
+			t.Errorf("Expected inherited field '%s' from BaseEntity in User", ef.name)
+			continue
+		}
+		if field.Model == nil {
+			t.Errorf("Inherited field '%s' has nil model", ef.name)
+			continue
+		}
+		if field.Model.Kind != ef.kind {
+			t.Errorf("Inherited field '%s': expected kind %s, got %s", ef.name, ef.kind, field.Model.Kind)
+		}
+		if field.Model.TypeName != ef.typeName {
+			t.Errorf("Inherited field '%s': expected typeName %s, got %s", ef.name, ef.typeName, field.Model.TypeName)
+		}
+	}
 }

--- a/api-collector-java/resolver/resolver.go
+++ b/api-collector-java/resolver/resolver.go
@@ -41,16 +41,22 @@ var mapTypes = map[string]bool{
 
 type TypeResolver struct {
 	classRegistry map[string]parser.Class
+	allTypeParams map[string]bool
 	resolving     map[string]bool
 }
 
 func NewTypeResolver(classes []parser.Class) *TypeResolver {
 	registry := make(map[string]parser.Class, len(classes))
+	allTypeParams := make(map[string]bool)
 	for _, c := range classes {
 		registry[c.Name] = c
+		for _, tp := range c.TypeParameters {
+			allTypeParams[tp] = true
+		}
 	}
 	return &TypeResolver{
 		classRegistry: registry,
+		allTypeParams: allTypeParams,
 		resolving:     make(map[string]bool),
 	}
 }
@@ -129,20 +135,18 @@ func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *
 			}
 		}
 
+		typeParamSet := make(map[string]bool, len(class.TypeParameters))
+		for _, tp := range class.TypeParameters {
+			typeParamSet[tp] = true
+		}
+
 		fields := make(map[string]*model.FieldModel, len(class.Fields))
 		for _, f := range class.Fields {
-			fieldModel := r.Resolve(f.Type, localBindings)
-			fm := &model.FieldModel{
-				Model:    fieldModel,
-				Required: true,
-			}
-			for _, ann := range f.Annotations {
-				if ann.Name == "Nullable" || ann.Name == "Null" {
-					fm.Required = false
-				}
-			}
+			fm := r.resolveField(f, localBindings, typeParamSet)
 			fields[f.Name] = fm
 		}
+
+		r.resolveInheritedFields(class, localBindings, fields)
 
 		return &model.ObjectModel{
 			Kind:     model.KindObject,
@@ -152,6 +156,79 @@ func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *
 	}
 
 	return model.SingleModel(rawType)
+}
+
+func (r *TypeResolver) resolveField(f parser.Field, localBindings map[string]string, typeParamSet map[string]bool) *model.FieldModel {
+	fieldModel := r.Resolve(f.Type, localBindings)
+	fm := &model.FieldModel{
+		Model:    fieldModel,
+		Required: true,
+	}
+	for _, ann := range f.Annotations {
+		if ann.Name == "Nullable" || ann.Name == "Null" {
+			fm.Required = false
+		}
+	}
+	if r.isUnboundTypeParam(f.Type, localBindings, typeParamSet) {
+		fm.Generic = true
+	} else if fieldModel != nil && fieldModel.Kind == model.KindSingle && r.allTypeParams[fieldModel.TypeName] {
+		fm.Generic = true
+	}
+	return fm
+}
+
+func (r *TypeResolver) isUnboundTypeParam(typeName string, localBindings map[string]string, typeParamSet map[string]bool) bool {
+	if typeParamSet == nil {
+		return false
+	}
+	if !typeParamSet[typeName] {
+		return false
+	}
+	if bound, exists := localBindings[typeName]; exists {
+		return r.allTypeParams[bound] && r.classRegistry[bound].Name == ""
+	}
+	return true
+}
+
+func (r *TypeResolver) resolveInheritedFields(class parser.Class, localBindings map[string]string, fields map[string]*model.FieldModel) {
+	if class.SuperClass == "" {
+		return
+	}
+
+	superClass, found := r.classRegistry[class.SuperClass]
+	if !found {
+		return
+	}
+
+	superBindings := make(map[string]string)
+	for i, tp := range superClass.TypeParameters {
+		if i < len(class.SuperClassTypeArgs) {
+			resolvedArg := class.SuperClassTypeArgs[i]
+			if bound, ok := localBindings[resolvedArg]; ok {
+				resolvedArg = bound
+			}
+			superBindings[tp] = resolvedArg
+		}
+	}
+	for k, v := range localBindings {
+		if _, exists := superBindings[k]; !exists {
+			superBindings[k] = v
+		}
+	}
+
+	superTypeParamSet := make(map[string]bool, len(superClass.TypeParameters))
+	for _, tp := range superClass.TypeParameters {
+		superTypeParamSet[tp] = true
+	}
+
+	for _, f := range superClass.Fields {
+		if _, exists := fields[f.Name]; !exists {
+			fm := r.resolveField(f, superBindings, superTypeParamSet)
+			fields[f.Name] = fm
+		}
+	}
+
+	r.resolveInheritedFields(superClass, superBindings, fields)
 }
 
 func parseGenericType(rawType string) (string, []string) {

--- a/api-collector-java/resolver/resolver_test.go
+++ b/api-collector-java/resolver/resolver_test.go
@@ -440,3 +440,272 @@ func TestResolve_PageResult(t *testing.T) {
 		t.Errorf("Expected total typeName 'long', got '%s'", totalField.Model.TypeName)
 	}
 }
+
+func TestResolve_InheritedFields(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "BaseEntity",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "createdAt", Type: "String"},
+			},
+		},
+		{
+			Name:       "User",
+			SuperClass: "BaseEntity",
+			Fields: []parser.Field{
+				{Name: "name", Type: "String"},
+				{Name: "email", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("User", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+	if result.TypeName != "User" {
+		t.Errorf("Expected typeName 'User', got '%s'", result.TypeName)
+	}
+
+	expectedFields := []struct {
+		name     string
+		typeName string
+	}{
+		{"name", model.JsonTypeString},
+		{"email", model.JsonTypeString},
+		{"id", model.JsonTypeLong},
+		{"createdAt", model.JsonTypeString},
+	}
+
+	if len(result.Fields) != len(expectedFields) {
+		t.Fatalf("Expected %d fields, got %d", len(expectedFields), len(result.Fields))
+	}
+
+	for _, ef := range expectedFields {
+		field, ok := result.Fields[ef.name]
+		if !ok {
+			t.Errorf("Expected field '%s'", ef.name)
+			continue
+		}
+		if field.Model == nil {
+			t.Errorf("Field '%s' has nil model", ef.name)
+			continue
+		}
+		if field.Model.TypeName != ef.typeName {
+			t.Errorf("Field '%s': expected typeName %s, got %s", ef.name, ef.typeName, field.Model.TypeName)
+		}
+	}
+}
+
+func TestResolve_InheritedFieldsWithGenerics(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "BaseEntity",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+		{
+			Name:           "TypedEntity",
+			SuperClass:     "BaseEntity",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "typeInfo", Type: "T"},
+			},
+		},
+		{
+			Name:              "Product",
+			SuperClass:        "TypedEntity",
+			SuperClassTypeArgs: []string{"String"},
+			Fields: []parser.Field{
+				{Name: "productName", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("Product", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+
+	if len(result.Fields) != 3 {
+		t.Fatalf("Expected 3 fields (productName + typeInfo + id), got %d", len(result.Fields))
+	}
+
+	productNameField := result.Fields["productName"]
+	if productNameField == nil || productNameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("Expected productName typeName 'string', got '%v'", productNameField)
+	}
+
+	typeInfoField := result.Fields["typeInfo"]
+	if typeInfoField == nil {
+		t.Fatal("Expected inherited 'typeInfo' field from TypedEntity")
+	}
+	if typeInfoField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("Expected typeInfo typeName 'string' (T resolved to String), got '%s'", typeInfoField.Model.TypeName)
+	}
+
+	idField := result.Fields["id"]
+	if idField == nil {
+		t.Fatal("Expected inherited 'id' field from BaseEntity")
+	}
+	if idField.Model.TypeName != model.JsonTypeLong {
+		t.Errorf("Expected id typeName 'long', got '%s'", idField.Model.TypeName)
+	}
+}
+
+func TestResolve_GenericFieldMarking(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "Result",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "code", Type: "int"},
+				{Name: "message", Type: "String"},
+				{Name: "data", Type: "T"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+
+	t.Run("unbound type param marked as generic", func(t *testing.T) {
+		result := r.Resolve("Result", nil)
+		dataField := result.Fields["data"]
+		if dataField == nil {
+			t.Fatal("Expected 'data' field")
+		}
+		if !dataField.Generic {
+			t.Error("Expected 'data' field to be marked as Generic since T is unbound")
+		}
+	})
+
+	t.Run("bound type param not marked as generic", func(t *testing.T) {
+		classesWithUser := append(classes, parser.Class{
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "name", Type: "String"},
+			},
+		})
+		r2 := NewTypeResolver(classesWithUser)
+		result := r2.Resolve("Result<User>", nil)
+		dataField := result.Fields["data"]
+		if dataField == nil {
+			t.Fatal("Expected 'data' field")
+		}
+		if dataField.Generic {
+			t.Error("Expected 'data' field NOT to be marked as Generic since T is bound to User")
+		}
+		if !dataField.Model.IsObject() {
+			t.Errorf("Expected data model KindObject, got %s", dataField.Model.Kind)
+		}
+	})
+
+	t.Run("non-type-param fields not marked as generic", func(t *testing.T) {
+		result := r.Resolve("Result", nil)
+		codeField := result.Fields["code"]
+		if codeField == nil {
+			t.Fatal("Expected 'code' field")
+		}
+		if codeField.Generic {
+			t.Error("Expected 'code' field NOT to be marked as Generic")
+		}
+	})
+}
+
+func TestResolve_InheritedFieldsWithGenericSuperclass(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name:           "BaseCrudController",
+			TypeParameters: []string{"Req", "Res"},
+			Fields: []parser.Field{
+				{Name: "request", Type: "Req"},
+				{Name: "response", Type: "Res"},
+			},
+		},
+		{
+			Name:              "OrderController",
+			SuperClass:        "BaseCrudController",
+			SuperClassTypeArgs: []string{"CreateOrderReq", "OrderVO"},
+			Fields:            []parser.Field{},
+		},
+		{
+			Name: "CreateOrderReq",
+			Fields: []parser.Field{
+				{Name: "orderId", Type: "String"},
+			},
+		},
+		{
+			Name: "OrderVO",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("OrderController", nil)
+
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+
+	reqField := result.Fields["request"]
+	if reqField == nil {
+		t.Fatal("Expected inherited 'request' field from BaseCrudController")
+	}
+	if reqField.Model.Kind != model.KindObject {
+		t.Errorf("Expected request KindObject, got %s", reqField.Model.Kind)
+	}
+	if reqField.Model.TypeName != "CreateOrderReq" {
+		t.Errorf("Expected request typeName 'CreateOrderReq', got '%s'", reqField.Model.TypeName)
+	}
+
+	resField := result.Fields["response"]
+	if resField == nil {
+		t.Fatal("Expected inherited 'response' field from BaseCrudController")
+	}
+	if resField.Model.TypeName != "OrderVO" {
+		t.Errorf("Expected response typeName 'OrderVO', got '%s'", resField.Model.TypeName)
+	}
+}
+
+func TestResolve_FieldOverrideInSubclass(t *testing.T) {
+	classes := []parser.Class{
+		{
+			Name: "BaseEntity",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+				{Name: "name", Type: "String"},
+			},
+		},
+		{
+			Name:       "User",
+			SuperClass: "BaseEntity",
+			Fields: []parser.Field{
+				{Name: "name", Type: "String"},
+				{Name: "email", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(classes)
+	result := r.Resolve("User", nil)
+
+	if len(result.Fields) != 3 {
+		t.Fatalf("Expected 3 fields, got %d", len(result.Fields))
+	}
+
+	nameField := result.Fields["name"]
+	if nameField == nil {
+		t.Fatal("Expected 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("Expected name typeName 'string', got '%s'", nameField.Model.TypeName)
+	}
+}

--- a/api-collector-java/springmvc/integration_test.go
+++ b/api-collector-java/springmvc/integration_test.go
@@ -108,7 +108,6 @@ func TestIntegration_ParseRealController(t *testing.T) {
 }
 
 func TestIntegration_ParseDirectory(t *testing.T) {
-	// Create parser
 	p, err := parser.NewParser(parser.ParserOptions{
 		LogLevel: parser.LogLevelError,
 	})
@@ -117,13 +116,11 @@ func TestIntegration_ParseDirectory(t *testing.T) {
 	}
 	defer p.Close()
 
-	// Parse entire testdata directory
 	results, err := p.ParseDirectory(filepath.Join("..", "testdata"))
 	if err != nil {
 		t.Fatalf("Failed to parse directory: %v", err)
 	}
 
-	// Extract Spring MVC endpoints
 	springParser := NewParser()
 	controllers := springParser.ExtractControllers(results)
 
@@ -131,7 +128,6 @@ func TestIntegration_ParseDirectory(t *testing.T) {
 		t.Error("Expected at least one controller")
 	}
 
-	// Verify we found UserController
 	found := false
 	for _, controller := range controllers {
 		if controller.Name == "UserController" {
@@ -144,5 +140,148 @@ func TestIntegration_ParseDirectory(t *testing.T) {
 
 	if !found {
 		t.Error("UserController not found in parsed controllers")
+	}
+}
+
+func TestIntegration_InheritedFieldResolution(t *testing.T) {
+	p, err := parser.NewParser(parser.ParserOptions{
+		LogLevel: parser.LogLevelError,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+	defer p.Close()
+
+	results, err := p.ParseDirectory(filepath.Join("..", "testdata"))
+	if err != nil {
+		t.Fatalf("Failed to parse directory: %v", err)
+	}
+
+	springParser := NewParser()
+	controllers := springParser.ExtractControllers(results)
+
+	var orderController *Controller
+	for i := range controllers {
+		if controllers[i].Name == "OrderController" {
+			orderController = &controllers[i]
+			break
+		}
+	}
+	if orderController == nil {
+		t.Fatal("Expected OrderController in parsed controllers")
+	}
+
+	var createEp *Endpoint
+	for i := range orderController.Endpoints {
+		if orderController.Endpoints[i].MethodName == "create" {
+			createEp = &orderController.Endpoints[i]
+			break
+		}
+	}
+	if createEp == nil {
+		t.Fatal("Expected 'create' endpoint in OrderController")
+	}
+
+	if createEp.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for create endpoint")
+	}
+
+	reqBody := createEp.RequestBodySchema
+	if !reqBody.IsObject() {
+		t.Fatalf("Expected object model for CreateOrderReq, got kind=%s", reqBody.Kind)
+	}
+
+	expectedFields := []string{"orderId", "customerName", "amount", "items", "metadata"}
+	for _, name := range expectedFields {
+		if _, ok := reqBody.Fields[name]; !ok {
+			t.Errorf("Expected field '%s' in CreateOrderReq", name)
+		}
+	}
+
+	if createEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for create endpoint")
+	}
+
+	respBody := createEp.ResponseSchema
+	if !respBody.IsObject() {
+		t.Fatalf("Expected object model for Result<OrderVO>, got kind=%s", respBody.Kind)
+	}
+
+	dataField, ok := respBody.Fields["data"]
+	if !ok {
+		t.Fatal("Expected 'data' field in Result<OrderVO>")
+	}
+	if dataField.Model == nil {
+		t.Fatal("Expected 'data' field to have a model")
+	}
+	if !dataField.Model.IsObject() {
+		t.Errorf("Expected 'data' field to be object (OrderVO), got kind=%s", dataField.Model.Kind)
+	}
+
+	orderVOFields := []string{"id", "orderId", "customerName", "total", "tags", "attributes"}
+	for _, name := range orderVOFields {
+		if _, ok := dataField.Model.Fields[name]; !ok {
+			t.Errorf("Expected field '%s' in OrderVO", name)
+		}
+	}
+}
+
+func TestIntegration_GenericBaseControllerResolution(t *testing.T) {
+	p, err := parser.NewParser(parser.ParserOptions{
+		LogLevel: parser.LogLevelError,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+	defer p.Close()
+
+	results, err := p.ParseDirectory(filepath.Join("..", "testdata"))
+	if err != nil {
+		t.Fatalf("Failed to parse directory: %v", err)
+	}
+
+	springParser := NewParser()
+	controllers := springParser.ExtractControllers(results)
+
+	var genericCtrl *Controller
+	for i := range controllers {
+		if controllers[i].Name == "GenericBaseController" {
+			genericCtrl = &controllers[i]
+			break
+		}
+	}
+	if genericCtrl == nil {
+		t.Fatal("Expected GenericBaseController in parsed controllers")
+	}
+
+	var infoEp *Endpoint
+	for i := range genericCtrl.Endpoints {
+		if genericCtrl.Endpoints[i].MethodName == "getInfo" {
+			infoEp = &genericCtrl.Endpoints[i]
+			break
+		}
+	}
+	if infoEp == nil {
+		t.Fatal("Expected 'getInfo' endpoint in GenericBaseController")
+	}
+
+	if infoEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for getInfo endpoint")
+	}
+
+	resp := infoEp.ResponseSchema
+	if !resp.IsObject() {
+		t.Fatalf("Expected object model for Result<R>, got kind=%s", resp.Kind)
+	}
+
+	dataField, ok := resp.Fields["data"]
+	if !ok {
+		t.Fatal("Expected 'data' field in Result<R>")
+	}
+	if dataField.Model == nil {
+		t.Fatal("Expected 'data' field to have a model")
+	}
+	if !dataField.Generic {
+		t.Error("Expected 'data' field to be marked as Generic since R is unbound")
 	}
 }

--- a/api-collector-java/testdata/BaseEntity.java
+++ b/api-collector-java/testdata/BaseEntity.java
@@ -1,0 +1,16 @@
+package com.example.demo.model;
+
+import java.time.LocalDateTime;
+
+public class BaseEntity {
+    private Long id;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/api-collector-java/testdata/TypedEntity.java
+++ b/api-collector-java/testdata/TypedEntity.java
@@ -1,0 +1,8 @@
+package com.example.demo.model;
+
+public class TypedEntity<T> extends BaseEntity {
+    private T typeInfo;
+
+    public T getTypeInfo() { return typeInfo; }
+    public void setTypeInfo(T typeInfo) { this.typeInfo = typeInfo; }
+}

--- a/api-collector-java/testdata/User.java
+++ b/api-collector-java/testdata/User.java
@@ -1,0 +1,14 @@
+package com.example.demo.model;
+
+public class User extends BaseEntity {
+    private String name;
+    private String email;
+    private boolean active;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/BaseEntity.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/BaseEntity.java
@@ -1,0 +1,16 @@
+package com.example.model;
+
+import java.time.LocalDateTime;
+
+public class BaseEntity {
+    private Long id;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/samples/java-springmvc/src/main/java/com/example/model/User.java
+++ b/samples/java-springmvc/src/main/java/com/example/model/User.java
@@ -1,0 +1,14 @@
+package com.example.model;
+
+public class User extends BaseEntity {
+    private String name;
+    private String email;
+    private boolean active;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+}


### PR DESCRIPTION
## Summary
- resolve inherited fields when building Java object schemas, including generic superclass bindings
- mark unresolved type-parameter fields as generic in resolved models
- add unit, integration, collector, and sample coverage for inherited request/response schemas

## Verification
- go test ./... (in api-collector-java)

Fixes #87