### PR TITLE
fix: resolve Java Feign request/response schemas

### DIFF
--- a/api-collector-java/collector.go
+++ b/api-collector-java/collector.go
@@ -200,5 +200,14 @@ func feignEndpointToAPI(ep feign.Endpoint, folder string) collector.ApiEndpoint 
 			})
 		}
 	}
+	if ep.RequestBodySchema != nil && out.RequestBody != nil {
+		out.RequestBody.Body = ep.RequestBodySchema
+	}
+	if ep.ResponseSchema != nil {
+		out.Response = &collector.ApiBody{
+			MediaType: "application/json",
+			Body:      ep.ResponseSchema,
+		}
+	}
 	return out
 }

--- a/api-collector-java/feign/integration_test.go
+++ b/api-collector-java/feign/integration_test.go
@@ -76,3 +76,117 @@ func TestIntegration_ParseRealFeignClient(t *testing.T) {
 		t.Errorf("Expected DELETE, got %s", ep3.Method)
 	}
 }
+
+func TestIntegration_TypeResolution(t *testing.T) {
+	p, err := parser.NewParser(parser.ParserOptions{
+		LogLevel: parser.LogLevelError,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+	defer p.Close()
+
+	results, err := p.ParseDirectory(filepath.Join("..", "testdata"))
+	if err != nil {
+		t.Fatalf("Failed to parse directory: %v", err)
+	}
+
+	fParser := NewParser()
+	clients := fParser.ExtractClients(results)
+
+	var userClient *FeignClient
+	for i := range clients {
+		if clients[i].Name == "UserClient" {
+			userClient = &clients[i]
+			break
+		}
+	}
+	if userClient == nil {
+		t.Fatal("Expected UserClient in parsed clients")
+	}
+
+	// getUser returns User — should resolve to object with inherited fields
+	var getEp *Endpoint
+	for i := range userClient.Endpoints {
+		if userClient.Endpoints[i].MethodName == "getUser" {
+			getEp = &userClient.Endpoints[i]
+			break
+		}
+	}
+	if getEp == nil {
+		t.Fatal("Expected 'getUser' endpoint")
+	}
+
+	if getEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for getUser")
+	}
+	if !getEp.ResponseSchema.IsObject() {
+		t.Fatalf("Expected object model for User, got kind=%s", getEp.ResponseSchema.Kind)
+	}
+
+	// User extends BaseEntity — check inherited fields
+	for _, name := range []string{"name", "email", "active", "id", "createdAt", "updatedAt"} {
+		if _, ok := getEp.ResponseSchema.Fields[name]; !ok {
+			t.Errorf("Expected field '%s' in User response schema", name)
+		}
+	}
+
+	// listUsers returns List<User>
+	var listEp *Endpoint
+	for i := range userClient.Endpoints {
+		if userClient.Endpoints[i].MethodName == "listUsers" {
+			listEp = &userClient.Endpoints[i]
+			break
+		}
+	}
+	if listEp == nil {
+		t.Fatal("Expected 'listUsers' endpoint")
+	}
+
+	if listEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for listUsers")
+	}
+	if !listEp.ResponseSchema.IsArray() {
+		t.Fatalf("Expected array model for List<User>, got kind=%s", listEp.ResponseSchema.Kind)
+	}
+	if listEp.ResponseSchema.Items == nil || !listEp.ResponseSchema.Items.IsObject() {
+		t.Error("Expected array items to be User object")
+	}
+
+	// createUser has @RequestBody User and returns User
+	var createEp *Endpoint
+	for i := range userClient.Endpoints {
+		if userClient.Endpoints[i].MethodName == "createUser" {
+			createEp = &userClient.Endpoints[i]
+			break
+		}
+	}
+	if createEp == nil {
+		t.Fatal("Expected 'createUser' endpoint")
+	}
+
+	if createEp.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for createUser")
+	}
+	if !createEp.RequestBodySchema.IsObject() {
+		t.Fatalf("Expected object model for User request body, got kind=%s", createEp.RequestBodySchema.Kind)
+	}
+	if createEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for createUser")
+	}
+
+	// deleteUser returns void
+	var deleteEp *Endpoint
+	for i := range userClient.Endpoints {
+		if userClient.Endpoints[i].MethodName == "deleteUser" {
+			deleteEp = &userClient.Endpoints[i]
+			break
+		}
+	}
+	if deleteEp == nil {
+		t.Fatal("Expected 'deleteUser' endpoint")
+	}
+	if deleteEp.ResponseSchema != nil {
+		t.Error("void return should not produce a ResponseSchema")
+	}
+}

--- a/api-collector-java/feign/parser.go
+++ b/api-collector-java/feign/parser.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/tangcent/apilot/api-collector-java/parser"
+	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
 // Parser extracts Feign client endpoints from parsed Java classes.
@@ -19,13 +20,16 @@ func NewParser() *Parser {
 // It supports both Spring Cloud OpenFeign (Spring MVC annotations) and
 // Netflix Feign (@RequestLine annotations).
 func (p *Parser) ExtractClients(results []parser.ParseResult) []FeignClient {
+	classRegistry := buildClassRegistry(results)
+	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
+
 	var clients []FeignClient
 	for _, result := range results {
 		if result.Error != nil {
 			continue
 		}
 		for _, class := range result.Classes {
-			if client := p.extractClient(class); client != nil {
+			if client := p.extractClient(class, typeResolver, classRegistry); client != nil {
 				clients = append(clients, *client)
 			}
 		}
@@ -33,7 +37,62 @@ func (p *Parser) ExtractClients(results []parser.ParseResult) []FeignClient {
 	return clients
 }
 
-func (p *Parser) extractClient(class parser.Class) *FeignClient {
+func buildClassRegistry(results []parser.ParseResult) map[string]parser.Class {
+	registry := make(map[string]parser.Class)
+	for _, result := range results {
+		if result.Error != nil {
+			continue
+		}
+		for _, class := range result.Classes {
+			registry[class.Name] = class
+		}
+	}
+	return registry
+}
+
+func flattenClasses(results []parser.ParseResult) []parser.Class {
+	var classes []parser.Class
+	for _, result := range results {
+		if result.Error != nil {
+			continue
+		}
+		classes = append(classes, result.Classes...)
+	}
+	return classes
+}
+
+func buildTypeBindings(class parser.Class, classRegistry map[string]parser.Class) map[string]string {
+	if class.SuperClass == "" {
+		return nil
+	}
+
+	superClass, found := classRegistry[class.SuperClass]
+	if !found {
+		return nil
+	}
+
+	bindings := make(map[string]string)
+	for i, tp := range superClass.TypeParameters {
+		if i < len(class.SuperClassTypeArgs) {
+			bindings[tp] = class.SuperClassTypeArgs[i]
+		}
+	}
+
+	return bindings
+}
+
+func mergeBindings(parent, child map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range parent {
+		merged[k] = v
+	}
+	for k, v := range child {
+		merged[k] = v
+	}
+	return merged
+}
+
+func (p *Parser) extractClient(class parser.Class, typeResolver *resolver.TypeResolver, classRegistry map[string]parser.Class) *FeignClient {
 	ann := findAnnotation(class.Annotations, "FeignClient")
 	if ann != nil {
 		name := ann.Params["name"]
@@ -41,12 +100,17 @@ func (p *Parser) extractClient(class parser.Class) *FeignClient {
 			name = ann.Params["value"]
 		}
 
+		typeBindings := buildTypeBindings(class, classRegistry)
+
 		var endpoints []Endpoint
 		for _, method := range class.Methods {
-			if ep := p.extractEndpoint(method, class); ep != nil {
+			if ep := p.extractEndpoint(method, class, typeResolver, typeBindings); ep != nil {
 				endpoints = append(endpoints, *ep)
 			}
 		}
+
+		inheritedEndpoints := p.extractInheritedEndpoints(class, typeResolver, classRegistry, typeBindings)
+		endpoints = append(endpoints, inheritedEndpoints...)
 
 		return &FeignClient{
 			Name:        class.Name,
@@ -58,12 +122,17 @@ func (p *Parser) extractClient(class parser.Class) *FeignClient {
 	}
 
 	if class.IsInterface && p.hasRequestLineMethods(class) {
+		typeBindings := buildTypeBindings(class, classRegistry)
+
 		var endpoints []Endpoint
 		for _, method := range class.Methods {
-			if ep := p.extractEndpoint(method, class); ep != nil {
+			if ep := p.extractEndpoint(method, class, typeResolver, typeBindings); ep != nil {
 				endpoints = append(endpoints, *ep)
 			}
 		}
+
+		inheritedEndpoints := p.extractInheritedEndpoints(class, typeResolver, classRegistry, typeBindings)
+		endpoints = append(endpoints, inheritedEndpoints...)
 
 		if len(endpoints) > 0 {
 			return &FeignClient{
@@ -77,6 +146,44 @@ func (p *Parser) extractClient(class parser.Class) *FeignClient {
 	return nil
 }
 
+func (p *Parser) extractInheritedEndpoints(class parser.Class, typeResolver *resolver.TypeResolver, classRegistry map[string]parser.Class, typeBindings map[string]string) []Endpoint {
+	if class.SuperClass == "" {
+		return nil
+	}
+
+	superClass, found := classRegistry[class.SuperClass]
+	if !found {
+		return nil
+	}
+
+	parentTypeBindings := buildTypeBindings(superClass, classRegistry)
+	mergedBindings := mergeBindings(parentTypeBindings, typeBindings)
+
+	var inherited []Endpoint
+	for _, method := range superClass.Methods {
+		if p.isMethodOverridden(method.Name, class) {
+			continue
+		}
+		if ep := p.extractEndpoint(method, class, typeResolver, mergedBindings); ep != nil {
+			inherited = append(inherited, *ep)
+		}
+	}
+
+	grandparentEndpoints := p.extractInheritedEndpoints(superClass, typeResolver, classRegistry, mergedBindings)
+	inherited = append(inherited, grandparentEndpoints...)
+
+	return inherited
+}
+
+func (p *Parser) isMethodOverridden(methodName string, class parser.Class) bool {
+	for _, m := range class.Methods {
+		if m.Name == methodName {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Parser) hasRequestLineMethods(class parser.Class) bool {
 	for _, method := range class.Methods {
 		if findAnnotation(method.Annotations, "RequestLine") != nil {
@@ -86,29 +193,31 @@ func (p *Parser) hasRequestLineMethods(class parser.Class) bool {
 	return false
 }
 
-func (p *Parser) extractEndpoint(method parser.Method, class parser.Class) *Endpoint {
-	// Try Spring Cloud OpenFeign style first (Spring MVC annotations)
-	if ep := p.extractSpringStyleEndpoint(method, class); ep != nil {
+func (p *Parser) extractEndpoint(method parser.Method, class parser.Class, typeResolver *resolver.TypeResolver, typeBindings map[string]string) *Endpoint {
+	if ep := p.extractSpringStyleEndpoint(method, class, typeResolver, typeBindings); ep != nil {
 		return ep
 	}
-	// Fall back to Netflix Feign style (@RequestLine)
-	return p.extractRequestLineEndpoint(method, class)
+	return p.extractRequestLineEndpoint(method, class, typeResolver, typeBindings)
 }
 
-func (p *Parser) extractSpringStyleEndpoint(method parser.Method, class parser.Class) *Endpoint {
+func (p *Parser) extractSpringStyleEndpoint(method parser.Method, class parser.Class, typeResolver *resolver.TypeResolver, typeBindings map[string]string) *Endpoint {
 	httpMethod, methodPath := p.extractSpringMappingInfo(method.Annotations)
 	if httpMethod == "" {
 		return nil
 	}
 
 	var params []EndpointParameter
+	var requestBodyType string
 	for _, param := range method.Parameters {
 		if ep := p.extractSpringParameter(param); ep != nil {
 			params = append(params, *ep)
+			if ep.ParamType == "body" {
+				requestBodyType = param.Type
+			}
 		}
 	}
 
-	return &Endpoint{
+	endpoint := &Endpoint{
 		Path:       methodPath,
 		Method:     httpMethod,
 		MethodName: method.Name,
@@ -117,6 +226,17 @@ func (p *Parser) extractSpringStyleEndpoint(method parser.Method, class parser.C
 		ClassName:  class.Name,
 		Package:    class.Package,
 	}
+
+	if requestBodyType != "" {
+		endpoint.RequestBodySchema = typeResolver.Resolve(requestBodyType, typeBindings)
+	}
+
+	if method.ReturnType != "" && method.ReturnType != "void" && method.ReturnType != "Void" {
+		resolvedType := unwrapResponseType(method.ReturnType)
+		endpoint.ResponseSchema = typeResolver.Resolve(resolvedType, typeBindings)
+	}
+
+	return endpoint
 }
 
 func (p *Parser) extractSpringMappingInfo(annotations []parser.Annotation) (HTTPMethod, string) {
@@ -183,12 +303,14 @@ func (p *Parser) extractSpringParameter(param parser.Parameter) *EndpointParamet
 			return &EndpointParameter{Name: param.Name, Type: param.Type, ParamType: "body", Required: true}
 		case "RequestHeader":
 			return &EndpointParameter{Name: param.Name, Type: param.Type, ParamType: "header", Required: true}
+		case "SpringQueryMap":
+			return &EndpointParameter{Name: param.Name, Type: param.Type, ParamType: "body", Required: true}
 		}
 	}
 	return nil
 }
 
-func (p *Parser) extractRequestLineEndpoint(method parser.Method, class parser.Class) *Endpoint {
+func (p *Parser) extractRequestLineEndpoint(method parser.Method, class parser.Class, typeResolver *resolver.TypeResolver, typeBindings map[string]string) *Endpoint {
 	ann := findAnnotation(method.Annotations, "RequestLine")
 	if ann == nil {
 		return nil
@@ -197,13 +319,17 @@ func (p *Parser) extractRequestLineEndpoint(method parser.Method, class parser.C
 	httpMethod, methodPath := parseRequestLine(ann.Params["value"])
 
 	var params []EndpointParameter
+	var requestBodyType string
 	for _, param := range method.Parameters {
 		if ep := p.extractFeignParam(param, methodPath); ep != nil {
 			params = append(params, *ep)
+			if ep.ParamType == "body" {
+				requestBodyType = param.Type
+			}
 		}
 	}
 
-	return &Endpoint{
+	endpoint := &Endpoint{
 		Path:       methodPath,
 		Method:     httpMethod,
 		MethodName: method.Name,
@@ -212,6 +338,16 @@ func (p *Parser) extractRequestLineEndpoint(method parser.Method, class parser.C
 		ClassName:  class.Name,
 		Package:    class.Package,
 	}
+
+	if requestBodyType != "" {
+		endpoint.RequestBodySchema = typeResolver.Resolve(requestBodyType, typeBindings)
+	}
+
+	if method.ReturnType != "" && method.ReturnType != "void" && method.ReturnType != "Void" {
+		endpoint.ResponseSchema = typeResolver.Resolve(method.ReturnType, typeBindings)
+	}
+
+	return endpoint
 }
 
 // parseRequestLine parses a value like "GET /users/{id}" into method and path.
@@ -260,6 +396,13 @@ func (p *Parser) extractFeignParam(param parser.Parameter, methodPath string) *E
 		paramType = "path"
 	}
 	return &EndpointParameter{Name: name, Type: param.Type, ParamType: paramType, Required: paramType == "path"}
+}
+
+func unwrapResponseType(rawType string) string {
+	if strings.HasPrefix(rawType, "ResponseEntity<") && strings.HasSuffix(rawType, ">") {
+		return rawType[len("ResponseEntity<") : len(rawType)-1]
+	}
+	return rawType
 }
 
 func isJavaPrimitive(typ string) bool {

--- a/api-collector-java/feign/parser_test.go
+++ b/api-collector-java/feign/parser_test.go
@@ -353,3 +353,444 @@ func TestParser_NonFeignInterface(t *testing.T) {
 		t.Errorf("Expected 0 clients, got %d", len(clients))
 	}
 }
+
+func TestParser_TypeResolution_SpringStyle(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name: "User",
+					Fields: []parser.Field{
+						{Name: "name", Type: "String"},
+						{Name: "email", Type: "String"},
+					},
+				},
+				{
+					Name:        "UserClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "user-service"}},
+					},
+					Methods: []parser.Method{
+						{
+							Name: "getUser",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/users/{id}"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "id", Type: "Long", Annotations: []parser.Annotation{{Name: "PathVariable"}}},
+							},
+							ReturnType: "User",
+						},
+						{
+							Name: "createUser",
+							Annotations: []parser.Annotation{
+								{Name: "PostMapping", Params: map[string]string{"value": "/users"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "user", Type: "User", Annotations: []parser.Annotation{{Name: "RequestBody"}}},
+							},
+							ReturnType: "User",
+						},
+						{
+							Name: "listUsers",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/users"}},
+							},
+							Parameters:  []parser.Parameter{},
+							ReturnType: "List<User>",
+						},
+						{
+							Name: "deleteUser",
+							Annotations: []parser.Annotation{
+								{Name: "DeleteMapping", Params: map[string]string{"value": "/users/{id}"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "id", Type: "Long", Annotations: []parser.Annotation{{Name: "PathVariable"}}},
+							},
+							ReturnType: "void",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 {
+		t.Fatalf("Expected 1 client, got %d", len(clients))
+	}
+
+	client := clients[0]
+	if len(client.Endpoints) != 4 {
+		t.Fatalf("Expected 4 endpoints, got %d", len(client.Endpoints))
+	}
+
+	// getUser returns User
+	ep0 := client.Endpoints[0]
+	if ep0.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for getUser")
+	}
+	if !ep0.ResponseSchema.IsObject() {
+		t.Errorf("Expected object model for User, got kind=%s", ep0.ResponseSchema.Kind)
+	}
+	if _, ok := ep0.ResponseSchema.Fields["name"]; !ok {
+		t.Error("Expected 'name' field in User response schema")
+	}
+
+	// createUser has User request body and returns User
+	ep1 := client.Endpoints[1]
+	if ep1.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for createUser")
+	}
+	if !ep1.RequestBodySchema.IsObject() {
+		t.Errorf("Expected object model for User request, got kind=%s", ep1.RequestBodySchema.Kind)
+	}
+	if ep1.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for createUser")
+	}
+
+	// listUsers returns List<User>
+	ep2 := client.Endpoints[2]
+	if ep2.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for listUsers")
+	}
+	if !ep2.ResponseSchema.IsArray() {
+		t.Errorf("Expected array model for List<User>, got kind=%s", ep2.ResponseSchema.Kind)
+	}
+	if ep2.ResponseSchema.Items == nil || !ep2.ResponseSchema.Items.IsObject() {
+		t.Error("Expected array items to be User object")
+	}
+
+	// deleteUser returns void
+	ep3 := client.Endpoints[3]
+	if ep3.ResponseSchema != nil {
+		t.Error("void return should not produce a ResponseSchema")
+	}
+}
+
+func TestParser_TypeResolution_RequestLineStyle(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name: "Order",
+					Fields: []parser.Field{
+						{Name: "orderId", Type: "String"},
+						{Name: "amount", Type: "double"},
+					},
+				},
+				{
+					Name:        "OrderClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "order-service"}},
+					},
+					Methods: []parser.Method{
+						{
+							Name: "createOrder",
+							Annotations: []parser.Annotation{
+								{Name: "RequestLine", Params: map[string]string{"value": "POST /orders"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "order", Type: "Order", Annotations: []parser.Annotation{}},
+							},
+							ReturnType: "Order",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 || len(clients[0].Endpoints) != 1 {
+		t.Fatal("Expected 1 client with 1 endpoint")
+	}
+
+	ep := clients[0].Endpoints[0]
+	if ep.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for createOrder")
+	}
+	if !ep.RequestBodySchema.IsObject() {
+		t.Errorf("Expected object model, got kind=%s", ep.RequestBodySchema.Kind)
+	}
+	if _, ok := ep.RequestBodySchema.Fields["orderId"]; !ok {
+		t.Error("Expected 'orderId' field in Order request body")
+	}
+
+	if ep.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for createOrder")
+	}
+	if !ep.ResponseSchema.IsObject() {
+		t.Errorf("Expected object model, got kind=%s", ep.ResponseSchema.Kind)
+	}
+}
+
+func TestParser_SpringQueryMap(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name: "SearchFilter",
+					Fields: []parser.Field{
+						{Name: "keyword", Type: "String"},
+						{Name: "page", Type: "int"},
+					},
+				},
+				{
+					Name:        "SearchClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "search-service"}},
+					},
+					Methods: []parser.Method{
+						{
+							Name: "search",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/search"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "filter", Type: "SearchFilter", Annotations: []parser.Annotation{{Name: "SpringQueryMap"}}},
+							},
+							ReturnType: "List<String>",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 || len(clients[0].Endpoints) != 1 {
+		t.Fatal("Expected 1 client with 1 endpoint")
+	}
+
+	ep := clients[0].Endpoints[0]
+	if len(ep.Parameters) != 1 {
+		t.Fatalf("Expected 1 parameter, got %d", len(ep.Parameters))
+	}
+	if ep.Parameters[0].ParamType != "body" {
+		t.Errorf("Expected body param for @SpringQueryMap, got '%s'", ep.Parameters[0].ParamType)
+	}
+	if ep.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for @SpringQueryMap parameter")
+	}
+	if !ep.RequestBodySchema.IsObject() {
+		t.Errorf("Expected object model for SearchFilter, got kind=%s", ep.RequestBodySchema.Kind)
+	}
+	if _, ok := ep.RequestBodySchema.Fields["keyword"]; !ok {
+		t.Error("Expected 'keyword' field in SearchFilter schema")
+	}
+}
+
+func TestParser_GenericReturnType(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name:           "Result",
+					TypeParameters: []string{"T"},
+					Fields: []parser.Field{
+						{Name: "code", Type: "int"},
+						{Name: "message", Type: "String"},
+						{Name: "data", Type: "T"},
+					},
+				},
+				{
+					Name: "User",
+					Fields: []parser.Field{
+						{Name: "name", Type: "String"},
+					},
+				},
+				{
+					Name:        "UserClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "user-service"}},
+					},
+					Methods: []parser.Method{
+						{
+							Name: "getUser",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/users/{id}"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "id", Type: "Long", Annotations: []parser.Annotation{{Name: "PathVariable"}}},
+							},
+							ReturnType: "Result<User>",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 || len(clients[0].Endpoints) != 1 {
+		t.Fatal("Expected 1 client with 1 endpoint")
+	}
+
+	ep := clients[0].Endpoints[0]
+	if ep.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for getUser")
+	}
+	if !ep.ResponseSchema.IsObject() {
+		t.Fatalf("Expected object model for Result<User>, got kind=%s", ep.ResponseSchema.Kind)
+	}
+
+	dataField, ok := ep.ResponseSchema.Fields["data"]
+	if !ok {
+		t.Fatal("Expected 'data' field in Result<User>")
+	}
+	if dataField.Model == nil || !dataField.Model.IsObject() {
+		t.Error("Expected 'data' field to be resolved as User object")
+	}
+	if dataField.Model != nil {
+		if _, ok := dataField.Model.Fields["name"]; !ok {
+			t.Error("Expected 'name' field in resolved User data")
+		}
+	}
+}
+
+func TestParser_InheritedEndpoints(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name: "User",
+					Fields: []parser.Field{
+						{Name: "name", Type: "String"},
+					},
+				},
+				{
+					Name:           "BaseCrudClient",
+					IsInterface:    true,
+					TypeParameters: []string{"T"},
+					Methods: []parser.Method{
+						{
+							Name: "getById",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/{id}"}},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "id", Type: "Long", Annotations: []parser.Annotation{{Name: "PathVariable"}}},
+							},
+							ReturnType: "T",
+						},
+						{
+							Name: "create",
+							Annotations: []parser.Annotation{
+								{Name: "PostMapping"},
+							},
+							Parameters: []parser.Parameter{
+								{Name: "entity", Type: "T", Annotations: []parser.Annotation{{Name: "RequestBody"}}},
+							},
+							ReturnType: "T",
+						},
+					},
+				},
+				{
+					Name:        "UserClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "user-service"}},
+					},
+					SuperClass:         "BaseCrudClient",
+					SuperClassTypeArgs: []string{"User"},
+					Methods:            []parser.Method{},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 {
+		t.Fatalf("Expected 1 client, got %d", len(clients))
+	}
+
+	client := clients[0]
+	if len(client.Endpoints) != 2 {
+		t.Fatalf("Expected 2 inherited endpoints, got %d", len(client.Endpoints))
+	}
+
+	methodNames := make(map[string]*Endpoint)
+	for i := range client.Endpoints {
+		methodNames[client.Endpoints[i].MethodName] = &client.Endpoints[i]
+	}
+
+	getEp := methodNames["getById"]
+	if getEp == nil {
+		t.Fatal("Expected inherited 'getById' endpoint")
+	}
+	if getEp.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema for inherited getById")
+	}
+	if !getEp.ResponseSchema.IsObject() {
+		t.Errorf("Expected object model for User (T=User), got kind=%s", getEp.ResponseSchema.Kind)
+	}
+	if _, ok := getEp.ResponseSchema.Fields["name"]; !ok {
+		t.Error("Expected 'name' field in resolved User response")
+	}
+
+	createEp := methodNames["create"]
+	if createEp == nil {
+		t.Fatal("Expected inherited 'create' endpoint")
+	}
+	if createEp.RequestBodySchema == nil {
+		t.Fatal("Expected RequestBodySchema for inherited create")
+	}
+	if !createEp.RequestBodySchema.IsObject() {
+		t.Errorf("Expected object model for User (T=User), got kind=%s", createEp.RequestBodySchema.Kind)
+	}
+}
+
+func TestParser_ResponseEntityUnwrapping(t *testing.T) {
+	results := []parser.ParseResult{
+		{
+			Classes: []parser.Class{
+				{
+					Name:        "TestClient",
+					IsInterface: true,
+					Annotations: []parser.Annotation{
+						{Name: "FeignClient", Params: map[string]string{"name": "test-service"}},
+					},
+					Methods: []parser.Method{
+						{
+							Name: "get",
+							Annotations: []parser.Annotation{
+								{Name: "GetMapping", Params: map[string]string{"value": "/test"}},
+							},
+							ReturnType: "ResponseEntity<String>",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	p := NewParser()
+	clients := p.ExtractClients(results)
+
+	if len(clients) != 1 || len(clients[0].Endpoints) != 1 {
+		t.Fatal("Expected 1 client with 1 endpoint")
+	}
+
+	ep := clients[0].Endpoints[0]
+	if ep.ResponseSchema == nil {
+		t.Fatal("Expected ResponseSchema")
+	}
+	if ep.ResponseSchema.TypeName != "string" {
+		t.Errorf("Expected unwrapped String type, got '%s'", ep.ResponseSchema.TypeName)
+	}
+}

--- a/api-collector-java/feign/types.go
+++ b/api-collector-java/feign/types.go
@@ -1,6 +1,8 @@
 // Package feign provides Feign client specific API extraction.
 package feign
 
+import model "github.com/tangcent/apilot/api-model"
+
 // HTTPMethod represents HTTP methods.
 type HTTPMethod string
 
@@ -22,13 +24,15 @@ type EndpointParameter struct {
 
 // Endpoint represents a Feign client endpoint.
 type Endpoint struct {
-	Path       string
-	Method     HTTPMethod
-	MethodName string
-	Parameters []EndpointParameter
-	ReturnType string
-	ClassName  string
-	Package    string
+	Path              string
+	Method            HTTPMethod
+	MethodName        string
+	Parameters        []EndpointParameter
+	ReturnType        string
+	ClassName         string
+	Package           string
+	RequestBodySchema *model.ObjectModel
+	ResponseSchema    *model.ObjectModel
 }
 
 // FeignClient represents a Feign client interface with its endpoints.

--- a/samples/java-feign/src/main/java/com/example/UserClient.java
+++ b/samples/java-feign/src/main/java/com/example/UserClient.java
@@ -2,26 +2,27 @@ package com.example;
 
 import feign.Param;
 import feign.RequestLine;
+import java.util.List;
 
 public interface UserClient {
 
     @RequestLine("GET /users?name={name}&role={role}")
-    String listUsers(@Param("name") String name, @Param("role") String role);
+    List<UserVO> listUsers(@Param("name") String name, @Param("role") String role);
 
     @RequestLine("POST /users")
-    String createUser(CreateUserReq req);
+    UserVO createUser(CreateUserReq req);
 
     @RequestLine("GET /users/{id}")
-    String getUser(@Param("id") String id);
+    UserVO getUser(@Param("id") String id);
 
     @RequestLine("PUT /users/{id}")
-    String updateUser(@Param("id") String id, UpdateUserReq req);
+    UserVO updateUser(@Param("id") String id, UpdateUserReq req);
 
     @RequestLine("DELETE /users/{id}")
     void deleteUser(@Param("id") String id);
 
     @RequestLine("PATCH /users/{id}?name={name}")
-    String patchUser(@Param("id") String id, @Param("name") String name);
+    UserVO patchUser(@Param("id") String id, @Param("name") String name);
 }
 
 class CreateUserReq {
@@ -38,6 +39,19 @@ class UpdateUserReq {
     private String name;
     private String email;
 
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+}
+
+class UserVO {
+    private Long id;
+    private String name;
+    private String email;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
     public String getEmail() { return email; }


### PR DESCRIPTION
## Summary
- resolve request body and response schemas for Java Feign endpoints
- support inherited Feign client methods and generic type bindings
- add unit and integration coverage plus sample updates

## Testing
- go test ./api-collector-java/feign/...

Closes #89