### PR TITLE
feat: add detailed request/response type resolution for Go Fiber

### DIFF
--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 
 	collector "github.com/tangcent/apilot/api-collector"
-	model "github.com/tangcent/apilot/api-model"
 )
 
 // fiberMethods maps Fiber route-registration method names that we recognize.
@@ -86,6 +85,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	funcDocs := make(map[string]string)
 	groupPrefixes := make(map[string]string)
 	handlerAnalyses := make(map[string]handlerAnalysis)
+	allStructs := make(map[string]StructDef)
+	varTypeMaps := make(map[string]map[string]string)
 	var allRaw []rawEndpoint
 
 	for res := range ch {
@@ -98,12 +99,20 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		for k, v := range res.handlerAnalyses {
 			handlerAnalyses[k] = v
 		}
+		for k, v := range res.structDefs {
+			allStructs[k] = v
+		}
+		for k, v := range res.varTypeMaps {
+			varTypeMaps[k] = v
+		}
 		allRaw = append(allRaw, res.rawEndpoints...)
 	}
 
 	if len(allRaw) == 0 {
 		return nil, nil
 	}
+
+	typeResolver := NewTypeResolver(allStructs)
 
 	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
 	for _, raw := range allRaw {
@@ -164,7 +173,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.requestBody.mediaType,
 			}
 			if analysis.requestBody.typeName != "" {
-				ep.RequestBody.Body = model.SingleModel(analysis.requestBody.typeName)
+				actualType := resolveVarType(analysis.requestBody.typeName, handlerKey, varTypeMaps)
+				ep.RequestBody.Body = typeResolver.Resolve(actualType)
 			}
 		}
 
@@ -173,7 +183,8 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 				MediaType: analysis.response.mediaType,
 			}
 			if analysis.response.typeName != "" {
-				ep.Response.Body = model.SingleModel(analysis.response.typeName)
+				actualType := resolveVarType(analysis.response.typeName, handlerKey, varTypeMaps)
+				ep.Response.Body = typeResolver.Resolve(actualType)
 			}
 		}
 
@@ -220,6 +231,8 @@ type fileResult struct {
 	groupPrefixes   map[string]string
 	rawEndpoints    []rawEndpoint
 	handlerAnalyses map[string]handlerAnalysis
+	structDefs      map[string]StructDef
+	varTypeMaps     map[string]map[string]string
 }
 
 // discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
@@ -253,9 +266,13 @@ func processFile(filePath string) fileResult {
 		return fileResult{}
 	}
 
+	structDefs := extractStructs(f)
+
 	if !importsPackage(f, "github.com/gofiber/fiber/v2") {
-		return fileResult{}
+		return fileResult{structDefs: structDefs}
 	}
+
+	varTypeMaps := make(map[string]map[string]string)
 
 	fiberHandlers := make(map[string]bool)
 	funcDocs := make(map[string]string)
@@ -272,6 +289,7 @@ func processFile(filePath string) fileResult {
 		if findContextParamName(fn) != "" {
 			fiberHandlers[name] = true
 		}
+		varTypeMaps[name] = buildVarTypeMap(fn)
 		params, reqBody, respBody := analyzeHandlerBody(fn)
 		if len(params) > 0 || reqBody != nil || respBody != nil {
 			handlerAnalyses[name] = handlerAnalysis{
@@ -347,6 +365,8 @@ func processFile(filePath string) fileResult {
 		groupPrefixes:   groupPrefixes,
 		rawEndpoints:    rawEndpoints,
 		handlerAnalyses: handlerAnalyses,
+		structDefs:      structDefs,
+		varTypeMaps:     varTypeMaps,
 	}
 }
 
@@ -363,6 +383,7 @@ func processFile(filePath string) fileResult {
 //   - Get                             → header parameter (c.Get("Header-Name"))
 //   - Cookies                         → cookie parameter
 //   - BodyParser                      → request body (auto-detect media type)
+//   - QueryParser                     → request body from query params
 //   - JSON                            → JSON response
 //   - XML                             → XML response
 //   - SendString                      → text/plain response
@@ -434,6 +455,14 @@ func analyzeHandlerBody(fn *ast.FuncDecl) ([]rawParam, *rawBody, *rawBody) {
 				typeName = extractTypeName(callExpr.Args[0])
 			}
 			requestBody = &rawBody{mediaType: "application/json", typeName: typeName}
+		case "QueryParser":
+			typeName := ""
+			if len(callExpr.Args) >= 1 {
+				typeName = extractTypeName(callExpr.Args[0])
+			}
+			if requestBody == nil {
+				requestBody = &rawBody{mediaType: "application/json", typeName: typeName}
+			}
 		case "JSON":
 			typeName := ""
 			if len(callExpr.Args) >= 1 {

--- a/api-collector-go/fiber/parser_test.go
+++ b/api-collector-go/fiber/parser_test.go
@@ -45,6 +45,14 @@ func TestParse_BasicRoutes(t *testing.T) {
 		return endpoints[i].Path < endpoints[j].Path
 	})
 
+	createUserReqBody := &model.ObjectModel{
+		Kind: model.KindObject, TypeName: "CreateUserReq",
+		Fields: map[string]*model.FieldModel{
+			"name":  {Model: model.SingleModel(model.JsonTypeString)},
+			"email": {Model: model.SingleModel(model.JsonTypeString)},
+		},
+	}
+
 	assertEndpoint(t, endpoints[0], collector.ApiEndpoint{
 		Name: "deleteUser", Path: "/users/:id", Method: "DELETE", Protocol: "http",
 		Description: "deleteUser removes a user by ID.",
@@ -95,8 +103,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[5], collector.ApiEndpoint{
 		Name: "createUser", Path: "/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
 	})
 
 	assertEndpoint(t, endpoints[6], collector.ApiEndpoint{
@@ -105,8 +113,8 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
+		Response:   &collector.ApiBody{MediaType: "application/json", Body: createUserReqBody},
 	})
 }
 
@@ -159,9 +167,108 @@ func TestParse_GroupRoutes(t *testing.T) {
 	assertEndpoint(t, endpoints[4], collector.ApiEndpoint{
 		Name: "createUser", Path: "/v1/users", Method: "POST", Protocol: "http",
 		Description: "createUser creates a new user.",
-		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("req")},
-		Response:   &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
+		RequestBody: &collector.ApiBody{MediaType: "application/json", Body: model.EmptyObject()},
+		Response:    &collector.ApiBody{MediaType: "application/json", Body: model.SingleModel("map")},
 	})
+}
+
+func TestParse_TypedEndpoints(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed endpoints should not error: %v", err)
+	}
+	if len(endpoints) != 5 {
+		t.Fatalf("expected 5 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	ep0 := endpoints[0]
+	if ep0.Name != "searchUsers" || ep0.Method != "GET" {
+		t.Errorf("Expected GET searchUsers, got %s %s", ep0.Method, ep0.Name)
+	}
+	if ep0.RequestBody == nil || !ep0.RequestBody.Body.IsObject() {
+		t.Fatal("Expected object request body for searchUsers (QueryParser)")
+	}
+	if !ep0.RequestBody.Body.Fields["keyword"].Required {
+		t.Error("Expected 'keyword' field to be required")
+	}
+	if ep0.RequestBody.Body.Fields["page"] == nil {
+		t.Error("Expected 'page' field in SearchQuery")
+	}
+	if ep0.RequestBody.Body.Fields["size"] == nil {
+		t.Error("Expected 'size' field in SearchQuery")
+	}
+
+	ep1 := endpoints[1]
+	if ep1.Name != "listUsers" || ep1.Method != "GET" {
+		t.Errorf("Expected GET listUsers, got %s %s", ep1.Method, ep1.Name)
+	}
+	if ep1.Response == nil || !ep1.Response.Body.IsMap() {
+		t.Error("Expected fiber.Map map response for listUsers")
+	}
+
+	ep2 := endpoints[2]
+	if ep2.Name != "getUser" || ep2.Method != "GET" {
+		t.Errorf("Expected GET getUser, got %s %s", ep2.Method, ep2.Name)
+	}
+	if ep2.Response == nil || !ep2.Response.Body.IsObject() {
+		t.Fatal("Expected object response for getUser")
+	}
+	if ep2.Response.Body.Fields["id"] == nil {
+		t.Error("Expected embedded 'id' field from BaseModel")
+	}
+	if ep2.Response.Body.Fields["created_at"] == nil {
+		t.Error("Expected embedded 'created_at' field from BaseModel")
+	}
+	if ep2.Response.Body.Fields["name"] == nil {
+		t.Error("Expected 'name' field in UserVO")
+	}
+	if ep2.Response.Body.Fields["tags"] == nil {
+		t.Error("Expected 'tags' field in UserVO")
+	}
+
+	ep3 := endpoints[3]
+	if ep3.Name != "createUser" || ep3.Method != "POST" {
+		t.Errorf("Expected POST createUser, got %s %s", ep3.Method, ep3.Name)
+	}
+	if ep3.RequestBody == nil || !ep3.RequestBody.Body.IsObject() {
+		t.Fatal("Expected object request body for createUser")
+	}
+	if !ep3.RequestBody.Body.Fields["name"].Required {
+		t.Error("Expected 'name' field to be required")
+	}
+	if !ep3.RequestBody.Body.Fields["email"].Required {
+		t.Error("Expected 'email' field to be required")
+	}
+	if ep3.RequestBody.Body.Fields["age"] == nil {
+		t.Error("Expected 'age' field (pointer type)")
+	}
+	if ep3.Response == nil || !ep3.Response.Body.IsObject() {
+		t.Fatal("Expected object response for createUser")
+	}
+	if ep3.Response.Body.Fields["id"] == nil {
+		t.Error("Expected embedded 'id' field from BaseModel in UserVO response")
+	}
+	if ep3.Response.Body.Fields["tags"] == nil {
+		t.Error("Expected 'tags' field in UserVO response")
+	}
+
+	ep4 := endpoints[4]
+	if ep4.Name != "updateUser" || ep4.Method != "PUT" {
+		t.Errorf("Expected PUT updateUser, got %s %s", ep4.Method, ep4.Name)
+	}
+	if ep4.RequestBody == nil || !ep4.RequestBody.Body.IsObject() {
+		t.Fatal("Expected object request body for updateUser")
+	}
+	if ep4.RequestBody.Body.Fields["name"] == nil {
+		t.Error("Expected 'name' field in UpdateUserReq")
+	}
 }
 
 func TestParse_NonexistentDir(t *testing.T) {
@@ -291,6 +398,17 @@ func assertBody(t *testing.T, field string, got, want *collector.ApiBody) {
 	if want.Body != nil {
 		if got.Body == nil {
 			t.Errorf("%s.Body = nil, want %+v", field, want.Body)
+			return
+		}
+		if got.Body.Kind != want.Body.Kind {
+			t.Errorf("%s.Body.Kind = %q, want %q", field, got.Body.Kind, want.Body.Kind)
+		}
+		if want.Body.IsObject() && got.Body.IsObject() {
+			for fieldName := range want.Body.Fields {
+				if _, ok := got.Body.Fields[fieldName]; !ok {
+					t.Errorf("%s.Body.Fields missing expected field %q", field, fieldName)
+				}
+			}
 		}
 	}
 }

--- a/api-collector-go/fiber/resolver.go
+++ b/api-collector-go/fiber/resolver.go
@@ -1,0 +1,323 @@
+package fiber
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"strings"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+type StructDef struct {
+	Name          string
+	Fields        []StructField
+	EmbeddedTypes []string
+}
+
+type StructField struct {
+	Name       string
+	Type       string
+	JsonTag    string
+	BindingTag string
+	Comment    string
+}
+
+func extractStructs(f *ast.File) map[string]StructDef {
+	structs := make(map[string]StructDef)
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+
+			structDef := StructDef{
+				Name:   typeSpec.Name.Name,
+				Fields: []StructField{},
+			}
+
+			if structType.Fields != nil {
+				for _, field := range structType.Fields.List {
+					if len(field.Names) == 0 {
+						typeName := extractTypeNameFromExpr(field.Type)
+						if typeName != "" {
+							structDef.EmbeddedTypes = append(structDef.EmbeddedTypes, typeName)
+						}
+						continue
+					}
+
+					for _, name := range field.Names {
+						sf := StructField{
+							Name: name.Name,
+							Type: extractTypeNameFromExpr(field.Type),
+						}
+
+						if field.Tag != nil {
+							tag := strings.Trim(field.Tag.Value, "`")
+							structTag := reflect.StructTag(tag)
+
+							if jsonTag, ok := structTag.Lookup("json"); ok {
+								parts := strings.SplitN(jsonTag, ",", 2)
+								if parts[0] != "-" {
+									sf.JsonTag = parts[0]
+								}
+							}
+
+							if bindingTag, ok := structTag.Lookup("binding"); ok {
+								sf.BindingTag = bindingTag
+							}
+
+							if validateTag, ok := structTag.Lookup("validate"); ok {
+								if sf.BindingTag == "" {
+									sf.BindingTag = validateTag
+								}
+							}
+						}
+
+						if field.Comment != nil {
+							sf.Comment = strings.TrimSpace(field.Comment.Text())
+						}
+
+						structDef.Fields = append(structDef.Fields, sf)
+					}
+				}
+			}
+
+			structs[structDef.Name] = structDef
+		}
+	}
+
+	return structs
+}
+
+func extractTypeNameFromExpr(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return "*" + extractTypeNameFromExpr(e.X)
+	case *ast.ArrayType:
+		return "[]" + extractTypeNameFromExpr(e.Elt)
+	case *ast.MapType:
+		return "map[" + extractTypeNameFromExpr(e.Key) + "]" + extractTypeNameFromExpr(e.Value)
+	case *ast.SelectorExpr:
+		if x, ok := e.X.(*ast.Ident); ok {
+			return x.Name + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.InterfaceType:
+		return "interface{}"
+	case *ast.StructType:
+		return "struct{}"
+	}
+	return ""
+}
+
+func buildVarTypeMap(fn *ast.FuncDecl) map[string]string {
+	if fn.Body == nil {
+		return nil
+	}
+
+	varMap := make(map[string]string)
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.DeclStmt:
+			genDecl, ok := stmt.Decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok || valueSpec.Type == nil {
+					continue
+				}
+				typeName := extractTypeNameFromExpr(valueSpec.Type)
+				for _, name := range valueSpec.Names {
+					varMap[name.Name] = typeName
+				}
+			}
+
+		case *ast.AssignStmt:
+			if stmt.Tok != token.DEFINE {
+				return true
+			}
+			for i, lhs := range stmt.Lhs {
+				ident, ok := lhs.(*ast.Ident)
+				if !ok || i >= len(stmt.Rhs) {
+					continue
+				}
+				typeName := inferTypeFromExpr(stmt.Rhs[i])
+				if typeName != "" {
+					varMap[ident.Name] = typeName
+				}
+			}
+		}
+		return true
+	})
+
+	return varMap
+}
+
+func inferTypeFromExpr(expr ast.Expr) string {
+	if unary, ok := expr.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+		inner := inferTypeFromExpr(unary.X)
+		if inner != "" {
+			return inner
+		}
+	}
+
+	if comp, ok := expr.(*ast.CompositeLit); ok {
+		return extractTypeNameFromExpr(comp.Type)
+	}
+
+	return ""
+}
+
+type TypeResolver struct {
+	structRegistry map[string]StructDef
+	resolving      map[string]bool
+}
+
+func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
+	return &TypeResolver{
+		structRegistry: structs,
+		resolving:      make(map[string]bool),
+	}
+}
+
+var goPrimitives = map[string]string{
+	"string":  model.JsonTypeString,
+	"bool":    model.JsonTypeBoolean,
+	"int":     model.JsonTypeInt,
+	"int8":    model.JsonTypeInt,
+	"int16":   model.JsonTypeInt,
+	"int32":   model.JsonTypeInt,
+	"int64":   model.JsonTypeLong,
+	"uint":    model.JsonTypeInt,
+	"uint8":   model.JsonTypeInt,
+	"uint16":  model.JsonTypeInt,
+	"uint32":  model.JsonTypeInt,
+	"uint64":  model.JsonTypeLong,
+	"float32": model.JsonTypeFloat,
+	"float64": model.JsonTypeDouble,
+	"byte":    model.JsonTypeInt,
+	"rune":    model.JsonTypeInt,
+}
+
+func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
+	if typeName == "" || typeName == "interface{}" || typeName == "any" {
+		return model.NullModel()
+	}
+
+	if typeName == "fiber.Map" {
+		return model.MapModel(model.SingleModel(model.JsonTypeString), model.NullModel())
+	}
+
+	if typeName == "struct{}" {
+		return model.EmptyObject()
+	}
+
+	if jsonType, ok := goPrimitives[typeName]; ok {
+		return model.SingleModel(jsonType)
+	}
+
+	if strings.HasPrefix(typeName, "*") {
+		return r.Resolve(typeName[1:])
+	}
+
+	if strings.HasPrefix(typeName, "[]") {
+		elemType := typeName[2:]
+		return model.ArrayModel(r.Resolve(elemType))
+	}
+
+	if strings.HasPrefix(typeName, "map[") {
+		keyType, valueType := parseMapType(typeName)
+		return model.MapModel(r.Resolve(keyType), r.Resolve(valueType))
+	}
+
+	structDef, found := r.structRegistry[typeName]
+	if !found {
+		return model.SingleModel(typeName)
+	}
+
+	if r.resolving[typeName] {
+		return model.RefModel(typeName)
+	}
+
+	r.resolving[typeName] = true
+	defer func() { delete(r.resolving, typeName) }()
+
+	fields := make(map[string]*model.FieldModel)
+
+	for _, f := range structDef.Fields {
+		fieldName := f.Name
+		if f.JsonTag != "" {
+			fieldName = f.JsonTag
+		} else {
+			fieldName = strings.ToLower(f.Name[:1]) + f.Name[1:]
+		}
+
+		required := strings.Contains(f.BindingTag, "required")
+
+		fields[fieldName] = &model.FieldModel{
+			Model:    r.Resolve(f.Type),
+			Required: required,
+		}
+	}
+
+	for _, embedded := range structDef.EmbeddedTypes {
+		embeddedModel := r.Resolve(strings.TrimPrefix(embedded, "*"))
+		if embeddedModel != nil && embeddedModel.IsObject() {
+			for k, v := range embeddedModel.Fields {
+				if _, exists := fields[k]; !exists {
+					fields[k] = v
+				}
+			}
+		}
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: typeName,
+		Fields:   fields,
+	}
+}
+
+func parseMapType(typeName string) (string, string) {
+	inner := typeName[4:]
+	depth := 1
+	for i, c := range inner {
+		switch c {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return inner[:i], inner[i+1:]
+			}
+		}
+	}
+	return "string", "interface{}"
+}
+
+func resolveVarType(typeName string, handlerKey string, varTypeMaps map[string]map[string]string) string {
+	if varMap, ok := varTypeMaps[handlerKey]; ok {
+		if resolved, found := varMap[typeName]; found {
+			return resolved
+		}
+	}
+	return typeName
+}

--- a/api-collector-go/fiber/resolver_test.go
+++ b/api-collector-go/fiber/resolver_test.go
@@ -1,0 +1,310 @@
+package fiber
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func parseSource(t *testing.T, src string) *ast.File {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+	return f
+}
+
+func TestExtractStructs(t *testing.T) {
+	src := `package main
+
+type User struct {
+	Name  string  ` + "`json:\"name\" validate:\"required\"`" + `
+	Email string  ` + "`json:\"email\"`" + `
+	Age   int     ` + "`json:\"age,omitempty\"`" + `
+}
+
+type Admin struct {
+	User
+	Role string ` + "`json:\"role\"`" + `
+}
+`
+	f := parseSource(t, src)
+	structs := extractStructs(f)
+
+	if len(structs) != 2 {
+		t.Fatalf("Expected 2 structs, got %d", len(structs))
+	}
+
+	user := structs["User"]
+	if len(user.Fields) != 3 {
+		t.Fatalf("Expected 3 fields in User, got %d", len(user.Fields))
+	}
+	if user.Fields[0].JsonTag != "name" {
+		t.Errorf("Expected json tag 'name', got '%s'", user.Fields[0].JsonTag)
+	}
+	if user.Fields[0].BindingTag != "required" {
+		t.Errorf("Expected binding tag 'required' from validate tag, got '%s'", user.Fields[0].BindingTag)
+	}
+	if user.Fields[2].JsonTag != "age" {
+		t.Errorf("Expected json tag 'age', got '%s'", user.Fields[2].JsonTag)
+	}
+
+	admin := structs["Admin"]
+	if len(admin.EmbeddedTypes) != 1 {
+		t.Fatalf("Expected 1 embedded type in Admin, got %d", len(admin.EmbeddedTypes))
+	}
+	if admin.EmbeddedTypes[0] != "User" {
+		t.Errorf("Expected embedded type 'User', got '%s'", admin.EmbeddedTypes[0])
+	}
+}
+
+func TestBuildVarTypeMap(t *testing.T) {
+	src := `package main
+
+func handler() {
+	var req CreateUserReq
+	var resp *UserResponse
+	item := Item{}
+	ptr := &Product{}
+}
+`
+	f := parseSource(t, src)
+	fn := f.Decls[0].(*ast.FuncDecl)
+	varMap := buildVarTypeMap(fn)
+
+	tests := []struct {
+		varName  string
+		typeName string
+	}{
+		{"req", "CreateUserReq"},
+		{"resp", "*UserResponse"},
+		{"item", "Item"},
+		{"ptr", "Product"},
+	}
+
+	for _, tt := range tests {
+		if got := varMap[tt.varName]; got != tt.typeName {
+			t.Errorf("varMap[%q] = %q, want %q", tt.varName, got, tt.typeName)
+		}
+	}
+}
+
+func TestResolve_Primitives(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+
+	tests := []struct {
+		goType   string
+		jsonType string
+	}{
+		{"string", model.JsonTypeString},
+		{"int", model.JsonTypeInt},
+		{"int64", model.JsonTypeLong},
+		{"float64", model.JsonTypeDouble},
+		{"bool", model.JsonTypeBoolean},
+	}
+
+	for _, tt := range tests {
+		result := resolver.Resolve(tt.goType)
+		if !result.IsSingle() {
+			t.Errorf("Resolve(%q): expected single model, got kind=%s", tt.goType, result.Kind)
+		}
+		if result.TypeName != tt.jsonType {
+			t.Errorf("Resolve(%q): got type %q, want %q", tt.goType, result.TypeName, tt.jsonType)
+		}
+	}
+}
+
+func TestResolve_Pointers(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("*string")
+
+	if !result.IsSingle() {
+		t.Errorf("Expected single model for *string, got kind=%s", result.Kind)
+	}
+	if result.TypeName != model.JsonTypeString {
+		t.Errorf("Expected string type, got %q", result.TypeName)
+	}
+}
+
+func TestResolve_Slices(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("[]string")
+
+	if !result.IsArray() {
+		t.Fatalf("Expected array model, got kind=%s", result.Kind)
+	}
+	if result.Items == nil || !result.Items.IsSingle() {
+		t.Error("Expected array items to be single model")
+	}
+	if result.Items.TypeName != model.JsonTypeString {
+		t.Errorf("Expected string items, got %q", result.Items.TypeName)
+	}
+}
+
+func TestResolve_Maps(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("map[string]int")
+
+	if !result.IsMap() {
+		t.Fatalf("Expected map model, got kind=%s", result.Kind)
+	}
+	if result.KeyModel == nil || result.KeyModel.TypeName != model.JsonTypeString {
+		t.Error("Expected string key type")
+	}
+	if result.ValueModel == nil || result.ValueModel.TypeName != model.JsonTypeInt {
+		t.Error("Expected int value type")
+	}
+}
+
+func TestResolve_FiberMap(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("fiber.Map")
+
+	if !result.IsMap() {
+		t.Fatalf("Expected map model for fiber.Map, got kind=%s", result.Kind)
+	}
+}
+
+func TestResolve_Struct(t *testing.T) {
+	structs := map[string]StructDef{
+		"User": {
+			Name: "User",
+			Fields: []StructField{
+				{Name: "Name", Type: "string", JsonTag: "name", BindingTag: "required"},
+				{Name: "Email", Type: "string", JsonTag: "email"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("User")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	if len(result.Fields) != 2 {
+		t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+	}
+	if result.Fields["name"] == nil {
+		t.Error("Expected 'name' field")
+	}
+	if !result.Fields["name"].Required {
+		t.Error("Expected 'name' field to be required")
+	}
+	if result.Fields["email"] == nil {
+		t.Error("Expected 'email' field")
+	}
+}
+
+func TestResolve_EmbeddedStruct(t *testing.T) {
+	structs := map[string]StructDef{
+		"Base": {
+			Name: "Base",
+			Fields: []StructField{
+				{Name: "ID", Type: "int64", JsonTag: "id"},
+			},
+		},
+		"User": {
+			Name:          "User",
+			EmbeddedTypes: []string{"Base"},
+			Fields: []StructField{
+				{Name: "Name", Type: "string", JsonTag: "name"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("User")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	if len(result.Fields) != 2 {
+		t.Fatalf("Expected 2 fields (1 own + 1 embedded), got %d", len(result.Fields))
+	}
+	if result.Fields["id"] == nil {
+		t.Error("Expected embedded 'id' field from Base")
+	}
+	if result.Fields["name"] == nil {
+		t.Error("Expected 'name' field")
+	}
+}
+
+func TestResolve_CircularReference(t *testing.T) {
+	structs := map[string]StructDef{
+		"Node": {
+			Name: "Node",
+			Fields: []StructField{
+				{Name: "Value", Type: "string", JsonTag: "value"},
+				{Name: "Next", Type: "*Node", JsonTag: "next"},
+			},
+		},
+	}
+
+	resolver := NewTypeResolver(structs)
+	result := resolver.Resolve("Node")
+
+	if !result.IsObject() {
+		t.Fatalf("Expected object model, got kind=%s", result.Kind)
+	}
+	nextField := result.Fields["next"]
+	if nextField == nil {
+		t.Fatal("Expected 'next' field")
+	}
+	if !nextField.Model.IsRef() {
+		t.Errorf("Expected ref model for circular reference, got kind=%s", nextField.Model.Kind)
+	}
+}
+
+func TestResolve_EmptyAndNull(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+
+	if result := resolver.Resolve(""); !result.IsSingle() || result.TypeName != model.JsonTypeNull {
+		t.Errorf("Expected null for empty type, got kind=%s typeName=%s", result.Kind, result.TypeName)
+	}
+
+	if result := resolver.Resolve("interface{}"); !result.IsSingle() || result.TypeName != model.JsonTypeNull {
+		t.Errorf("Expected null for interface{}, got kind=%s typeName=%s", result.Kind, result.TypeName)
+	}
+
+	if result := resolver.Resolve("struct{}"); !result.IsObject() {
+		t.Errorf("Expected object for struct{}, got kind=%s", result.Kind)
+	}
+}
+
+func TestResolve_UnknownType(t *testing.T) {
+	resolver := NewTypeResolver(nil)
+	result := resolver.Resolve("CustomType")
+
+	if !result.IsSingle() {
+		t.Errorf("Expected single model for unknown type, got kind=%s", result.Kind)
+	}
+	if result.TypeName != "CustomType" {
+		t.Errorf("Expected typeName 'CustomType', got %q", result.TypeName)
+	}
+}
+
+func TestResolveVarType(t *testing.T) {
+	varTypeMaps := map[string]map[string]string{
+		"handler": {
+			"req": "CreateUserReq",
+		},
+	}
+
+	if got := resolveVarType("req", "handler", varTypeMaps); got != "CreateUserReq" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "CreateUserReq")
+	}
+
+	if got := resolveVarType("unknown", "handler", varTypeMaps); got != "unknown" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "unknown")
+	}
+
+	if got := resolveVarType("req", "otherHandler", varTypeMaps); got != "req" {
+		t.Errorf("resolveVarType: got %q, want %q", got, "req")
+	}
+}

--- a/api-collector-go/fiber/testdata/typed/main.go
+++ b/api-collector-go/fiber/testdata/typed/main.go
@@ -1,0 +1,78 @@
+package main
+
+import "github.com/gofiber/fiber/v2"
+
+type BaseModel struct {
+	ID        int64  `json:"id"`
+	CreatedAt string `json:"created_at"`
+}
+
+type CreateUserReq struct {
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"required"`
+	Age   *int   `json:"age"`
+}
+
+type UserVO struct {
+	BaseModel
+	Name   string   `json:"name"`
+	Email  string   `json:"email"`
+	Active bool     `json:"active"`
+	Tags   []string `json:"tags"`
+}
+
+type UpdateUserReq struct {
+	Name  *string `json:"name"`
+	Email *string `json:"email"`
+}
+
+type SearchQuery struct {
+	Keyword string `json:"keyword" validate:"required"`
+	Page    int    `json:"page"`
+	Size    int    `json:"size"`
+}
+
+func main() {
+	app := fiber.New()
+
+	app.Post("/users", createUser)
+	app.Get("/users/:id", getUser)
+	app.Put("/users/:id", updateUser)
+	app.Get("/users", listUsers)
+	app.Get("/search", searchUsers)
+
+	app.Listen(":3000")
+}
+
+// createUser creates a new user.
+func createUser(c *fiber.Ctx) error {
+	var req CreateUserReq
+	_ = c.BodyParser(&req)
+	return c.JSON(UserVO{})
+}
+
+// getUser returns a user by ID.
+func getUser(c *fiber.Ctx) error {
+	return c.JSON(UserVO{})
+}
+
+// updateUser updates a user.
+func updateUser(c *fiber.Ctx) error {
+	req := UpdateUserReq{}
+	_ = c.BodyParser(&req)
+	return c.JSON(UserVO{})
+}
+
+// listUsers returns all users.
+func listUsers(c *fiber.Ctx) error {
+	name := c.Query("name")
+	_ = name
+	return c.JSON(fiber.Map{"users": []UserVO{}})
+}
+
+// searchUsers searches users by query.
+func searchUsers(c *fiber.Ctx) error {
+	var query SearchQuery
+	_ = c.QueryParser(&query)
+	return c.JSON(fiber.Map{"results": []UserVO{}})
+}


### PR DESCRIPTION
Implements detailed request/response type resolution for the Go Fiber parser, resolving #92.

## Changes
- Add fiber/resolver.go with TypeResolver, StructDef, extractStructs, buildVarTypeMap
- Integrate type resolution into fiber/parser.go (structDefs, varTypeMaps, TypeResolver)
- Add QueryParser support for extracting query parameter types
- Handle struct embedding, pointers, slices, maps, fiber.Map, generics
- Add fiber/testdata/typed/main.go with typed request/response test cases
- Add fiber/resolver_test.go with unit tests for type resolution
- Update fiber/parser_test.go with typed endpoint integration tests

Closes #92