### PR TITLE
feat: add detailed request/response type resolution for Go Echo

### DIFF
--- a/api-collector-go/echo/parser.go
+++ b/api-collector-go/echo/parser.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	collector "github.com/tangcent/apilot/api-collector"
-	model "github.com/tangcent/apilot/api-model"
 )
 
 // echoMethods maps Echo route-registration method names that we recognize.
@@ -84,6 +83,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	funcDocs := make(map[string]string)
 	groupPrefixes := make(map[string]string)
 	handlerAnalyses := make(map[string]handlerAnalysis)
+	allStructs := make(map[string]StructDef)
+	varTypeMaps := make(map[string]map[string]string)
 	var allRaw []rawEndpoint
 
 	for res := range ch {
@@ -96,12 +97,20 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		for k, v := range res.handlerAnalyses {
 			handlerAnalyses[k] = v
 		}
+		for k, v := range res.structDefs {
+			allStructs[k] = v
+		}
+		for k, v := range res.varTypeMaps {
+			varTypeMaps[k] = v
+		}
 		allRaw = append(allRaw, res.rawEndpoints...)
 	}
 
 	if len(allRaw) == 0 {
 		return nil, nil
 	}
+
+	typeResolver := NewTypeResolver(allStructs)
 
 	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
 	for _, raw := range allRaw {
@@ -162,7 +171,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.requestBody.mediaType,
 			}
 			if analysis.requestBody.typeName != "" {
-				ep.RequestBody.Body = model.SingleModel(analysis.requestBody.typeName)
+				actualType := resolveVarType(analysis.requestBody.typeName, handlerKey, varTypeMaps)
+				ep.RequestBody.Body = typeResolver.Resolve(actualType)
 			}
 		}
 
@@ -171,7 +181,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.response.mediaType,
 			}
 			if analysis.response.typeName != "" {
-				ep.Response.Body = model.SingleModel(analysis.response.typeName)
+				actualType := resolveVarType(analysis.response.typeName, handlerKey, varTypeMaps)
+				ep.Response.Body = typeResolver.Resolve(actualType)
 			}
 		}
 
@@ -218,6 +229,8 @@ type fileResult struct {
 	groupPrefixes   map[string]string
 	rawEndpoints    []rawEndpoint
 	handlerAnalyses map[string]handlerAnalysis
+	structDefs      map[string]StructDef
+	varTypeMaps     map[string]map[string]string
 }
 
 // discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
@@ -251,9 +264,13 @@ func processFile(filePath string) fileResult {
 		return fileResult{}
 	}
 
+	structDefs := extractStructs(f)
+
 	if !importsPackage(f, "github.com/labstack/echo/v4") {
-		return fileResult{}
+		return fileResult{structDefs: structDefs}
 	}
+
+	varTypeMaps := make(map[string]map[string]string)
 
 	echoHandlers := make(map[string]bool)
 	funcDocs := make(map[string]string)
@@ -270,6 +287,7 @@ func processFile(filePath string) fileResult {
 		if findContextParamName(fn) != "" {
 			echoHandlers[name] = true
 		}
+		varTypeMaps[name] = buildVarTypeMap(fn)
 		params, reqBody, respBody := analyzeHandlerBody(fn)
 		if len(params) > 0 || reqBody != nil || respBody != nil {
 			handlerAnalyses[name] = handlerAnalysis{
@@ -345,6 +363,8 @@ func processFile(filePath string) fileResult {
 		groupPrefixes:   groupPrefixes,
 		rawEndpoints:    rawEndpoints,
 		handlerAnalyses: handlerAnalyses,
+		structDefs:      structDefs,
+		varTypeMaps:     varTypeMaps,
 	}
 }
 

--- a/api-collector-go/echo/parser_test.go
+++ b/api-collector-go/echo/parser_test.go
@@ -91,11 +91,19 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Response: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
 
+	createUserReqBody := &model.ObjectModel{
+		Kind: model.KindObject, TypeName: "CreateUserReq",
+		Fields: map[string]*model.FieldModel{
+			"name":  {Model: model.SingleModel(model.JsonTypeString)},
+			"email": {Model: model.SingleModel(model.JsonTypeString)},
+		},
+	}
+
 	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
 		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
 	})
 
 	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
@@ -104,8 +112,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
 	})
 }
 
@@ -157,9 +165,82 @@ func TestParse_GroupRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
 		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.EmptyObject()},
+		Response:    &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
+}
+
+func TestParse_TypedEndpoints(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed endpoints should not error: %v", err)
+	}
+	if len(endpoints) != 4 {
+		t.Fatalf("expected 4 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	ep0 := endpoints[0]
+	if ep0.Name != "listUsers" || ep0.Method != "GET" {
+		t.Errorf("Expected GET listUsers, got %s %s", ep0.Method, ep0.Name)
+	}
+	if ep0.Response == nil {
+		t.Fatal("Expected response for listUsers")
+	}
+
+	ep1 := endpoints[1]
+	if ep1.Name != "getUser" || ep1.Method != "GET" {
+		t.Errorf("Expected GET getUser, got %s %s", ep1.Method, ep1.Name)
+	}
+	if ep1.Response == nil || !ep1.Response.Body.IsObject() {
+		t.Fatal("Expected object response for getUser")
+	}
+	if ep1.Response.Body.Fields["id"] == nil {
+		t.Error("Expected embedded 'id' field from BaseModel")
+	}
+	if ep1.Response.Body.Fields["created_at"] == nil {
+		t.Error("Expected embedded 'created_at' field from BaseModel")
+	}
+	if ep1.Response.Body.Fields["name"] == nil {
+		t.Error("Expected 'name' field in UserVO")
+	}
+	if ep1.Response.Body.Fields["tags"] == nil {
+		t.Error("Expected 'tags' field in UserVO")
+	}
+
+	ep2 := endpoints[2]
+	if ep2.Name != "createUser" || ep2.Method != "POST" {
+		t.Errorf("Expected POST createUser, got %s %s", ep2.Method, ep2.Name)
+	}
+	if ep2.RequestBody == nil || !ep2.RequestBody.Body.IsObject() {
+		t.Fatal("Expected object request body for createUser")
+	}
+	if !ep2.RequestBody.Body.Fields["name"].Required {
+		t.Error("Expected 'name' field to be required")
+	}
+	if !ep2.RequestBody.Body.Fields["email"].Required {
+		t.Error("Expected 'email' field to be required")
+	}
+	if ep2.RequestBody.Body.Fields["age"] == nil {
+		t.Error("Expected 'age' field (pointer type)")
+	}
+
+	ep3 := endpoints[3]
+	if ep3.Name != "updateUser" || ep3.Method != "PUT" {
+		t.Errorf("Expected PUT updateUser, got %s %s", ep3.Method, ep3.Name)
+	}
+	if ep3.RequestBody == nil || !ep3.RequestBody.Body.IsObject() {
+		t.Fatal("Expected object request body for updateUser")
+	}
+	if ep3.RequestBody.Body.Fields["name"] == nil {
+		t.Error("Expected 'name' field in UpdateUserReq")
+	}
 }
 
 func TestParse_NonexistentDir(t *testing.T) {
@@ -274,6 +355,17 @@ func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
 	if want.Body != nil {
 		if got.Body == nil {
 			t.Errorf("%s.Body = nil, want %+v", field, want.Body)
+			return
+		}
+		if got.Body.Kind != want.Body.Kind {
+			t.Errorf("%s.Body.Kind = %q, want %q", field, got.Body.Kind, want.Body.Kind)
+		}
+		if want.Body.IsObject() && got.Body.IsObject() {
+			for fieldName := range want.Body.Fields {
+				if _, ok := got.Body.Fields[fieldName]; !ok {
+					t.Errorf("%s.Body.Fields missing expected field %q", field, fieldName)
+				}
+			}
 		}
 	}
 }

--- a/api-collector-go/echo/resolver.go
+++ b/api-collector-go/echo/resolver.go
@@ -1,0 +1,319 @@
+package echo
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"strings"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+type StructDef struct {
+	Name          string
+	Fields        []StructField
+	EmbeddedTypes []string
+}
+
+type StructField struct {
+	Name       string
+	Type       string
+	JsonTag    string
+	BindingTag string
+	Comment    string
+}
+
+func extractStructs(f *ast.File) map[string]StructDef {
+	structs := make(map[string]StructDef)
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+
+			structDef := StructDef{
+				Name:   typeSpec.Name.Name,
+				Fields: []StructField{},
+			}
+
+			if structType.Fields != nil {
+				for _, field := range structType.Fields.List {
+					if len(field.Names) == 0 {
+						typeName := extractTypeNameFromExpr(field.Type)
+						if typeName != "" {
+							structDef.EmbeddedTypes = append(structDef.EmbeddedTypes, typeName)
+						}
+						continue
+					}
+
+					for _, name := range field.Names {
+						sf := StructField{
+							Name: name.Name,
+							Type: extractTypeNameFromExpr(field.Type),
+						}
+
+						if field.Tag != nil {
+							tag := strings.Trim(field.Tag.Value, "`")
+							structTag := reflect.StructTag(tag)
+
+							if jsonTag, ok := structTag.Lookup("json"); ok {
+								parts := strings.SplitN(jsonTag, ",", 2)
+								if parts[0] != "-" {
+									sf.JsonTag = parts[0]
+								}
+							}
+
+							if bindingTag, ok := structTag.Lookup("binding"); ok {
+								sf.BindingTag = bindingTag
+							}
+
+							if validateTag, ok := structTag.Lookup("validate"); ok {
+								if sf.BindingTag == "" {
+									sf.BindingTag = validateTag
+								}
+							}
+						}
+
+						if field.Comment != nil {
+							sf.Comment = strings.TrimSpace(field.Comment.Text())
+						}
+
+						structDef.Fields = append(structDef.Fields, sf)
+					}
+				}
+			}
+
+			structs[structDef.Name] = structDef
+		}
+	}
+
+	return structs
+}
+
+func extractTypeNameFromExpr(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return "*" + extractTypeNameFromExpr(e.X)
+	case *ast.ArrayType:
+		return "[]" + extractTypeNameFromExpr(e.Elt)
+	case *ast.MapType:
+		return "map[" + extractTypeNameFromExpr(e.Key) + "]" + extractTypeNameFromExpr(e.Value)
+	case *ast.SelectorExpr:
+		if x, ok := e.X.(*ast.Ident); ok {
+			return x.Name + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.InterfaceType:
+		return "interface{}"
+	case *ast.StructType:
+		return "struct{}"
+	}
+	return ""
+}
+
+func buildVarTypeMap(fn *ast.FuncDecl) map[string]string {
+	if fn.Body == nil {
+		return nil
+	}
+
+	varMap := make(map[string]string)
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.DeclStmt:
+			genDecl, ok := stmt.Decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok || valueSpec.Type == nil {
+					continue
+				}
+				typeName := extractTypeNameFromExpr(valueSpec.Type)
+				for _, name := range valueSpec.Names {
+					varMap[name.Name] = typeName
+				}
+			}
+
+		case *ast.AssignStmt:
+			if stmt.Tok != token.DEFINE {
+				return true
+			}
+			for i, lhs := range stmt.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || i >= len(stmt.Rhs) {
+					continue
+				}
+				typeName := inferTypeFromExpr(stmt.Rhs[i])
+				if typeName != "" {
+					varMap[ident.Name] = typeName
+				}
+			}
+		}
+		return true
+	})
+
+	return varMap
+}
+
+func inferTypeFromExpr(expr ast.Expr) string {
+	if unary, ok := expr.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+		inner := inferTypeFromExpr(unary.X)
+		if inner != "" {
+			return inner
+		}
+	}
+
+	if comp, ok := expr.(*ast.CompositeLit); ok {
+		return extractTypeNameFromExpr(comp.Type)
+	}
+
+	return ""
+}
+
+type TypeResolver struct {
+	structRegistry map[string]StructDef
+	resolving      map[string]bool
+}
+
+func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
+	return &TypeResolver{
+		structRegistry: structs,
+		resolving:      make(map[string]bool),
+	}
+}
+
+var goPrimitives = map[string]string{
+	"string":  model.JsonTypeString,
+	"bool":    model.JsonTypeBoolean,
+	"int":     model.JsonTypeInt,
+	"int8":    model.JsonTypeInt,
+	"int16":   model.JsonTypeInt,
+	"int32":   model.JsonTypeInt,
+	"int64":   model.JsonTypeLong,
+	"uint":    model.JsonTypeInt,
+	"uint8":   model.JsonTypeInt,
+	"uint16":  model.JsonTypeInt,
+	"uint32":  model.JsonTypeInt,
+	"uint64":  model.JsonTypeLong,
+	"float32": model.JsonTypeFloat,
+	"float64": model.JsonTypeDouble,
+	"byte":    model.JsonTypeInt,
+	"rune":    model.JsonTypeInt,
+}
+
+func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
+	if typeName == "" || typeName == "interface{}" || typeName == "any" {
+		return model.NullModel()
+	}
+
+	if typeName == "struct{}" {
+		return model.EmptyObject()
+	}
+
+	if jsonType, ok := goPrimitives[typeName]; ok {
+		return model.SingleModel(jsonType)
+	}
+
+	if strings.HasPrefix(typeName, "*") {
+		return r.Resolve(typeName[1:])
+	}
+
+	if strings.HasPrefix(typeName, "[]") {
+		elemType := typeName[2:]
+		return model.ArrayModel(r.Resolve(elemType))
+	}
+
+	if strings.HasPrefix(typeName, "map[") {
+		keyType, valueType := parseMapType(typeName)
+		return model.MapModel(r.Resolve(keyType), r.Resolve(valueType))
+	}
+
+	structDef, found := r.structRegistry[typeName]
+	if !found {
+		return model.SingleModel(typeName)
+	}
+
+	if r.resolving[typeName] {
+		return model.RefModel(typeName)
+	}
+
+	r.resolving[typeName] = true
+	defer func() { delete(r.resolving, typeName) }()
+
+	fields := make(map[string]*model.FieldModel)
+
+	for _, f := range structDef.Fields {
+		fieldName := f.Name
+		if f.JsonTag != "" {
+			fieldName = f.JsonTag
+		} else {
+			fieldName = strings.ToLower(f.Name[:1]) + f.Name[1:]
+		}
+
+		required := strings.Contains(f.BindingTag, "required")
+
+		fields[fieldName] = &model.FieldModel{
+			Model:    r.Resolve(f.Type),
+			Required: required,
+		}
+	}
+
+	for _, embedded := range structDef.EmbeddedTypes {
+		embeddedModel := r.Resolve(strings.TrimPrefix(embedded, "*"))
+		if embeddedModel != nil && embeddedModel.IsObject() {
+			for k, v := range embeddedModel.Fields {
+				if _, exists := fields[k]; !exists {
+					fields[k] = v
+				}
+			}
+		}
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: typeName,
+		Fields:   fields,
+	}
+}
+
+func parseMapType(typeName string) (string, string) {
+	inner := typeName[4:]
+	depth := 1
+	for i, c := range inner {
+		switch c {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return inner[:i], inner[i+1:]
+			}
+		}
+	}
+	return "string", "interface{}"
+}
+
+func resolveVarType(typeName string, handlerKey string, varTypeMaps map[string]map[string]string) string {
+	if varMap, ok := varTypeMaps[handlerKey]; ok {
+		if resolved, found := varMap[typeName]; found {
+			return resolved
+		}
+	}
+	return typeName
+}

--- a/api-collector-go/echo/resolver_test.go
+++ b/api-collector-go/echo/resolver_test.go
@@ -1,0 +1,301 @@
+package echo
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func parseSource(t *testing.T, src string) *ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+	return f
+}
+
+func TestExtractStructs(t *testing.T) {
+	src := `package main
+
+type User struct {
+	Name  string  ` + "`json:\"name\" validate:\"required\"`" + `
+	Email string  ` + "`json:\"email\"`" + `
+	Age   int     ` + "`json:\"age,omitempty\"`" + `
+}
+
+type Admin struct {
+	User
+	Role string ` + "`json:\"role\"`" + `
+}
+`
+	f := parseSource(t, src)
+	structs := extractStructs(f)
+
+	if len(structs) != 2 {
+		t.Fatalf("Expected 2 structs, got %d", len(structs))
+	}
+
+	user := structs["User"]
+	if len(user.Fields) != 3 {
+		t.Fatalf("Expected 3 fields in User, got %d", len(user.Fields))
+	}
+	if user.Fields[0].JsonTag != "name" {
+		t.Errorf("Expected json tag 'name', got '%s'", user.Fields[0].JsonTag)
+	}
+	if user.Fields[0].BindingTag != "required" {
+		t.Errorf("Expected binding tag 'required' from validate tag, got '%s'", user.Fields[0].BindingTag)
+	}
+	if user.Fields[2].JsonTag != "age" {
+		t.Errorf("Expected json tag 'age', got '%s'", user.Fields[2].JsonTag)
+	}
+
+	admin := structs["Admin"]
+	if len(admin.EmbeddedTypes) != 1 {
+		t.Fatalf("Expected 1 embedded type in Admin, got %d", len(admin.EmbeddedTypes))
+	}
+	if admin.EmbeddedTypes[0] != "User" {
+		t.Errorf("Expected embedded type 'User', got '%s'", admin.EmbeddedTypes[0])
+	}
+}
+
+func TestBuildVarTypeMap(t *testing.T) {
+	src := `package main
+
+func handler() {
+	var req CreateUserReq
+	var resp *UserResponse
+	item := Item{}
+	ptr := &Product{}
+}
+`
+	f := parseSource(t, src)
+	fn := f.Decls[0].(*ast.FuncDecl)
+	varMap := buildVarTypeMap(fn)
+
+	tests := []struct {
+		varName  string
+		typeName string
+	}{
+		{"req", "CreateUserReq"},
+		{"resp", "*UserResponse"},
+		{"item", "Item"},
+		{"ptr", "Product"},
+	}
+
+	for _, tt := range tests {
+		if got := varMap[tt.varName]; got != tt.typeName {
+			t.Errorf("varMap[%q] = %q, want %q", tt.varName, got, tt.typeName)
+		}
+	}
+}
+
+func TestResolve_Primitives(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+
+	tests := []struct {
+		goType   string
+		jsonType string
+	}{
+		{"string", model.JsonTypeString},
+		{"int", model.JsonTypeInt},
+		{"int64", model.JsonTypeLong},
+		{"float64", model.JsonTypeDouble},
+		{"bool", model.JsonTypeBoolean},
+	}
+
+	for _, tt := range tests {
+		result := resolver.Resolve(tt.goType)
+		if !result.IsSingle() {
+			t.Errorf("Resolve(%q): expected single model, got kind=%s", tt.goType, result.Kind)
+		}
+		if result.TypeName != tt.jsonType {
+			t.Errorf("Resolve(%q): got type %q, want %q", tt.goType, result.TypeName, tt.jsonType)
+		}
+	}
+}
+
+func TestResolve_Pointers(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("*string")
+
+	if !result.IsSingle() {
+		t.Errorf("Expected single model for *string, got kind=%s", result.Kind)
+	}
+	if result.TypeName != model.JsonTypeString {
+		t.Errorf("Expected string type, got %q", result.TypeName)
+	}
+}
+
+func TestResolve_Slices(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("[]string")
+
+	if !result.IsArray() {
+		t.Fatalf("Expected array model, got kind=%s", result.Kind)
+	}
+	if result.Items == nil || !result.Items.IsSingle() {
+		t.Error("Expected array items to be single model")
+	}
+	if result.Items.TypeName != model.JsonTypeString {
+		t.Errorf("Expected string items, got %q", result.Items.TypeName)
+	}
+}
+
+func TestResolve_Maps(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("map[string]int")
+
+	if !result.IsMap() {
+		t.Fatalf("Expected map model, got kind=%s", result.Kind)
+	}
+	if result.KeyModel == nil || result.KeyModel.TypeName != model.JsonTypeString {
+		t.Error("Expected string key type")
+	}
+	if result.ValueModel == nil || result.ValueModel.TypeName != model.JsonTypeInt {
+		t.Error("Expected int value type")
+	}
+}
+
+func TestResolve_Struct(t *testing.T) {
+	structs := map[string]StructDef{
+		"User": {
+			Name: "User",
+			Fields: []StructField{
+				{Name: "Name", Type: "string", JsonTag: "name", BindingTag: "required"},
+				{Name: "Email", Type: "string", JsonTag: "email"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("User")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	if len(result.Fields) != 2 {
+		t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+	}
+	if result.Fields["name"] == nil {
+		t.Error("Expected 'name' field")
+	}
+	if !result.Fields["name"].Required {
+		t.Error("Expected 'name' field to be required")
+	}
+	if result.Fields["email"] == nil {
+		t.Error("Expected 'email' field")
+	}
+}
+
+func TestResolve_EmbeddedStruct(t *testing.T) {
+	structs := map[string]StructDef{
+		"Base": {
+			Name: "Base",
+			Fields: []StructField{
+				{Name: "ID", Type: "int64", JsonTag: "id"},
+			},
+		},
+		"User": {
+			Name:          "User",
+			EmbeddedTypes: []string{"Base"},
+			Fields: []StructField{
+				{Name: "Name", Type: "string", JsonTag: "name"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("User")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	if len(result.Fields) != 2 {
+		t.Fatalf("Expected 2 fields (1 own + 1 embedded), got %d", len(result.Fields))
+	}
+	if result.Fields["id"] == nil {
+		t.Error("Expected embedded 'id' field from Base")
+	}
+	if result.Fields["name"] == nil {
+		t.Error("Expected 'name' field")
+	}
+}
+
+func TestResolve_CircularReference(t *testing.T) {
+	structs := map[string]StructDef{
+		"Node": {
+			Name: "Node",
+			Fields: []StructField{
+				{Name: "Value", Type: "string", JsonTag: "value"},
+				{Name: "Next", Type: "*Node", JsonTag: "next"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("Node")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	nextField := result.Fields["next"]
+	if nextField == nil {
+		t.Fatal("Expected 'next' field")
+	}
+	if !nextField.Model.IsRef() {
+		t.Errorf("Expected ref model for circular reference, got kind=%s", nextField.Model.Kind)
+	}
+}
+
+func TestResolve_EmptyAndNull(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+
+	if result := resolver.Resolve(""); !result.IsSingle() || result.TypeName != model.JsonTypeNull {
+		t.Errorf("Expected null for empty type, got kind=%s typeName=%s", result.Kind, result.TypeName)
+	}
+
+	if result := resolver.Resolve("interface{}"); !result.IsSingle() || result.TypeName != model.JsonTypeNull {
+		t.Errorf("Expected null for interface{}, got kind=%s typeName=%s", result.Kind, result.TypeName)
+	}
+
+	if result := resolver.Resolve("struct{}"); !result.IsObject() {
+		t.Errorf("Expected object for struct{}, got kind=%s", result.Kind)
+	}
+}
+
+func TestResolve_UnknownType(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("CustomType")
+
+	if !result.IsSingle() {
+		t.Errorf("Expected single model for unknown type, got kind=%s", result.Kind)
+	}
+	if result.TypeName != "CustomType" {
+		t.Errorf("Expected typeName 'CustomType', got %q", result.TypeName)
+	}
+}
+
+func TestResolveVarType(t *testing.T) {
+	varTypeMaps := map[string]map[string]string{
+		"handler": {
+			"req": "CreateUserReq",
+		},
+	}
+
+	if got := resolveVarType("req", "handler", varTypeMaps); got != "CreateUserReq" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "CreateUserReq")
+	}
+
+	if got := resolveVarType("unknown", "handler", varTypeMaps); got != "unknown" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "unknown")
+	}
+
+	if got := resolveVarType("req", "otherHandler", varTypeMaps); got != "req" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "req")
+	}
+}

--- a/api-collector-go/echo/testdata/typed/main.go
+++ b/api-collector-go/echo/testdata/typed/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type BaseModel struct {
+	ID        int64  `json:"id"`
+	CreatedAt string `json:"created_at"`
+}
+
+type CreateUserReq struct {
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"required"`
+	Age   *int   `json:"age"`
+}
+
+type UserVO struct {
+	BaseModel
+	Name   string   `json:"name"`
+	Email  string   `json:"email"`
+	Active bool     `json:"active"`
+	Tags   []string `json:"tags"`
+}
+
+type UpdateUserReq struct {
+	Name  *string `json:"name"`
+	Email *string `json:"email"`
+}
+
+func main() {
+	e := echo.New()
+
+	e.POST("/users", createUser)
+	e.GET("/users/:id", getUser)
+	e.PUT("/users/:id", updateUser)
+	e.GET("/users", listUsers)
+
+	e.Logger.Fatal(e.Start(":8080"))
+}
+
+// createUser creates a new user.
+func createUser(c echo.Context) error {
+	var req CreateUserReq
+	_ = c.Bind(&req)
+	return c.JSON(http.StatusCreated, UserVO{})
+}
+
+// getUser returns a user by ID.
+func getUser(c echo.Context) error {
+	return c.JSON(http.StatusOK, UserVO{})
+}
+
+// updateUser updates a user.
+func updateUser(c echo.Context) error {
+	req := UpdateUserReq{}
+	_ = c.Bind(&req)
+	return c.JSON(http.StatusOK, UserVO{})
+}
+
+// listUsers returns all users.
+func listUsers(c echo.Context) error {
+	name := c.QueryParam("name")
+	_ = name
+	return c.JSON(http.StatusOK, map[string]interface{}{"users": []UserVO{}})
+}

--- a/samples/go-echo/main.go
+++ b/samples/go-echo/main.go
@@ -6,9 +6,25 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+type BaseModel struct {
+	ID        int64  `json:"id"`
+	CreatedAt string `json:"created_at"`
+}
+
 type CreateUserReq struct {
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"required"`
+}
+
+type UserVO struct {
+	BaseModel
 	Name  string `json:"name"`
 	Email string `json:"email"`
+}
+
+type UpdateUserReq struct {
+	Name  *string `json:"name"`
+	Email *string `json:"email"`
 }
 
 func main() {
@@ -36,21 +52,21 @@ func listUsers(c echo.Context) error {
 func createUser(c echo.Context) error {
 	var req CreateUserReq
 	_ = c.Bind(&req)
-	return c.JSON(http.StatusCreated, req)
+	return c.JSON(http.StatusCreated, UserVO{})
 }
 
 // getUser returns a single user by ID.
 func getUser(c echo.Context) error {
 	id := c.Param("id")
 	_ = id
-	return c.JSON(http.StatusOK, map[string]interface{}{"id": id})
+	return c.JSON(http.StatusOK, UserVO{})
 }
 
 // updateUser updates an existing user.
 func updateUser(c echo.Context) error {
-	var req CreateUserReq
+	var req UpdateUserReq
 	_ = c.Bind(&req)
-	return c.JSON(http.StatusOK, req)
+	return c.JSON(http.StatusOK, UserVO{})
 }
 
 // deleteUser removes a user by ID.


### PR DESCRIPTION
Resolves #91

## Changes
- Add resolver.go with StructDef, TypeResolver, extractStructs, buildVarTypeMap
- Integrate type resolution into Echo parser for request/response bodies
- Support struct field extraction with json/binding/validate tags
- Handle embedded structs, pointers, slices, maps, and circular references
- Add typed test data and integration tests
- Update samples/go-echo with typed request/response patterns