### PR TITLE
feat: add detailed request/response type resolution for Express TypeScript

### DIFF
--- a/api-collector-node/express/parser.go
+++ b/api-collector-node/express/parser.go
@@ -1,7 +1,3 @@
-// Package express parses Express route registrations using tree-sitter-javascript.
-// It walks JavaScript source files for app.get, app.post, router.get, etc. calls
-// and extracts endpoint metadata including path, HTTP method, handler function name,
-// and JSDoc comments.
 package express
 
 import (
@@ -13,6 +9,7 @@ import (
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+	typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
 
 	collector "github.com/tangcent/apilot/api-collector"
 )
@@ -28,19 +25,46 @@ var httpMethods = map[string]bool{
 }
 
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	jsFiles, err := discoverJSFiles(sourceDir)
-	if err != nil || len(jsFiles) == 0 {
+	allFiles, err := discoverSourceFiles(sourceDir)
+	if err != nil || len(allFiles) == 0 {
 		return nil, nil
 	}
 
-	ch := make(chan fileResult, len(jsFiles))
+	var tsFiles []string
+	var jsFiles []string
+	for _, f := range allFiles {
+		if strings.HasSuffix(f, ".ts") || strings.HasSuffix(f, ".tsx") {
+			tsFiles = append(tsFiles, f)
+		} else {
+			jsFiles = append(jsFiles, f)
+		}
+	}
+
+	typeRegistry := NewTSTypeRegistry()
+	if len(tsFiles) > 0 {
+		reg, err := ParseTSTypes(sourceDir)
+		if err == nil && reg != nil {
+			typeRegistry = reg
+		}
+	}
+
+	ch := make(chan fileResult, len(allFiles))
 	var wg sync.WaitGroup
 
 	for _, path := range jsFiles {
 		wg.Add(1)
 		go func(filePath string) {
 			defer wg.Done()
-			res := processFile(filePath)
+			res := processJSFile(filePath, typeRegistry)
+			ch <- res
+		}(path)
+	}
+
+	for _, path := range tsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processTSFile(filePath, typeRegistry)
 			ch <- res
 		}(path)
 	}
@@ -70,6 +94,28 @@ type fileResult struct {
 	err       error
 }
 
+func discoverSourceFiles(sourceDir string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".js", ".mjs", ".ts", ".tsx":
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
 func discoverJSFiles(sourceDir string) ([]string, error) {
 	var jsFiles []string
 	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
@@ -85,6 +131,58 @@ func discoverJSFiles(sourceDir string) ([]string, error) {
 		return nil, err
 	}
 	return jsFiles, nil
+}
+
+func processJSFile(filePath string, typeRegistry *TSTypeRegistry) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(javascript.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source, typeRegistry)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func processTSFile(filePath string, typeRegistry *TSTypeRegistry) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(typescript.LanguageTypescript())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source, typeRegistry)
+
+	return fileResult{endpoints: endpoints}
 }
 
 func processFile(filePath string) fileResult {
@@ -108,12 +206,12 @@ func processFile(filePath string) fileResult {
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	endpoints := extractEndpoints(rootNode, source)
+	endpoints := extractEndpoints(rootNode, source, nil)
 
 	return fileResult{endpoints: endpoints}
 }
 
-func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte, typeRegistry *TSTypeRegistry) []collector.ApiEndpoint {
 	var endpoints []collector.ApiEndpoint
 	var lastComment string
 
@@ -131,7 +229,7 @@ func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.Api
 		}
 
 		if child.Kind() == "expression_statement" {
-			ep := extractFromExpressionStatement(child, source, lastComment)
+			ep := extractFromExpressionStatement(child, source, lastComment, typeRegistry)
 			if ep != nil {
 				endpoints = append(endpoints, *ep)
 			}
@@ -144,17 +242,17 @@ func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.Api
 	return endpoints
 }
 
-func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string, typeRegistry *TSTypeRegistry) *collector.ApiEndpoint {
 	for i := uint(0); i < node.ChildCount(); i++ {
 		child := node.Child(i)
 		if child.Kind() == "call_expression" {
-			return extractFromCallExpression(child, source, description)
+			return extractFromCallExpression(child, source, description, typeRegistry)
 		}
 	}
 	return nil
 }
 
-func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string, typeRegistry *TSTypeRegistry) *collector.ApiEndpoint {
 	method, isRoute := extractMethodInfo(callNode, source)
 	if !isRoute {
 		return nil
@@ -187,6 +285,25 @@ func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, descri
 			})
 		}
 		ep.Parameters = params
+	}
+
+	if typeRegistry != nil {
+		handlerInfo := AnalyzeExpressHandler(callNode, source)
+		if handlerInfo != nil {
+			reqBody, resBody := ResolveHandlerTypes(handlerInfo, typeRegistry)
+			if reqBody != nil && !reqBody.IsNull() {
+				ep.RequestBody = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      reqBody,
+				}
+			}
+			if resBody != nil && !resBody.IsNull() {
+				ep.Response = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      resBody,
+				}
+			}
+		}
 	}
 
 	return ep

--- a/api-collector-node/express/parser_test.go
+++ b/api-collector-node/express/parser_test.go
@@ -257,6 +257,131 @@ func assertEndpoint(t *testing.T, got collector.ApiEndpoint, want collector.ApiE
 	assertParams(t, got.Parameters, want.Parameters)
 }
 
+func TestParse_TypedRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed routes should not error: %v", err)
+	}
+	if len(endpoints) == 0 {
+		t.Fatalf("expected endpoints for typed routes, got 0")
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	var postUsers, getUsers, getUserById, putUserById []collector.ApiEndpoint
+	for _, ep := range endpoints {
+		switch {
+		case ep.Method == "POST" && ep.Path == "/users":
+			postUsers = append(postUsers, ep)
+		case ep.Method == "GET" && ep.Path == "/users":
+			getUsers = append(getUsers, ep)
+		case ep.Method == "GET" && ep.Path == "/users/{id}":
+			getUserById = append(getUserById, ep)
+		case ep.Method == "PUT" && ep.Path == "/users/{id}":
+			putUserById = append(putUserById, ep)
+		}
+	}
+
+	if len(postUsers) > 0 {
+		ep := postUsers[0]
+		if ep.RequestBody == nil || ep.RequestBody.Body == nil {
+			t.Errorf("POST /users should have request body with type info")
+		} else {
+			body := ep.RequestBody.Body
+			if !body.IsObject() {
+				t.Errorf("POST /users request body should be object, got %s", body.Kind)
+			}
+			if _, ok := body.Fields["name"]; !ok {
+				t.Errorf("POST /users request body should have 'name' field")
+			}
+			if _, ok := body.Fields["email"]; !ok {
+				t.Errorf("POST /users request body should have 'email' field")
+			}
+		}
+
+		if ep.Response == nil || ep.Response.Body == nil {
+			t.Errorf("POST /users should have response with type info")
+		} else {
+			body := ep.Response.Body
+			if !body.IsObject() {
+				t.Errorf("POST /users response should be object, got %s", body.Kind)
+			}
+		}
+	}
+
+	if len(getUserById) > 0 {
+		ep := getUserById[0]
+		if ep.Response == nil || ep.Response.Body == nil {
+			t.Errorf("GET /users/{id} should have response with type info")
+		} else {
+			body := ep.Response.Body
+			if !body.IsObject() {
+				t.Errorf("GET /users/{id} response should be object, got %s", body.Kind)
+			}
+			if _, ok := body.Fields["id"]; !ok {
+				t.Errorf("GET /users/{id} response should have 'id' field")
+			}
+			if _, ok := body.Fields["name"]; !ok {
+				t.Errorf("GET /users/{id} response should have 'name' field")
+			}
+		}
+	}
+}
+
+func TestParse_TypedRoutesWithOrders(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed routes should not error: %v", err)
+	}
+
+	var postOrders, getOrders, getOrderById []collector.ApiEndpoint
+	for _, ep := range endpoints {
+		switch {
+		case ep.Method == "POST" && ep.Path == "/orders":
+			postOrders = append(postOrders, ep)
+		case ep.Method == "GET" && ep.Path == "/orders":
+			getOrders = append(getOrders, ep)
+		case ep.Method == "GET" && ep.Path == "/orders/{id}":
+			getOrderById = append(getOrderById, ep)
+		}
+	}
+
+	if len(postOrders) > 0 {
+		ep := postOrders[0]
+		if ep.RequestBody == nil || ep.RequestBody.Body == nil {
+			t.Errorf("POST /orders should have request body with type info")
+		} else {
+			body := ep.RequestBody.Body
+			if !body.IsObject() {
+				t.Errorf("POST /orders request body should be object, got %s", body.Kind)
+			}
+			if _, ok := body.Fields["productId"]; !ok {
+				t.Errorf("POST /orders request body should have 'productId' field")
+			}
+			if _, ok := body.Fields["quantity"]; !ok {
+				t.Errorf("POST /orders request body should have 'quantity' field")
+			}
+		}
+	}
+
+	if len(getOrderById) > 0 {
+		ep := getOrderById[0]
+		if ep.Response == nil || ep.Response.Body == nil {
+			t.Errorf("GET /orders/{id} should have response with type info")
+		} else {
+			body := ep.Response.Body
+			if !body.IsObject() {
+				t.Errorf("GET /orders/{id} response should be object, got %s", body.Kind)
+			}
+		}
+	}
+}
+
 func assertParams(t *testing.T, got, want []collector.ApiParameter) {
 	t.Helper()
 

--- a/api-collector-node/express/resolver.go
+++ b/api-collector-node/express/resolver.go
@@ -1,0 +1,376 @@
+package express
+
+import (
+	"strings"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+var tsPrimitiveTypes = map[string]string{
+	"string":          model.JsonTypeString,
+	"number":          model.JsonTypeInt,
+	"boolean":         model.JsonTypeBoolean,
+	"null":            model.JsonTypeNull,
+	"undefined":       model.JsonTypeNull,
+	"void":            model.JsonTypeNull,
+	"any":             model.JsonTypeString,
+	"unknown":         model.JsonTypeString,
+	"never":           model.JsonTypeNull,
+	"object":          model.JsonTypeString,
+	"Date":            model.JsonTypeString,
+	"BigInt":          model.JsonTypeLong,
+	"symbol":          model.JsonTypeString,
+	"string[]":        "string[]",
+	"number[]":        "int[]",
+	"boolean[]":       "boolean[]",
+	"Record":          "map",
+	"Partial":         "object",
+	"Required":        "object",
+	"Readonly":        "object",
+	"Pick":            "object",
+	"Omit":            "object",
+	"Exclude":         "object",
+	"Extract":         "object",
+	"NonNullable":     "object",
+	"ReturnType":      "object",
+	"InstanceType":    "object",
+	"ParamsDictionary": "",
+	"ParsedQs":       "",
+	"qs.ParsedQs":    "",
+}
+
+var tsCollectionTypes = map[string]bool{
+	"Array":      true,
+	"ReadonlyArray": true,
+	"Set":        true,
+	"ReadonlySet": true,
+	"Map":        true,
+	"ReadonlyMap": true,
+	"Iterable":   true,
+	"AsyncIterable": true,
+}
+
+type TSTypeResolver struct {
+	registry   *TSTypeRegistry
+	resolving  map[string]bool
+}
+
+func NewTSTypeResolver(registry *TSTypeRegistry) *TSTypeResolver {
+	return &TSTypeResolver{
+		registry:  registry,
+		resolving: make(map[string]bool),
+	}
+}
+
+func (r *TSTypeResolver) Resolve(rawType string, typeBindings map[string]string) *model.ObjectModel {
+	if rawType == "" {
+		return model.NullModel()
+	}
+
+	rawType = strings.TrimSpace(rawType)
+
+	if typeBindings != nil {
+		if bound, ok := typeBindings[rawType]; ok {
+			return r.Resolve(bound, nil)
+		}
+	}
+
+	if jsonType, ok := tsPrimitiveTypes[rawType]; ok {
+		if jsonType == "" {
+			return model.NullModel()
+		}
+		if strings.HasSuffix(jsonType, "[]") {
+			itemType := strings.TrimSuffix(jsonType, "[]")
+			return model.ArrayModel(model.SingleModel(itemType))
+		}
+		if jsonType == "map" {
+			return model.MapModel(model.SingleModel(model.JsonTypeString), model.SingleModel(model.JsonTypeString))
+		}
+		return model.SingleModel(jsonType)
+	}
+
+	if strings.HasSuffix(rawType, "[]") {
+		itemType := strings.TrimSuffix(rawType, "[]")
+		itemModel := r.Resolve(itemType, typeBindings)
+		return model.ArrayModel(itemModel)
+	}
+
+	if strings.Contains(rawType, " | ") {
+		return r.resolveUnionType(rawType, typeBindings)
+	}
+
+	if strings.Contains(rawType, " & ") {
+		return r.resolveIntersectionType(rawType, typeBindings)
+	}
+
+	baseName, typeArgs := parseTSTypeArgs(rawType)
+
+	if baseName != rawType && len(typeArgs) > 0 {
+		return r.resolveGenericType(baseName, typeArgs, typeBindings)
+	}
+
+	if enum, found := r.registry.Enums[baseName]; found {
+		return r.resolveEnum(enum)
+	}
+
+	if iface, found := r.registry.Interfaces[baseName]; found {
+		return r.resolveInterface(iface, typeArgs, typeBindings)
+	}
+
+	if alias, found := r.registry.TypeAliases[baseName]; found {
+		return r.resolveTypeAlias(alias, typeArgs, typeBindings)
+	}
+
+	return model.SingleModel(rawType)
+}
+
+func (r *TSTypeResolver) resolveUnionType(rawType string, typeBindings map[string]string) *model.ObjectModel {
+	parts := strings.Split(rawType, " | ")
+	var nonNullParts []string
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "null" || part == "undefined" {
+			continue
+		}
+		nonNullParts = append(nonNullParts, part)
+	}
+
+	if len(nonNullParts) == 1 {
+		result := r.Resolve(nonNullParts[0], typeBindings)
+		return result
+	}
+
+	return model.SingleModel(rawType)
+}
+
+func (r *TSTypeResolver) resolveIntersectionType(rawType string, typeBindings map[string]string) *model.ObjectModel {
+	parts := strings.Split(rawType, " & ")
+	mergedFields := make(map[string]*model.FieldModel)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		resolved := r.Resolve(part, typeBindings)
+		if resolved != nil && resolved.IsObject() {
+			for name, field := range resolved.Fields {
+				if _, exists := mergedFields[name]; !exists {
+					mergedFields[name] = field
+				}
+			}
+		}
+	}
+
+	if len(mergedFields) > 0 {
+		return &model.ObjectModel{
+			Kind:     model.KindObject,
+			TypeName: "object",
+			Fields:   mergedFields,
+		}
+	}
+
+	return model.SingleModel("object")
+}
+
+func (r *TSTypeResolver) resolveGenericType(baseName string, typeArgs []string, typeBindings map[string]string) *model.ObjectModel {
+	if tsCollectionTypes[baseName] {
+		if baseName == "Map" || baseName == "ReadonlyMap" {
+			keyModel := model.SingleModel(model.JsonTypeString)
+			valueModel := model.NullModel()
+			if len(typeArgs) >= 2 {
+				valueModel = r.Resolve(typeArgs[1], typeBindings)
+			} else if len(typeArgs) == 1 {
+				valueModel = r.Resolve(typeArgs[0], typeBindings)
+			}
+			return model.MapModel(keyModel, valueModel)
+		}
+		if len(typeArgs) > 0 {
+			itemModel := r.Resolve(typeArgs[0], typeBindings)
+			return model.ArrayModel(itemModel)
+		}
+		return model.ArrayModel(model.NullModel())
+	}
+
+	if baseName == "Record" {
+		valueModel := model.NullModel()
+		if len(typeArgs) >= 2 {
+			valueModel = r.Resolve(typeArgs[1], typeBindings)
+		} else if len(typeArgs) == 1 {
+			valueModel = r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.MapModel(model.SingleModel(model.JsonTypeString), valueModel)
+	}
+
+	if baseName == "Promise" {
+		if len(typeArgs) > 0 {
+			return r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.NullModel()
+	}
+
+	if baseName == "Array" || baseName == "ReadonlyArray" {
+		if len(typeArgs) > 0 {
+			itemModel := r.Resolve(typeArgs[0], typeBindings)
+			return model.ArrayModel(itemModel)
+		}
+		return model.ArrayModel(model.NullModel())
+	}
+
+	if baseName == "Partial" || baseName == "Required" || baseName == "Readonly" {
+		if len(typeArgs) > 0 {
+			return r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.EmptyObject()
+	}
+
+	if baseName == "Pick" || baseName == "Omit" {
+		if len(typeArgs) > 0 {
+			return r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.EmptyObject()
+	}
+
+	if baseName == "Exclude" || baseName == "Extract" {
+		if len(typeArgs) > 0 {
+			return r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.NullModel()
+	}
+
+	if baseName == "NonNullable" {
+		if len(typeArgs) > 0 {
+			return r.Resolve(typeArgs[0], typeBindings)
+		}
+		return model.NullModel()
+	}
+
+	if baseName == "ReturnType" || baseName == "InstanceType" {
+		return model.EmptyObject()
+	}
+
+	if enum, found := r.registry.Enums[baseName]; found {
+		return r.resolveEnum(enum)
+	}
+
+	if iface, found := r.registry.Interfaces[baseName]; found {
+		return r.resolveInterface(iface, typeArgs, typeBindings)
+	}
+
+	if alias, found := r.registry.TypeAliases[baseName]; found {
+		return r.resolveTypeAlias(alias, typeArgs, typeBindings)
+	}
+
+	return model.SingleModel(baseName)
+}
+
+func (r *TSTypeResolver) resolveEnum(enum *TSEnum) *model.ObjectModel {
+	options := make([]model.FieldOption, 0, len(enum.Members))
+	for _, m := range enum.Members {
+		opt := model.FieldOption{Value: m.Name}
+		if m.Value != "" {
+			opt.Value = m.Value
+		}
+		options = append(options, opt)
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindSingle,
+		TypeName: enum.Name,
+	}
+}
+
+func (r *TSTypeResolver) resolveInterface(iface *TSInterface, typeArgs []string, typeBindings map[string]string) *model.ObjectModel {
+	if r.resolving[iface.Name] {
+		return model.RefModel(iface.Name)
+	}
+
+	r.resolving[iface.Name] = true
+	defer func() { delete(r.resolving, iface.Name) }()
+
+	localBindings := make(map[string]string)
+	for i, tp := range iface.TypeParameters {
+		if i < len(typeArgs) {
+			localBindings[tp] = typeArgs[i]
+		}
+	}
+	if typeBindings != nil {
+		for k, v := range typeBindings {
+			if _, exists := localBindings[k]; !exists {
+				localBindings[k] = v
+			}
+		}
+	}
+
+	fields := make(map[string]*model.FieldModel, len(iface.Fields))
+	for _, f := range iface.Fields {
+		fieldModel := r.Resolve(f.Type, localBindings)
+		fm := &model.FieldModel{
+			Model:    fieldModel,
+			Required: f.Required,
+			Comment:  f.Comment,
+		}
+		fields[f.Name] = fm
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: iface.Name,
+		Fields:   fields,
+	}
+}
+
+func (r *TSTypeResolver) resolveTypeAlias(alias *TSTypeAlias, typeArgs []string, typeBindings map[string]string) *model.ObjectModel {
+	if r.resolving[alias.Name] {
+		return model.RefModel(alias.Name)
+	}
+
+	r.resolving[alias.Name] = true
+	defer func() { delete(r.resolving, alias.Name) }()
+
+	localBindings := make(map[string]string)
+	for i, tp := range alias.TypeParameters {
+		if i < len(typeArgs) {
+			localBindings[tp] = typeArgs[i]
+		}
+	}
+	if typeBindings != nil {
+		for k, v := range typeBindings {
+			if _, exists := localBindings[k]; !exists {
+				localBindings[k] = v
+			}
+		}
+	}
+
+	return r.Resolve(alias.TypeDef, localBindings)
+}
+
+func parseTSTypeArgs(rawType string) (string, []string) {
+	idx := strings.Index(rawType, "<")
+	if idx == -1 {
+		return rawType, nil
+	}
+
+	baseName := rawType[:idx]
+	rest := rawType[idx:]
+
+	if len(rest) < 2 || rest[0] != '<' || rest[len(rest)-1] != '>' {
+		return rawType, nil
+	}
+
+	inner := rest[1 : len(rest)-1]
+	args := splitTypeArgs(inner)
+	return baseName, args
+}
+
+func ResolveHandlerTypes(handlerInfo *ExpressHandlerInfo, registry *TSTypeRegistry) (reqBody *model.ObjectModel, resBody *model.ObjectModel) {
+	resolver := NewTSTypeResolver(registry)
+
+	if handlerInfo.ReqBodyType != "" {
+		reqBody = resolver.Resolve(handlerInfo.ReqBodyType, nil)
+	}
+
+	if handlerInfo.ResBodyType != "" {
+		resBody = resolver.Resolve(handlerInfo.ResBodyType, nil)
+	}
+
+	return reqBody, resBody
+}

--- a/api-collector-node/express/resolver_test.go
+++ b/api-collector-node/express/resolver_test.go
@@ -1,0 +1,461 @@
+package express
+
+import (
+	"testing"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func TestTSTypeResolver_Primitives(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	tests := []struct {
+		input    string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"string", model.KindSingle, model.JsonTypeString},
+		{"number", model.KindSingle, model.JsonTypeInt},
+		{"boolean", model.KindSingle, model.JsonTypeBoolean},
+		{"null", model.KindSingle, model.JsonTypeNull},
+		{"void", model.KindSingle, model.JsonTypeNull},
+		{"any", model.KindSingle, model.JsonTypeString},
+		{"unknown", model.KindSingle, model.JsonTypeString},
+	}
+
+	for _, tt := range tests {
+		result := resolver.Resolve(tt.input, nil)
+		if result.Kind != tt.kind {
+			t.Errorf("Resolve(%q).Kind = %q, want %q", tt.input, result.Kind, tt.kind)
+		}
+		if result.TypeName != tt.typeName {
+			t.Errorf("Resolve(%q).TypeName = %q, want %q", tt.input, result.TypeName, tt.typeName)
+		}
+	}
+}
+
+func TestTSTypeResolver_ArrayTypes(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	result := resolver.Resolve("string[]", nil)
+	if !result.IsArray() {
+		t.Errorf("Resolve('string[]') should be array, got %s", result.Kind)
+	}
+	if result.Items == nil || result.Items.TypeName != model.JsonTypeString {
+		t.Errorf("Resolve('string[]').Items should be string, got %v", result.Items)
+	}
+
+	result = resolver.Resolve("number[]", nil)
+	if !result.IsArray() {
+		t.Errorf("Resolve('number[]') should be array, got %s", result.Kind)
+	}
+}
+
+func TestTSTypeResolver_GenericArray(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	result := resolver.Resolve("Array<string>", nil)
+	if !result.IsArray() {
+		t.Errorf("Resolve('Array<string>') should be array, got %s", result.Kind)
+	}
+	if result.Items == nil || result.Items.TypeName != model.JsonTypeString {
+		t.Errorf("Resolve('Array<string>').Items should be string, got %v", result.Items)
+	}
+}
+
+func TestTSTypeResolver_InterfaceResolution(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["User"] = &TSInterface{
+		Name: "User",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+			{Name: "name", Type: "string", Required: true},
+			{Name: "email", Type: "string", Required: true},
+			{Name: "age", Type: "number", Required: false},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("User", nil)
+
+	if !result.IsObject() {
+		t.Fatalf("Resolve('User') should be object, got %s", result.Kind)
+	}
+	if result.TypeName != "User" {
+		t.Errorf("Resolve('User').TypeName = %q, want 'User'", result.TypeName)
+	}
+	if len(result.Fields) != 4 {
+		t.Fatalf("Resolve('User') should have 4 fields, got %d", len(result.Fields))
+	}
+
+	nameField, ok := result.Fields["name"]
+	if !ok {
+		t.Fatal("User should have 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("User.name type = %q, want %q", nameField.Model.TypeName, model.JsonTypeString)
+	}
+	if !nameField.Required {
+		t.Error("User.name should be required")
+	}
+
+	ageField, ok := result.Fields["age"]
+	if !ok {
+		t.Fatal("User should have 'age' field")
+	}
+	if ageField.Required {
+		t.Error("User.age should be optional")
+	}
+}
+
+func TestTSTypeResolver_TypeAliasResolution(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["User"] = &TSInterface{
+		Name: "User",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+			{Name: "name", Type: "string", Required: true},
+		},
+	}
+	registry.TypeAliases["UserList"] = &TSTypeAlias{
+		Name:    "UserList",
+		TypeDef: "Array<User>",
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("UserList", nil)
+
+	if !result.IsArray() {
+		t.Fatalf("Resolve('UserList') should be array, got %s", result.Kind)
+	}
+	if result.Items == nil || !result.Items.IsObject() {
+		t.Errorf("Resolve('UserList').Items should be object, got %v", result.Items)
+	}
+}
+
+func TestTSTypeResolver_GenericInterface(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["PaginatedResponse"] = &TSInterface{
+		Name:           "PaginatedResponse",
+		TypeParameters: []string{"T"},
+		Fields: []TSField{
+			{Name: "items", Type: "Array<T>", Required: true},
+			{Name: "total", Type: "number", Required: true},
+			{Name: "page", Type: "number", Required: true},
+		},
+	}
+	registry.Interfaces["User"] = &TSInterface{
+		Name: "User",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+			{Name: "name", Type: "string", Required: true},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("PaginatedResponse<User>", nil)
+
+	if !result.IsObject() {
+		t.Fatalf("Resolve('PaginatedResponse<User>') should be object, got %s", result.Kind)
+	}
+
+	itemsField, ok := result.Fields["items"]
+	if !ok {
+		t.Fatal("PaginatedResponse<User> should have 'items' field")
+	}
+	if !itemsField.Model.IsArray() {
+		t.Errorf("PaginatedResponse<User>.items should be array, got %s", itemsField.Model.Kind)
+	}
+	if itemsField.Model.Items == nil || !itemsField.Model.Items.IsObject() {
+		t.Errorf("PaginatedResponse<User>.items items should be object, got %v", itemsField.Model.Items)
+	}
+}
+
+func TestTSTypeResolver_UnionType(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	result := resolver.Resolve("string | null", nil)
+	if !result.IsSingle() {
+		t.Errorf("Resolve('string | null') should be single, got %s", result.Kind)
+	}
+	if result.TypeName != model.JsonTypeString {
+		t.Errorf("Resolve('string | null').TypeName = %q, want %q", result.TypeName, model.JsonTypeString)
+	}
+}
+
+func TestTSTypeResolver_IntersectionType(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["Named"] = &TSInterface{
+		Name: "Named",
+		Fields: []TSField{
+			{Name: "name", Type: "string", Required: true},
+		},
+	}
+	registry.Interfaces["Aged"] = &TSInterface{
+		Name: "Aged",
+		Fields: []TSField{
+			{Name: "age", Type: "number", Required: true},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("Named & Aged", nil)
+
+	if !result.IsObject() {
+		t.Fatalf("Resolve('Named & Aged') should be object, got %s", result.Kind)
+	}
+	if len(result.Fields) != 2 {
+		t.Errorf("Resolve('Named & Aged') should have 2 fields, got %d", len(result.Fields))
+	}
+	if _, ok := result.Fields["name"]; !ok {
+		t.Error("Named & Aged should have 'name' field")
+	}
+	if _, ok := result.Fields["age"]; !ok {
+		t.Error("Named & Aged should have 'age' field")
+	}
+}
+
+func TestTSTypeResolver_RecordType(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	result := resolver.Resolve("Record<string, number>", nil)
+	if !result.IsMap() {
+		t.Errorf("Resolve('Record<string, number>') should be map, got %s", result.Kind)
+	}
+}
+
+func TestTSTypeResolver_PromiseType(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["User"] = &TSInterface{
+		Name: "User",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("Promise<User>", nil)
+
+	if !result.IsObject() {
+		t.Errorf("Resolve('Promise<User>') should unwrap to object, got %s", result.Kind)
+	}
+}
+
+func TestTSTypeResolver_CircularReference(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["Node"] = &TSInterface{
+		Name: "Node",
+		Fields: []TSField{
+			{Name: "value", Type: "string", Required: true},
+			{Name: "children", Type: "Array<Node>", Required: false},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("Node", nil)
+
+	if !result.IsObject() {
+		t.Fatalf("Resolve('Node') should be object, got %s", result.Kind)
+	}
+
+	childrenField, ok := result.Fields["children"]
+	if !ok {
+		t.Fatal("Node should have 'children' field")
+	}
+	if !childrenField.Model.IsArray() {
+		t.Errorf("Node.children should be array, got %s", childrenField.Model.Kind)
+	}
+}
+
+func TestTSTypeResolver_UnknownType(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	result := resolver.Resolve("UnknownType", nil)
+	if !result.IsSingle() {
+		t.Errorf("Resolve('UnknownType') should be single, got %s", result.Kind)
+	}
+	if result.TypeName != "UnknownType" {
+		t.Errorf("Resolve('UnknownType').TypeName = %q, want 'UnknownType'", result.TypeName)
+	}
+}
+
+func TestTSTypeResolver_EnumResolution(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Enums["Status"] = &TSEnum{
+		Name: "Status",
+		Members: []TSEnumMember{
+			{Name: "Active", Value: ""},
+			{Name: "Inactive", Value: ""},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("Status", nil)
+
+	if !result.IsSingle() {
+		t.Errorf("Resolve('Status') should be single, got %s", result.Kind)
+	}
+	if result.TypeName != "Status" {
+		t.Errorf("Resolve('Status').TypeName = %q, want 'Status'", result.TypeName)
+	}
+}
+
+func TestTSTypeResolver_TypeBindings(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["User"] = &TSInterface{
+		Name: "User",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+		},
+	}
+
+	resolver := NewTSTypeResolver(registry)
+	result := resolver.Resolve("T", map[string]string{"T": "User"})
+
+	if !result.IsObject() {
+		t.Errorf("Resolve('T' with binding T->User) should be object, got %s", result.Kind)
+	}
+	if result.TypeName != "User" {
+		t.Errorf("Resolve('T' with binding T->User).TypeName = %q, want 'User'", result.TypeName)
+	}
+}
+
+func TestParseExpressRequestGenerics(t *testing.T) {
+	tests := []struct {
+		input           string
+		wantReqBody     string
+		wantQuery       string
+		wantParams      string
+	}{
+		{
+			"Request<{}, {}, CreateUserRequest>",
+			"CreateUserRequest", "", "",
+		},
+		{
+			"Request<{ id: string }>",
+			"", "", "{ id: string }",
+		},
+		{
+			"Request<{ id: string }, {}, CreateUserRequest>",
+			"CreateUserRequest", "", "{ id: string }",
+		},
+		{
+			"Request<{ id: string }, {}, CreateUserRequest, QueryParams>",
+			"CreateUserRequest", "QueryParams", "{ id: string }",
+		},
+		{
+			"Request",
+			"", "", "",
+		},
+		{
+			"Request<ParamsDictionary, {}, CreateUserBody, ParsedQs>",
+			"CreateUserBody", "", "",
+		},
+	}
+
+	for _, tt := range tests {
+		reqBody, query, params := parseExpressRequestGenerics(tt.input)
+		if reqBody != tt.wantReqBody {
+			t.Errorf("parseExpressRequestGenerics(%q) reqBody = %q, want %q", tt.input, reqBody, tt.wantReqBody)
+		}
+		if query != tt.wantQuery {
+			t.Errorf("parseExpressRequestGenerics(%q) query = %q, want %q", tt.input, query, tt.wantQuery)
+		}
+		if params != tt.wantParams {
+			t.Errorf("parseExpressRequestGenerics(%q) params = %q, want %q", tt.input, params, tt.wantParams)
+		}
+	}
+}
+
+func TestSplitTypeArgs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"string, number", []string{"string", "number"}},
+		{"Array<User>", []string{"Array<User>"}},
+		{"string, Array<User>", []string{"string", "Array<User>"}},
+		{"string, number, boolean", []string{"string", "number", "boolean"}},
+	}
+
+	for _, tt := range tests {
+		result := splitTypeArgs(tt.input)
+		if len(result) != len(tt.expected) {
+			t.Errorf("splitTypeArgs(%q) = %v, want %v", tt.input, result, tt.expected)
+			continue
+		}
+		for i, v := range result {
+			if v != tt.expected[i] {
+				t.Errorf("splitTypeArgs(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+			}
+		}
+	}
+}
+
+func TestParseExpressResponseGenerics(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Response<UserResponse>", "UserResponse"},
+		{"Response", ""},
+		{"Response<any>", ""},
+		{"Response<{}>", ""},
+		{"Response<ListUsersResponse>", "ListUsersResponse"},
+		{"Response<PaginatedResponse<User>>", "PaginatedResponse<User>"},
+	}
+
+	for _, tt := range tests {
+		result := parseExpressResponseGenerics(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseExpressResponseGenerics(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestResolveHandlerTypes(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["CreateUserRequest"] = &TSInterface{
+		Name: "CreateUserRequest",
+		Fields: []TSField{
+			{Name: "name", Type: "string", Required: true},
+			{Name: "email", Type: "string", Required: true},
+		},
+	}
+	registry.Interfaces["UserResponse"] = &TSInterface{
+		Name: "UserResponse",
+		Fields: []TSField{
+			{Name: "id", Type: "number", Required: true},
+			{Name: "name", Type: "string", Required: true},
+		},
+	}
+
+	handlerInfo := &ExpressHandlerInfo{
+		ReqBodyType: "CreateUserRequest",
+		ResBodyType: "UserResponse",
+	}
+
+	reqBody, resBody := ResolveHandlerTypes(handlerInfo, registry)
+
+	if reqBody == nil || !reqBody.IsObject() {
+		t.Errorf("reqBody should be object, got %v", reqBody)
+	} else {
+		if _, ok := reqBody.Fields["name"]; !ok {
+			t.Error("reqBody should have 'name' field")
+		}
+	}
+
+	if resBody == nil || !resBody.IsObject() {
+		t.Errorf("resBody should be object, got %v", resBody)
+	} else {
+		if _, ok := resBody.Fields["id"]; !ok {
+			t.Error("resBody should have 'id' field")
+		}
+	}
+}

--- a/api-collector-node/express/testdata/typed/app.ts
+++ b/api-collector-node/express/testdata/typed/app.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from 'express';
+
+interface CreateUserRequest {
+    name: string;
+    email: string;
+    age?: number;
+}
+
+interface UserResponse {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface ListUsersResponse {
+    users: UserResponse[];
+    total: number;
+}
+
+/**
+ * listUsers returns all users.
+ */
+app.get('/users', (req: Request, res: Response<ListUsersResponse>) => {
+    res.json({ users: [], total: 0 });
+});
+
+/**
+ * createUser creates a new user.
+ */
+app.post('/users', (req: Request<{}, {}, CreateUserRequest>, res: Response<UserResponse>) => {
+    const { name, email } = req.body;
+    res.json({ id: 1, name, email });
+});
+
+/**
+ * getUser returns a single user by ID.
+ */
+app.get('/users/:id', (req: Request<{ id: string }>, res: Response<UserResponse>) => {
+    res.json({ id: 1, name: 'test', email: 'test@example.com' });
+});
+
+/**
+ * updateUser updates an existing user.
+ */
+app.put('/users/:id', (req: Request<{ id: string }, {}, CreateUserRequest>, res: Response<UserResponse>) => {
+    const { name, email } = req.body;
+    res.json({ id: 1, name, email });
+});
+
+/**
+ * deleteUser removes a user by ID.
+ */
+app.delete('/users/:id', (req: Request<{ id: string }>, res: Response) => {
+    res.status(204).send();
+});

--- a/api-collector-node/express/testdata/typed/orders.ts
+++ b/api-collector-node/express/testdata/typed/orders.ts
@@ -1,0 +1,57 @@
+import { Request, Response } from 'express';
+
+interface CreateOrderRequest {
+    productId: string;
+    quantity: number;
+    notes?: string;
+}
+
+interface OrderItem {
+    productId: string;
+    productName: string;
+    quantity: number;
+    price: number;
+}
+
+interface OrderResponse {
+    id: string;
+    items: OrderItem[];
+    total: number;
+    status: string;
+}
+
+type OrderStatus = 'pending' | 'confirmed' | 'shipped' | 'delivered';
+
+interface OrderDetailResponse extends OrderResponse {
+    status: OrderStatus;
+    createdAt: string;
+}
+
+interface PaginatedResponse<T> {
+    items: T[];
+    total: number;
+    page: number;
+    pageSize: number;
+}
+
+/**
+ * createOrder creates a new order.
+ */
+app.post('/orders', (req: Request<{}, {}, CreateOrderRequest>, res: Response<OrderResponse>) => {
+    const { productId, quantity } = req.body;
+    res.json({ id: '1', items: [], total: 0, status: 'pending' });
+});
+
+/**
+ * getOrder returns an order by ID.
+ */
+app.get('/orders/:id', (req: Request<{ id: string }>, res: Response<OrderDetailResponse>) => {
+    res.json({ id: '1', items: [], total: 0, status: 'pending', createdAt: '2024-01-01' });
+});
+
+/**
+ * listOrders returns all orders.
+ */
+app.get('/orders', (req: Request, res: Response<PaginatedResponse<OrderResponse>>) => {
+    res.json({ items: [], total: 0, page: 1, pageSize: 10 });
+});

--- a/api-collector-node/express/tsparser.go
+++ b/api-collector-node/express/tsparser.go
@@ -1,0 +1,924 @@
+package express
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+)
+
+func ParseTSTypes(sourceDir string) (*TSTypeRegistry, error) {
+	tsFiles, err := discoverTSFiles(sourceDir)
+	if err != nil || len(tsFiles) == 0 {
+		return NewTSTypeRegistry(), nil
+	}
+
+	ch := make(chan *TSTypeRegistry, len(tsFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range tsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			registry, err := extractTypesFromFile(filePath)
+			if err != nil {
+				ch <- NewTSTypeRegistry()
+				return
+			}
+			ch <- registry
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	merged := NewTSTypeRegistry()
+	for reg := range ch {
+		merged.Merge(reg)
+	}
+
+	return merged, nil
+}
+
+func discoverTSFiles(sourceDir string) ([]string, error) {
+	var tsFiles []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && (strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".tsx")) {
+			tsFiles = append(tsFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tsFiles, nil
+}
+
+func extractTypesFromFile(filePath string) (*TSTypeRegistry, error) {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(typescript.LanguageTypescript())
+	if err := p.SetLanguage(lang); err != nil {
+		return nil, fmt.Errorf("failed to set language: %w", err)
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return NewTSTypeRegistry(), nil
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	registry := extractTypesFromAST(rootNode, source)
+
+	return registry, nil
+}
+
+func extractTypesFromAST(rootNode *tree_sitter.Node, source []byte) *TSTypeRegistry {
+	registry := NewTSTypeRegistry()
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+		extractTopLevelType(child, registry, source)
+	}
+
+	return registry
+}
+
+func extractTopLevelType(node *tree_sitter.Node, registry *TSTypeRegistry, source []byte) {
+	switch node.Kind() {
+	case "interface_declaration":
+		iface := extractInterface(node, source)
+		if iface != nil {
+			registry.Interfaces[iface.Name] = iface
+		}
+	case "type_alias_declaration":
+		alias := extractTypeAlias(node, source)
+		if alias != nil {
+			registry.TypeAliases[alias.Name] = alias
+		}
+	case "enum_declaration":
+		enum := extractEnum(node, source)
+		if enum != nil {
+			registry.Enums[enum.Name] = enum
+		}
+	case "export_statement":
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			extractTopLevelType(child, registry, source)
+		}
+	case "ambient_declaration":
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			extractTopLevelType(child, registry, source)
+		}
+	case "declaration_list":
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			extractTopLevelType(child, registry, source)
+		}
+	}
+}
+
+func extractInterface(node *tree_sitter.Node, source []byte) *TSInterface {
+	name := ""
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "type_identifier" {
+			name = child.Utf8Text(source)
+			break
+		}
+	}
+	if name == "" {
+		return nil
+	}
+
+	iface := &TSInterface{
+		Name:    name,
+		Comment: extractPrevComment(node, source),
+	}
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "type_parameters":
+			iface.TypeParameters = extractTypeParameterNames(child, source)
+		case "object_type":
+			iface.Fields = extractInterfaceFields(child, source)
+		case "interface_body":
+			iface.Fields = extractInterfaceFields(child, source)
+		case "extends_clause":
+		}
+	}
+
+	return iface
+}
+
+func extractTypeParameterNames(node *tree_sitter.Node, source []byte) []string {
+	var names []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "type_parameter" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				tpChild := child.Child(j)
+				if tpChild.Kind() == "type_identifier" {
+					names = append(names, tpChild.Utf8Text(source))
+					break
+				}
+			}
+		}
+	}
+	return names
+}
+
+func extractInterfaceFields(objectType *tree_sitter.Node, source []byte) []TSField {
+	var fields []TSField
+
+	for i := uint(0); i < objectType.ChildCount(); i++ {
+		child := objectType.Child(i)
+		if child.Kind() == "property_signature" {
+			field := extractPropertySignature(child, source)
+			if field != nil {
+				fields = append(fields, *field)
+			}
+		}
+	}
+
+	return fields
+}
+
+func extractPropertySignature(node *tree_sitter.Node, source []byte) *TSField {
+	name := ""
+	typeStr := ""
+	required := true
+	comment := ""
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "property_identifier":
+			name = child.Utf8Text(source)
+		case "type_annotation":
+			typeStr = extractTypeAnnotation(child, source)
+		case "?":
+			required = false
+		case "comment":
+			comment = cleanComment(child.Utf8Text(source))
+		}
+	}
+
+	if name == "" {
+		return nil
+	}
+
+	if typeStr == "" {
+		typeStr = "any"
+	}
+
+	return &TSField{
+		Name:     name,
+		Type:     typeStr,
+		Required: required,
+		Comment:  comment,
+	}
+}
+
+func extractTypeAnnotation(node *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == ":" {
+			continue
+		}
+		return extractTypeNodeText(child, source)
+	}
+	return ""
+}
+
+func extractTypeNodeText(node *tree_sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind() {
+	case "type_identifier":
+		return node.Utf8Text(source)
+	case "predefined_type":
+		return node.Utf8Text(source)
+	case "generic_type":
+		return extractGenericTypeText(node, source)
+	case "array_type":
+		return extractArrayTypeText(node, source)
+	case "union_type":
+		return extractUnionTypeText(node, source)
+	case "intersection_type":
+		return extractIntersectionTypeText(node, source)
+	case "tuple_type":
+		return extractTupleTypeText(node, source)
+	case "object_type":
+		return "object"
+	case "literal_type":
+		return node.Utf8Text(source)
+	case "parenthesized_type":
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			if child.Kind() != "(" && child.Kind() != ")" {
+				return extractTypeNodeText(child, source)
+			}
+		}
+		return node.Utf8Text(source)
+	case "type_query":
+		return node.Utf8Text(source)
+	case "conditional_type":
+		return node.Utf8Text(source)
+	case "indexed_access_type":
+		return node.Utf8Text(source)
+	case "mapped_type":
+		return "object"
+	case "optional_type":
+		inner := extractInnerType(node, source)
+		return inner + "?"
+	case "nullable_type":
+		inner := extractInnerType(node, source)
+		return inner + " | null"
+	default:
+		return node.Utf8Text(source)
+	}
+}
+
+func extractInnerType(node *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		text := child.Utf8Text(source)
+		if text != "?" && text != "|" && text != "null" {
+			return extractTypeNodeText(child, source)
+		}
+	}
+	return ""
+}
+
+func extractGenericTypeText(node *tree_sitter.Node, source []byte) string {
+	var baseName string
+	var args []string
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "type_identifier":
+			baseName = child.Utf8Text(source)
+		case "type_arguments":
+			args = extractTypeArgumentTexts(child, source)
+		}
+	}
+
+	if len(args) > 0 {
+		return baseName + "<" + strings.Join(args, ", ") + ">"
+	}
+	return baseName
+}
+
+func extractTypeArgumentTexts(node *tree_sitter.Node, source []byte) []string {
+	var args []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "<" || child.Kind() == ">" || child.Kind() == "," {
+			continue
+		}
+		args = append(args, extractTypeNodeText(child, source))
+	}
+	return args
+}
+
+func extractArrayTypeText(node *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() != "[" && child.Kind() != "]" {
+			inner := extractTypeNodeText(child, source)
+			return inner + "[]"
+		}
+	}
+	return "any[]"
+}
+
+func extractUnionTypeText(node *tree_sitter.Node, source []byte) string {
+	var parts []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "|" {
+			continue
+		}
+		parts = append(parts, extractTypeNodeText(child, source))
+	}
+	return strings.Join(parts, " | ")
+}
+
+func extractIntersectionTypeText(node *tree_sitter.Node, source []byte) string {
+	var parts []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "&" {
+			continue
+		}
+		parts = append(parts, extractTypeNodeText(child, source))
+	}
+	return strings.Join(parts, " & ")
+}
+
+func extractTupleTypeText(node *tree_sitter.Node, source []byte) string {
+	var elems []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "[" || child.Kind() == "]" || child.Kind() == "," {
+			continue
+		}
+		elems = append(elems, extractTypeNodeText(child, source))
+	}
+	return "[" + strings.Join(elems, ", ") + "]"
+}
+
+func extractTypeAlias(node *tree_sitter.Node, source []byte) *TSTypeAlias {
+	name := ""
+	typeDef := ""
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "type_identifier":
+			name = child.Utf8Text(source)
+		case "type_parameters":
+		case "=":
+		case "object_type":
+			typeDef = "object"
+		default:
+			if name != "" && child.Kind() != "type_parameters" && child.Kind() != ";" {
+				typeDef = extractTypeNodeText(child, source)
+			}
+		}
+	}
+
+	if name == "" {
+		return nil
+	}
+
+	var typeParams []string
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "type_parameters" {
+			typeParams = extractTypeParameterNames(child, source)
+			break
+		}
+	}
+
+	return &TSTypeAlias{
+		Name:           name,
+		TypeDef:        typeDef,
+		TypeParameters: typeParams,
+		Comment:        extractPrevComment(node, source),
+	}
+}
+
+func extractEnum(node *tree_sitter.Node, source []byte) *TSEnum {
+	name := ""
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "identifier" {
+			name = child.Utf8Text(source)
+			break
+		}
+	}
+	if name == "" {
+		return nil
+	}
+
+	enum := &TSEnum{
+		Name:    name,
+		Comment: extractPrevComment(node, source),
+	}
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "enum_body" {
+			enum.Members = extractEnumMembers(child, source)
+		}
+	}
+
+	return enum
+}
+
+func extractEnumMembers(node *tree_sitter.Node, source []byte) []TSEnumMember {
+	var members []TSEnumMember
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "enum_assignment" {
+			member := extractEnumAssignment(child, source)
+			if member != nil {
+				members = append(members, *member)
+			}
+		} else if child.Kind() == "property_identifier" {
+			members = append(members, TSEnumMember{
+				Name:  child.Utf8Text(source),
+				Value: "",
+			})
+		}
+	}
+	return members
+}
+
+func extractEnumAssignment(node *tree_sitter.Node, source []byte) *TSEnumMember {
+	name := ""
+	value := ""
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "property_identifier":
+			name = child.Utf8Text(source)
+		case "=":
+		case "number", "string", "identifier":
+			value = child.Utf8Text(source)
+		}
+	}
+	if name == "" {
+		return nil
+	}
+	return &TSEnumMember{Name: name, Value: value}
+}
+
+func extractPrevComment(node *tree_sitter.Node, source []byte) string {
+	prev := node.PrevNamedSibling()
+	if prev != nil && prev.Kind() == "comment" {
+		commentText := prev.Utf8Text(source)
+		return cleanComment(commentText)
+	}
+	return ""
+}
+
+func cleanComment(comment string) string {
+	if strings.HasPrefix(comment, "/**") {
+		return cleanJSDocComment(comment)
+	}
+	if strings.HasPrefix(comment, "//") {
+		return strings.TrimSpace(strings.TrimPrefix(comment, "//"))
+	}
+	if strings.HasPrefix(comment, "/*") {
+		comment = strings.TrimPrefix(comment, "/*")
+		comment = strings.TrimSuffix(comment, "*/")
+		return strings.TrimSpace(comment)
+	}
+	return comment
+}
+
+func AnalyzeExpressHandler(callNode *tree_sitter.Node, source []byte) *ExpressHandlerInfo {
+	info := &ExpressHandlerInfo{}
+
+	handlerNode := findHandlerNode(callNode, source)
+	if handlerNode == nil {
+		return info
+	}
+
+	switch handlerNode.Kind() {
+	case "arrow_function":
+		info = analyzeArrowHandler(handlerNode, source)
+	case "function_expression":
+		info = analyzeFunctionHandler(handlerNode, source)
+	case "identifier":
+		info = analyzeIdentifierHandler(handlerNode, callNode, source)
+	}
+
+	return info
+}
+
+func findHandlerNode(callNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	argsNode := findChildByKindTS(callNode, "arguments")
+	if argsNode == nil {
+		return nil
+	}
+
+	pathFound := false
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		if !pathFound {
+			if child.Kind() == "string" {
+				pathFound = true
+			}
+			continue
+		}
+		return child
+	}
+	return nil
+}
+
+func analyzeArrowHandler(node *tree_sitter.Node, source []byte) *ExpressHandlerInfo {
+	info := &ExpressHandlerInfo{}
+	params := findChildByKindTS(node, "formal_parameters")
+	if params == nil {
+		return info
+	}
+
+	info.ReqBodyType, info.QueryType, info.ParamsType = extractRequestTypes(params, source)
+
+	resTypeFromGeneric := extractResponseTypes(params, source)
+	if resTypeFromGeneric != "" {
+		info.ResBodyType = resTypeFromGeneric
+	} else {
+		bodyNode := findChildByKindTS(node, "statement_block")
+		if bodyNode != nil {
+			info.ResBodyType = extractResponseTypeFromBody(bodyNode, source)
+		}
+	}
+
+	return info
+}
+
+func analyzeFunctionHandler(node *tree_sitter.Node, source []byte) *ExpressHandlerInfo {
+	info := &ExpressHandlerInfo{}
+	params := findChildByKindTS(node, "formal_parameters")
+	if params == nil {
+		return info
+	}
+
+	info.ReqBodyType, info.QueryType, info.ParamsType = extractRequestTypes(params, source)
+
+	resTypeFromGeneric := extractResponseTypes(params, source)
+	if resTypeFromGeneric != "" {
+		info.ResBodyType = resTypeFromGeneric
+	} else {
+		bodyNode := findChildByKindTS(node, "statement_block")
+		if bodyNode != nil {
+			info.ResBodyType = extractResponseTypeFromBody(bodyNode, source)
+		}
+	}
+
+	return info
+}
+
+func analyzeIdentifierHandler(idNode *tree_sitter.Node, callNode *tree_sitter.Node, source []byte) *ExpressHandlerInfo {
+	info := &ExpressHandlerInfo{}
+
+	handlerName := idNode.Utf8Text(source)
+	_ = handlerName
+
+	return info
+}
+
+func extractRequestTypes(params *tree_sitter.Node, source []byte) (reqBodyType string, queryType string, paramsType string) {
+	for i := uint(0); i < params.ChildCount(); i++ {
+		child := params.Child(i)
+		if child.Kind() == "required_parameter" || child.Kind() == "optional_parameter" {
+			paramType := extractParamTypeAnnotation(child, source)
+			paramName := extractParamName(child, source)
+
+			if paramName == "req" || paramName == "request" {
+				if strings.Contains(paramType, "Request<") {
+					reqBodyType, queryType, paramsType = parseExpressRequestGenerics(paramType)
+				}
+			}
+		}
+	}
+	return
+}
+
+func extractResponseTypes(params *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < params.ChildCount(); i++ {
+		child := params.Child(i)
+		if child.Kind() == "required_parameter" || child.Kind() == "optional_parameter" {
+			paramType := extractParamTypeAnnotation(child, source)
+			paramName := extractParamName(child, source)
+
+			if paramName == "res" || paramName == "response" {
+				if strings.Contains(paramType, "Response<") {
+					return parseExpressResponseGenerics(paramType)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func extractParamTypeAnnotation(paramNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < paramNode.ChildCount(); i++ {
+		child := paramNode.Child(i)
+		if child.Kind() == "type_annotation" {
+			return extractTypeAnnotation(child, source)
+		}
+	}
+	return ""
+}
+
+func extractParamName(paramNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < paramNode.ChildCount(); i++ {
+		child := paramNode.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
+func parseExpressRequestGenerics(requestType string) (reqBodyType string, queryType string, paramsType string) {
+	if !strings.Contains(requestType, "<") || !strings.Contains(requestType, ">") {
+		return "", "", ""
+	}
+
+	start := strings.Index(requestType, "<")
+	end := strings.LastIndex(requestType, ">")
+	if start >= end {
+		return "", "", ""
+	}
+
+	inner := requestType[start+1 : end]
+	args := splitTypeArgs(inner)
+
+	if len(args) >= 1 {
+		paramsType = strings.TrimSpace(args[0])
+		if paramsType == "ParamsDictionary" || paramsType == "Record<string, string>" || paramsType == "{}" {
+			paramsType = ""
+		}
+	}
+	if len(args) >= 2 {
+		resBody := strings.TrimSpace(args[1])
+		_ = resBody
+	}
+	if len(args) >= 3 {
+		reqBodyType = strings.TrimSpace(args[2])
+		if reqBodyType == "any" || reqBodyType == "{}" {
+			reqBodyType = ""
+		}
+	}
+	if len(args) >= 4 {
+		queryType = strings.TrimSpace(args[3])
+		if queryType == "qs.ParsedQs" || queryType == "ParsedQs" {
+			queryType = ""
+		}
+	}
+
+	return reqBodyType, queryType, paramsType
+}
+
+func parseExpressResponseGenerics(responseType string) string {
+	if !strings.Contains(responseType, "<") || !strings.Contains(responseType, ">") {
+		return ""
+	}
+
+	start := strings.Index(responseType, "<")
+	end := strings.LastIndex(responseType, ">")
+	if start >= end {
+		return ""
+	}
+
+	inner := responseType[start+1 : end]
+	args := splitTypeArgs(inner)
+
+	if len(args) >= 1 {
+		bodyType := strings.TrimSpace(args[0])
+		if bodyType != "" && bodyType != "any" && bodyType != "{}" {
+			return bodyType
+		}
+	}
+
+	return ""
+}
+
+func extractResponseTypeFromBody(bodyNode *tree_sitter.Node, source []byte) string {
+	var resType string
+	walkForResJson(bodyNode, source, &resType)
+	return resType
+}
+
+func walkForResJson(node *tree_sitter.Node, source []byte, resType *string) bool {
+	if node == nil {
+		return false
+	}
+
+	if node.Kind() == "call_expression" {
+		callee := findChildByKindTS(node, "member_expression")
+		if callee != nil {
+			prop := findChildByKindTS(callee, "property_identifier")
+			if prop != nil && prop.Utf8Text(source) == "json" {
+				argsNode := findChildByKindTS(node, "arguments")
+				if argsNode != nil {
+					*resType = inferTypeFromArguments(argsNode, source)
+					return true
+				}
+			}
+		}
+	}
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		if walkForResJson(node.Child(i), source, resType) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func inferTypeFromArguments(argsNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		return inferTypeFromExpression(child, source)
+	}
+	return ""
+}
+
+func inferTypeFromExpression(node *tree_sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+
+	switch node.Kind() {
+	case "object":
+		return inferTypeFromObjectLiteral(node, source)
+	case "array":
+		return "any[]"
+	case "string":
+		return "string"
+	case "number":
+		return "number"
+	case "true", "false":
+		return "boolean"
+	case "null":
+		return "null"
+	case "identifier":
+		return node.Utf8Text(source)
+	case "call_expression":
+		return ""
+	case "member_expression":
+		return ""
+	case "parenthesized_expression":
+		for i := uint(0); i < node.ChildCount(); i++ {
+			child := node.Child(i)
+			if child.Kind() != "(" && child.Kind() != ")" {
+				return inferTypeFromExpression(child, source)
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+func inferTypeFromObjectLiteral(node *tree_sitter.Node, source []byte) string {
+	fields := make(map[string]string)
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "pair" {
+			key, valType := extractPairType(child, source)
+			if key != "" {
+				fields[key] = valType
+			}
+		} else if child.Kind() == "shorthand_property_identifier" {
+			fields[child.Utf8Text(source)] = "any"
+		} else if child.Kind() == "spread_element" {
+		} else if child.Kind() == "method_definition" {
+		}
+	}
+
+	if len(fields) == 0 {
+		return "object"
+	}
+
+	return "object"
+}
+
+func extractPairType(node *tree_sitter.Node, source []byte) (string, string) {
+	key := ""
+	valType := "any"
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		kind := child.Kind()
+		if kind == "property_identifier" || kind == "string_fragment" {
+			if key == "" {
+				key = child.Utf8Text(source)
+			}
+		} else if kind == "string" {
+			if key == "" {
+				key = unquoteJSString(child.Utf8Text(source))
+			} else {
+				valType = "string"
+			}
+		} else if kind == ":" {
+		} else if kind == "number" {
+			valType = "number"
+		} else if kind == "true" || kind == "false" {
+			valType = "boolean"
+		} else if kind == "null" {
+			valType = "null"
+		} else if kind == "array" {
+			valType = "any[]"
+		} else if kind == "object" {
+			valType = "object"
+		} else if kind == "identifier" {
+			valType = "any"
+		} else {
+			inferred := inferTypeFromExpression(child, source)
+			if inferred != "" {
+				valType = inferred
+			}
+		}
+	}
+
+	return key, valType
+}
+
+func findChildByKindTS(node *tree_sitter.Node, kind string) *tree_sitter.Node {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func splitTypeArgs(s string) []string {
+	var args []string
+	depth := 0
+	start := 0
+
+	for i, c := range s {
+		switch c {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				arg := strings.TrimSpace(s[start:i])
+				if arg != "" {
+					args = append(args, arg)
+				}
+				start = i + 1
+			}
+		}
+	}
+
+	if start < len(s) {
+		arg := strings.TrimSpace(s[start:])
+		if arg != "" {
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}

--- a/api-collector-node/express/types.go
+++ b/api-collector-node/express/types.go
@@ -1,0 +1,70 @@
+package express
+
+type TSInterface struct {
+	Name           string
+	Fields         []TSField
+	TypeParameters []string
+	Comment        string
+}
+
+type TSField struct {
+	Name        string
+	Type        string
+	Comment     string
+	Required    bool
+	Annotations []string
+}
+
+type TSTypeAlias struct {
+	Name           string
+	TypeDef        string
+	TypeParameters []string
+	Comment        string
+}
+
+type TSEnum struct {
+	Name    string
+	Members []TSEnumMember
+	Comment string
+}
+
+type TSEnumMember struct {
+	Name    string
+	Value   string
+	Comment string
+}
+
+type TSTypeRegistry struct {
+	Interfaces  map[string]*TSInterface
+	TypeAliases map[string]*TSTypeAlias
+	Enums       map[string]*TSEnum
+}
+
+func NewTSTypeRegistry() *TSTypeRegistry {
+	return &TSTypeRegistry{
+		Interfaces:  make(map[string]*TSInterface),
+		TypeAliases: make(map[string]*TSTypeAlias),
+		Enums:       make(map[string]*TSEnum),
+	}
+}
+
+func (r *TSTypeRegistry) Merge(other *TSTypeRegistry) {
+	for k, v := range other.Interfaces {
+		r.Interfaces[k] = v
+	}
+	for k, v := range other.TypeAliases {
+		r.TypeAliases[k] = v
+	}
+	for k, v := range other.Enums {
+		r.Enums[k] = v
+	}
+}
+
+type ExpressHandlerInfo struct {
+	ReqBodyType string
+	ResBodyType string
+	QueryType   string
+	ParamsType  string
+	ReqBodyIn   string
+	ResBodyIn   string
+}

--- a/api-model/model.go
+++ b/api-model/model.go
@@ -120,6 +120,7 @@ func (m *ObjectModel) IsObject() bool { return m != nil && m.Kind == KindObject 
 func (m *ObjectModel) IsArray() bool  { return m != nil && m.Kind == KindArray }
 func (m *ObjectModel) IsMap() bool    { return m != nil && m.Kind == KindMap }
 func (m *ObjectModel) IsRef() bool    { return m != nil && m.Kind == KindRef }
+func (m *ObjectModel) IsNull() bool   { return m == nil || (m.Kind == KindSingle && m.TypeName == JsonTypeNull) }
 
 type FieldOpt func(*FieldModel)
 

--- a/samples/node-express/app.ts
+++ b/samples/node-express/app.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express';
+const app = require('express')();
+
+app.use(require('express').json());
+
+interface CreateUserRequest {
+    name: string;
+    email: string;
+    age?: number;
+}
+
+interface UserResponse {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface ListUsersResponse {
+    users: UserResponse[];
+    total: number;
+}
+
+interface UpdateUserRequest {
+    name?: string;
+    email?: string;
+}
+
+/**
+ * listUsers returns all users.
+ */
+app.get('/users', (req: Request, res: Response<ListUsersResponse>) => {
+    const { name, role = 'user' } = req.query;
+    res.json({ users: [], total: 0 });
+});
+
+/**
+ * createUser creates a new user.
+ */
+app.post('/users', (req: Request<{}, {}, CreateUserRequest>, res: Response<UserResponse>) => {
+    const { name, email } = req.body;
+    res.status(201).json({ id: 1, name, email });
+});
+
+/**
+ * getUser returns a single user by ID.
+ */
+app.get('/users/:id', (req: Request<{ id: string }>, res: Response<UserResponse>) => {
+    res.json({ id: 1, name: 'test', email: 'test@example.com' });
+});
+
+/**
+ * updateUser updates an existing user.
+ */
+app.put('/users/:id', (req: Request<{ id: string }, {}, UpdateUserRequest>, res: Response<UserResponse>) => {
+    const { name, email } = req.body;
+    res.json({ id: 1, name: name || 'unknown', email: email || '' });
+});
+
+/**
+ * deleteUser removes a user by ID.
+ */
+app.delete('/users/:id', (req: Request<{ id: string }>, res: Response) => {
+    res.status(204).send();
+});
+
+app.listen(3000, () => {
+    console.log('Server running on port 3000');
+});


### PR DESCRIPTION
Resolves #93

Adds detailed request/response type resolution for the Node.js Express parser, enabling structured field-level schemas for request bodies and response bodies extracted from TypeScript code.

Changes:
- TypeScript type extraction (tsparser.go): Parse interfaces, type aliases, and enums from .ts/.tsx files using tree-sitter-typescript
- Type resolution (resolver.go): Resolve TypeScript types including generics, intersections, unions, mapped types (Record, Partial, Pick, Omit), and Promise unwrapping
- Express integration (parser.go): Resolve Express Request and Response generic type parameters
- Model enhancement (model.go): Add IsNull() helper to ObjectModel
- Comprehensive tests and test data files
- Sample data: Enhanced samples/node-express/app.ts