### PR TITLE
feat: add detailed request/response type resolution for Fastify parser

### DIFF
--- a/api-collector-node/fastify/parser.go
+++ b/api-collector-node/fastify/parser.go
@@ -1,12 +1,3 @@
-// Package fastify parses Fastify route registrations using tree-sitter-javascript.
-// It walks JavaScript source files for fastify.get, fastify.post, etc. calls
-// and extracts endpoint metadata including path, HTTP method, handler function name,
-// and JSDoc comments.
-//
-// Supported patterns:
-//   - Shorthand: fastify.get('/path', handler)
-//   - Shorthand with options: fastify.get('/path', { schema: ... }, handler)
-//   - Route object: fastify.route({ method: 'GET', url: '/path', handler: fn })
 package fastify
 
 import (
@@ -18,7 +9,9 @@ import (
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+	typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
 
+	"github.com/tangcent/apilot/api-collector-node/express"
 	collector "github.com/tangcent/apilot/api-collector"
 )
 
@@ -31,19 +24,46 @@ var httpMethods = map[string]bool{
 }
 
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
-	jsFiles, err := discoverJSFiles(sourceDir)
-	if err != nil || len(jsFiles) == 0 {
+	allFiles, err := discoverSourceFiles(sourceDir)
+	if err != nil || len(allFiles) == 0 {
 		return nil, nil
 	}
 
-	ch := make(chan fileResult, len(jsFiles))
+	var tsFiles []string
+	var jsFiles []string
+	for _, f := range allFiles {
+		if strings.HasSuffix(f, ".ts") || strings.HasSuffix(f, ".tsx") {
+			tsFiles = append(tsFiles, f)
+		} else {
+			jsFiles = append(jsFiles, f)
+		}
+	}
+
+	typeRegistry := express.NewTSTypeRegistry()
+	if len(tsFiles) > 0 {
+		reg, err := express.ParseTSTypes(sourceDir)
+		if err == nil && reg != nil {
+			typeRegistry = reg
+		}
+	}
+
+	ch := make(chan fileResult, len(allFiles))
 	var wg sync.WaitGroup
 
 	for _, path := range jsFiles {
 		wg.Add(1)
 		go func(filePath string) {
 			defer wg.Done()
-			res := processFile(filePath)
+			res := processJSFile(filePath, typeRegistry)
+			ch <- res
+		}(path)
+	}
+
+	for _, path := range tsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := processTSFile(filePath, typeRegistry)
 			ch <- res
 		}(path)
 	}
@@ -73,6 +93,28 @@ type fileResult struct {
 	err       error
 }
 
+func discoverSourceFiles(sourceDir string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		switch ext {
+		case ".js", ".mjs", ".ts", ".tsx":
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
 func discoverJSFiles(sourceDir string) ([]string, error) {
 	var jsFiles []string
 	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
@@ -88,6 +130,58 @@ func discoverJSFiles(sourceDir string) ([]string, error) {
 		return nil, err
 	}
 	return jsFiles, nil
+}
+
+func processJSFile(filePath string, typeRegistry *express.TSTypeRegistry) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(javascript.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source, typeRegistry)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func processTSFile(filePath string, typeRegistry *express.TSTypeRegistry) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(typescript.LanguageTypescript())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := extractEndpoints(rootNode, source, typeRegistry)
+
+	return fileResult{endpoints: endpoints}
 }
 
 func processFile(filePath string) fileResult {
@@ -111,12 +205,12 @@ func processFile(filePath string) fileResult {
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	endpoints := extractEndpoints(rootNode, source)
+	endpoints := extractEndpoints(rootNode, source, nil)
 
 	return fileResult{endpoints: endpoints}
 }
 
-func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	var endpoints []collector.ApiEndpoint
 	var lastComment string
 
@@ -134,7 +228,7 @@ func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.Api
 		}
 
 		if child.Kind() == "expression_statement" {
-			ep := extractFromExpressionStatement(child, source, lastComment)
+			ep := extractFromExpressionStatement(child, source, lastComment, typeRegistry)
 			if ep != nil {
 				endpoints = append(endpoints, ep...)
 			}
@@ -147,20 +241,20 @@ func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.Api
 	return endpoints
 }
 
-func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+func extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	for i := uint(0); i < node.ChildCount(); i++ {
 		child := node.Child(i)
 		if child.Kind() == "call_expression" {
-			return extractFromCallExpression(child, source, description)
+			return extractFromCallExpression(child, source, description, typeRegistry)
 		}
 	}
 	return nil
 }
 
-func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	method, isRoute := extractMethodInfo(callNode, source)
 	if isRoute {
-		ep := extractShorthandRoute(callNode, source, method, description)
+		ep := extractShorthandRoute(callNode, source, method, description, typeRegistry)
 		if ep != nil {
 			return []collector.ApiEndpoint{*ep}
 		}
@@ -168,7 +262,7 @@ func extractFromCallExpression(callNode *tree_sitter.Node, source []byte, descri
 	}
 
 	if isRouteObjectCall(callNode, source) {
-		return extractRouteObject(callNode, source, description)
+		return extractRouteObject(callNode, source, description, typeRegistry)
 	}
 
 	return nil
@@ -224,7 +318,7 @@ func isRouteProperty(memberNode *tree_sitter.Node, source []byte) bool {
 	return false
 }
 
-func extractShorthandRoute(callNode *tree_sitter.Node, source []byte, method string, description string) *collector.ApiEndpoint {
+func extractShorthandRoute(callNode *tree_sitter.Node, source []byte, method string, description string, typeRegistry *express.TSTypeRegistry) *collector.ApiEndpoint {
 	path, handlerName := extractShorthandArguments(callNode, source)
 	if path == "" {
 		return nil
@@ -254,7 +348,79 @@ func extractShorthandRoute(callNode *tree_sitter.Node, source []byte, method str
 		ep.Parameters = params
 	}
 
+	argsNode := findArgsNode(callNode, source)
+	if argsNode != nil {
+		optionsNode := findOptionsObject(argsNode, source)
+		if optionsNode != nil {
+			schemaNode := extractSchemaFromOptions(optionsNode, source)
+			if schemaNode != nil {
+				populateSchemaBody(schemaNode, source, ep, typeRegistry)
+			}
+		}
+	}
+
+	if typeRegistry != nil && ep.RequestBody == nil && ep.Response == nil {
+		handlerInfo := AnalyzeFastifyHandler(callNode, source)
+		if handlerInfo != nil {
+			reqBody, resBody := ResolveFastifyHandlerTypes(handlerInfo, typeRegistry)
+			if reqBody != nil && !reqBody.IsNull() {
+				ep.RequestBody = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      reqBody,
+				}
+			}
+			if resBody != nil && !resBody.IsNull() {
+				ep.Response = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      resBody,
+				}
+			}
+		}
+	}
+
 	return ep
+}
+
+func populateSchemaBody(schemaNode *tree_sitter.Node, source []byte, ep *collector.ApiEndpoint, typeRegistry *express.TSTypeRegistry) {
+	bodySchema := extractSchemaBody(schemaNode, source)
+	if bodySchema != nil && !bodySchema.IsNull() {
+		if bodySchema.IsSingle() && bodySchema.TypeName != "" && typeRegistry != nil {
+			resolver := express.NewTSTypeResolver(typeRegistry)
+			resolved := resolver.Resolve(bodySchema.TypeName, nil)
+			if resolved != nil && !resolved.IsNull() {
+				bodySchema = resolved
+			}
+		}
+		ep.RequestBody = &collector.ApiBody{
+			MediaType: "application/json",
+			Body:      bodySchema,
+		}
+	}
+
+	responseSchema := extractSchemaResponse(schemaNode, source)
+	if responseSchema != nil && !responseSchema.IsNull() {
+		if responseSchema.IsSingle() && responseSchema.TypeName != "" && typeRegistry != nil {
+			resolver := express.NewTSTypeResolver(typeRegistry)
+			resolved := resolver.Resolve(responseSchema.TypeName, nil)
+			if resolved != nil && !resolved.IsNull() {
+				responseSchema = resolved
+			}
+		}
+		ep.Response = &collector.ApiBody{
+			MediaType: "application/json",
+			Body:      responseSchema,
+		}
+	}
+}
+
+func findArgsNode(callNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "arguments" {
+			return child
+		}
+	}
+	return nil
 }
 
 func extractShorthandArguments(callNode *tree_sitter.Node, source []byte) (path string, handlerName string) {
@@ -292,27 +458,27 @@ func extractShorthandArgsFromNode(argsNode *tree_sitter.Node, source []byte) (pa
 	return path, handlerName
 }
 
-func extractRouteObject(callNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+func extractRouteObject(callNode *tree_sitter.Node, source []byte, description string, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	for i := uint(0); i < callNode.ChildCount(); i++ {
 		child := callNode.Child(i)
 		if child.Kind() == "arguments" {
-			return extractRouteObjectArgs(child, source, description)
+			return extractRouteObjectArgs(child, source, description, typeRegistry)
 		}
 	}
 	return nil
 }
 
-func extractRouteObjectArgs(argsNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+func extractRouteObjectArgs(argsNode *tree_sitter.Node, source []byte, description string, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	for i := uint(0); i < argsNode.ChildCount(); i++ {
 		child := argsNode.Child(i)
 		if child.Kind() == "object" {
-			return extractRouteObjectFromObject(child, source, description)
+			return extractRouteObjectFromObject(child, source, description, typeRegistry)
 		}
 	}
 	return nil
 }
 
-func extractRouteObjectFromObject(objNode *tree_sitter.Node, source []byte, description string) []collector.ApiEndpoint {
+func extractRouteObjectFromObject(objNode *tree_sitter.Node, source []byte, description string, typeRegistry *express.TSTypeRegistry) []collector.ApiEndpoint {
 	var method, path, handlerName string
 
 	for i := uint(0); i < objNode.ChildCount(); i++ {
@@ -369,6 +535,11 @@ func extractRouteObjectFromObject(objNode *tree_sitter.Node, source []byte, desc
 			})
 		}
 		ep.Parameters = params
+	}
+
+	schemaNode := extractSchemaFromRouteObject(objNode, source)
+	if schemaNode != nil {
+		populateSchemaBody(schemaNode, source, &ep, typeRegistry)
 	}
 
 	return []collector.ApiEndpoint{ep}

--- a/api-collector-node/fastify/parser_test.go
+++ b/api-collector-node/fastify/parser_test.go
@@ -130,6 +130,155 @@ func TestParse_RouteObject(t *testing.T) {
 	})
 }
 
+func TestParse_SchemaRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "schema"))
+	if err != nil {
+		t.Fatalf("schema routes should not error: %v", err)
+	}
+	if len(endpoints) != 3 {
+		t.Fatalf("expected 3 endpoints, got %d", len(endpoints))
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	getUsers := endpoints[0]
+	if getUsers.Method != "GET" || getUsers.Path != "/users" {
+		t.Fatalf("expected GET /users, got %s %s", getUsers.Method, getUsers.Path)
+	}
+
+	if getUsers.Response == nil || getUsers.Response.Body == nil {
+		t.Fatalf("GET /users should have response with schema")
+	} else {
+		body := getUsers.Response.Body
+		if !body.IsObject() {
+			t.Errorf("GET /users response should be object, got %s", body.Kind)
+		}
+		if _, ok := body.Fields["users"]; !ok {
+			t.Errorf("GET /users response should have 'users' field")
+		}
+		if _, ok := body.Fields["total"]; !ok {
+			t.Errorf("GET /users response should have 'total' field")
+		}
+	}
+
+	getUserById := endpoints[1]
+	if getUserById.Method != "GET" || getUserById.Path != "/users/{id}" {
+		t.Fatalf("expected GET /users/{id}, got %s %s", getUserById.Method, getUserById.Path)
+	}
+
+	if getUserById.Response == nil || getUserById.Response.Body == nil {
+		t.Fatalf("GET /users/{id} should have response with schema")
+	} else {
+		body := getUserById.Response.Body
+		if !body.IsObject() {
+			t.Errorf("GET /users/{id} response should be object, got %s", body.Kind)
+		}
+		if _, ok := body.Fields["id"]; !ok {
+			t.Errorf("GET /users/{id} response should have 'id' field")
+		}
+	}
+
+	postUsers := endpoints[2]
+	if postUsers.Method != "POST" || postUsers.Path != "/users" {
+		t.Fatalf("expected POST /users, got %s %s", postUsers.Method, postUsers.Path)
+	}
+
+	if postUsers.RequestBody == nil || postUsers.RequestBody.Body == nil {
+		t.Fatalf("POST /users should have request body with schema")
+	} else {
+		body := postUsers.RequestBody.Body
+		if !body.IsObject() {
+			t.Errorf("POST /users request body should be object, got %s", body.Kind)
+		}
+		if _, ok := body.Fields["name"]; !ok {
+			t.Errorf("POST /users request body should have 'name' field")
+		}
+		if _, ok := body.Fields["email"]; !ok {
+			t.Errorf("POST /users request body should have 'email' field")
+		}
+		nameField := body.Fields["name"]
+		if !nameField.Required {
+			t.Errorf("POST /users request body 'name' should be required")
+		}
+	}
+
+	if postUsers.Response == nil || postUsers.Response.Body == nil {
+		t.Fatalf("POST /users should have response with schema")
+	} else {
+		body := postUsers.Response.Body
+		if !body.IsObject() {
+			t.Errorf("POST /users response should be object, got %s", body.Kind)
+		}
+		if _, ok := body.Fields["id"]; !ok {
+			t.Errorf("POST /users response should have 'id' field")
+		}
+	}
+}
+
+func TestParse_TypedRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed routes should not error: %v", err)
+	}
+	if len(endpoints) == 0 {
+		t.Fatalf("expected endpoints for typed routes, got 0")
+	}
+
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Method != endpoints[j].Method {
+			return endpoints[i].Method < endpoints[j].Method
+		}
+		return endpoints[i].Path < endpoints[j].Path
+	})
+
+	var postUsers, getUserById, putUserById []collector.ApiEndpoint
+	for _, ep := range endpoints {
+		switch {
+		case ep.Method == "POST" && ep.Path == "/users":
+			postUsers = append(postUsers, ep)
+		case ep.Method == "GET" && ep.Path == "/users/{id}":
+			getUserById = append(getUserById, ep)
+		case ep.Method == "PUT" && ep.Path == "/users/{id}":
+			putUserById = append(putUserById, ep)
+		}
+	}
+
+	if len(postUsers) > 0 {
+		ep := postUsers[0]
+		if ep.RequestBody == nil || ep.RequestBody.Body == nil {
+			t.Errorf("POST /users should have request body with type info")
+		} else {
+			body := ep.RequestBody.Body
+			if !body.IsObject() {
+				t.Errorf("POST /users request body should be object, got %s", body.Kind)
+			}
+			if _, ok := body.Fields["name"]; !ok {
+				t.Errorf("POST /users request body should have 'name' field")
+			}
+			if _, ok := body.Fields["email"]; !ok {
+				t.Errorf("POST /users request body should have 'email' field")
+			}
+		}
+	}
+
+	if len(putUserById) > 0 {
+		ep := putUserById[0]
+		if ep.RequestBody == nil || ep.RequestBody.Body == nil {
+			t.Errorf("PUT /users/{id} should have request body with type info")
+		} else {
+			body := ep.RequestBody.Body
+			if !body.IsObject() {
+				t.Errorf("PUT /users/{id} request body should be object, got %s", body.Kind)
+			}
+		}
+	}
+}
+
 func TestConvertPath(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -211,6 +360,104 @@ func TestCleanJSDocComment(t *testing.T) {
 		result := cleanJSDocComment(tt.input)
 		if result != tt.expected {
 			t.Errorf("cleanJSDocComment(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestParseFastifyRequestGenerics(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantBody    string
+		wantQuery   string
+		wantParams  string
+	}{
+		{
+			"FastifyRequest<{ Body: CreateUserRequest }>",
+			"CreateUserRequest", "", "",
+		},
+		{
+			"FastifyRequest<{ Params: { id: string } }>",
+			"", "", "{ id: string }",
+		},
+		{
+			"FastifyRequest<{ Params: { id: string }; Body: CreateUserRequest }>",
+			"CreateUserRequest", "", "{ id: string }",
+		},
+		{
+			"FastifyRequest<{ Body: CreateUserRequest; Querystring: UserQuery }>",
+			"CreateUserRequest", "UserQuery", "",
+		},
+		{
+			"FastifyRequest",
+			"", "", "",
+		},
+		{
+			"FastifyRequest<{ Body: any }>",
+			"", "", "",
+		},
+		{
+			"FastifyRequest<RawServerDefault, CreateUserRequest>",
+			"CreateUserRequest", "", "",
+		},
+		{
+			"FastifyRequest<RawServerDefault, CreateUserRequest, UserQuery>",
+			"CreateUserRequest", "UserQuery", "",
+		},
+	}
+
+	for _, tt := range tests {
+		reqBody, query, params := parseFastifyRequestGenerics(tt.input)
+		if reqBody != tt.wantBody {
+			t.Errorf("parseFastifyRequestGenerics(%q) reqBody = %q, want %q", tt.input, reqBody, tt.wantBody)
+		}
+		if query != tt.wantQuery {
+			t.Errorf("parseFastifyRequestGenerics(%q) query = %q, want %q", tt.input, query, tt.wantQuery)
+		}
+		if params != tt.wantParams {
+			t.Errorf("parseFastifyRequestGenerics(%q) params = %q, want %q", tt.input, params, tt.wantParams)
+		}
+	}
+}
+
+func TestParseFastifyReplyGenerics(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"FastifyReply<UserResponse>", "UserResponse"},
+		{"FastifyReply", ""},
+		{"FastifyReply<any>", ""},
+	}
+	for _, tt := range tests {
+		result := parseFastifyReplyGenerics(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseFastifyReplyGenerics(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestMapJSONSchemaType(t *testing.T) {
+	tests := []struct {
+		input    string
+		kind     string
+		typeName string
+	}{
+		{"string", "single", "string"},
+		{"integer", "single", "int"},
+		{"number", "single", "double"},
+		{"boolean", "single", "boolean"},
+		{"null", "single", "null"},
+		{"array", "array", "array"},
+		{"object", "object", "object"},
+	}
+
+	for _, tt := range tests {
+		result := mapJSONSchemaType(tt.input)
+		if string(result.Kind) != tt.kind {
+			t.Errorf("mapJSONSchemaType(%q).Kind = %q, want %q", tt.input, result.Kind, tt.kind)
+		}
+		if result.TypeName != tt.typeName {
+			t.Errorf("mapJSONSchemaType(%q).TypeName = %q, want %q", tt.input, result.TypeName, tt.typeName)
 		}
 	}
 }

--- a/api-collector-node/fastify/resolver.go
+++ b/api-collector-node/fastify/resolver.go
@@ -1,0 +1,310 @@
+package fastify
+
+import (
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/tangcent/apilot/api-collector-node/express"
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func AnalyzeFastifyHandler(callNode *tree_sitter.Node, source []byte) *FastifyHandlerInfo {
+	info := &FastifyHandlerInfo{}
+
+	handlerNode := findHandlerNode(callNode, source)
+	if handlerNode == nil {
+		return info
+	}
+
+	switch handlerNode.Kind() {
+	case "arrow_function":
+		info = analyzeArrowHandler(handlerNode, source)
+	case "function_expression":
+		info = analyzeFunctionHandler(handlerNode, source)
+	}
+
+	return info
+}
+
+func findHandlerNode(callNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	argsNode := findChildByKind(callNode, "arguments")
+	if argsNode == nil {
+		return nil
+	}
+
+	pathFound := false
+	optionsFound := false
+
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if !pathFound {
+			if child.Kind() == "string" {
+				pathFound = true
+			}
+			continue
+		}
+
+		if !optionsFound && child.Kind() == "object" {
+			optionsFound = true
+			continue
+		}
+
+		return child
+	}
+
+	return nil
+}
+
+func analyzeArrowHandler(node *tree_sitter.Node, source []byte) *FastifyHandlerInfo {
+	info := &FastifyHandlerInfo{}
+	params := findChildByKind(node, "formal_parameters")
+	if params == nil {
+		return info
+	}
+
+	info.ReqBodyType, info.QueryType, info.ParamsType = extractFastifyRequestTypes(params, source)
+	info.ResBodyType = extractFastifyResponseType(params, source)
+
+	return info
+}
+
+func analyzeFunctionHandler(node *tree_sitter.Node, source []byte) *FastifyHandlerInfo {
+	info := &FastifyHandlerInfo{}
+	params := findChildByKind(node, "formal_parameters")
+	if params == nil {
+		return info
+	}
+
+	info.ReqBodyType, info.QueryType, info.ParamsType = extractFastifyRequestTypes(params, source)
+	info.ResBodyType = extractFastifyResponseType(params, source)
+
+	return info
+}
+
+func extractFastifyRequestTypes(params *tree_sitter.Node, source []byte) (reqBodyType string, queryType string, paramsType string) {
+	for i := uint(0); i < params.ChildCount(); i++ {
+		child := params.Child(i)
+		if child.Kind() == "required_parameter" || child.Kind() == "optional_parameter" {
+			paramType := extractParamTypeAnnotation(child, source)
+			paramName := extractParamName(child, source)
+
+			if paramName == "request" || paramName == "req" {
+				if strings.Contains(paramType, "FastifyRequest") {
+					reqBodyType, queryType, paramsType = parseFastifyRequestGenerics(paramType)
+				}
+			}
+		}
+	}
+	return
+}
+
+func extractFastifyResponseType(params *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < params.ChildCount(); i++ {
+		child := params.Child(i)
+		if child.Kind() == "required_parameter" || child.Kind() == "optional_parameter" {
+			paramType := extractParamTypeAnnotation(child, source)
+			paramName := extractParamName(child, source)
+
+			if paramName == "reply" || paramName == "response" || paramName == "res" {
+				if strings.Contains(paramType, "FastifyReply") {
+					return parseFastifyReplyGenerics(paramType)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func parseFastifyRequestGenerics(requestType string) (reqBodyType string, queryType string, paramsType string) {
+	if !strings.Contains(requestType, "<") || !strings.Contains(requestType, ">") {
+		return "", "", ""
+	}
+
+	start := strings.Index(requestType, "<")
+	end := strings.LastIndex(requestType, ">")
+	if start >= end {
+		return "", "", ""
+	}
+
+	inner := requestType[start+1 : end]
+
+	if strings.Contains(inner, ":") || strings.Contains(inner, ";") {
+		return parseFastifyRequestInlineObject(inner)
+	}
+
+	args := splitTypeArgs(inner)
+	if len(args) >= 1 {
+		paramsType = strings.TrimSpace(args[0])
+		if paramsType == "RawServerDefault" || paramsType == "{}" {
+			paramsType = ""
+		}
+	}
+	if len(args) >= 2 {
+		reqBodyType = strings.TrimSpace(args[1])
+		if reqBodyType == "RawBodyDefault" || reqBodyType == "{}" || reqBodyType == "any" {
+			reqBodyType = ""
+		}
+	}
+	if len(args) >= 3 {
+		queryType = strings.TrimSpace(args[2])
+		if queryType == "RawQueryDefault" || queryType == "{}" || queryType == "any" {
+			queryType = ""
+		}
+	}
+
+	return reqBodyType, queryType, paramsType
+}
+
+func parseFastifyRequestInlineObject(inner string) (reqBodyType string, queryType string, paramsType string) {
+	inner = strings.TrimPrefix(inner, "{")
+	inner = strings.TrimSuffix(inner, "}")
+
+	parts := strings.Split(inner, ";")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		kv := strings.SplitN(part, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+
+		switch key {
+		case "Body":
+			if value != "" && value != "any" && value != "{}" {
+				reqBodyType = value
+			}
+		case "Querystring", "Query":
+			if value != "" && value != "any" && value != "{}" {
+				queryType = value
+			}
+		case "Params":
+			if value != "" && value != "any" && value != "{}" {
+				paramsType = value
+			}
+		}
+	}
+
+	return reqBodyType, queryType, paramsType
+}
+
+func parseFastifyReplyGenerics(replyType string) string {
+	if !strings.Contains(replyType, "<") || !strings.Contains(replyType, ">") {
+		return ""
+	}
+
+	start := strings.Index(replyType, "<")
+	end := strings.LastIndex(replyType, ">")
+	if start >= end {
+		return ""
+	}
+
+	inner := replyType[start+1 : end]
+	args := splitTypeArgs(inner)
+
+	if len(args) >= 1 {
+		bodyType := strings.TrimSpace(args[0])
+		if bodyType != "" && bodyType != "any" && bodyType != "{}" && bodyType != "RawReplyDefaultExpression" {
+			return bodyType
+		}
+	}
+
+	return ""
+}
+
+func extractParamTypeAnnotation(paramNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < paramNode.ChildCount(); i++ {
+		child := paramNode.Child(i)
+		if child.Kind() == "type_annotation" {
+			return extractTypeAnnotationText(child, source)
+		}
+	}
+	return ""
+}
+
+func extractTypeAnnotationText(node *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == ":" {
+			continue
+		}
+		return child.Utf8Text(source)
+	}
+	return ""
+}
+
+func extractParamName(paramNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < paramNode.ChildCount(); i++ {
+		child := paramNode.Child(i)
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
+func findChildByKind(node *tree_sitter.Node, kind string) *tree_sitter.Node {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+func splitTypeArgs(s string) []string {
+	var args []string
+	depth := 0
+	start := 0
+
+	for i, c := range s {
+		switch c {
+		case '<':
+			depth++
+		case '>':
+			depth--
+		case ',':
+			if depth == 0 {
+				arg := strings.TrimSpace(s[start:i])
+				if arg != "" {
+					args = append(args, arg)
+				}
+				start = i + 1
+			}
+		}
+	}
+
+	if start < len(s) {
+		arg := strings.TrimSpace(s[start:])
+		if arg != "" {
+			args = append(args, arg)
+		}
+	}
+
+	return args
+}
+
+func ResolveFastifyHandlerTypes(handlerInfo *FastifyHandlerInfo, registry *express.TSTypeRegistry) (reqBody *model.ObjectModel, resBody *model.ObjectModel) {
+	resolver := express.NewTSTypeResolver(registry)
+
+	if handlerInfo.ReqBodyType != "" {
+		reqBody = resolver.Resolve(handlerInfo.ReqBodyType, nil)
+	}
+
+	if handlerInfo.ResBodyType != "" {
+		resBody = resolver.Resolve(handlerInfo.ResBodyType, nil)
+	}
+
+	return reqBody, resBody
+}

--- a/api-collector-node/fastify/schema.go
+++ b/api-collector-node/fastify/schema.go
@@ -1,0 +1,372 @@
+package fastify
+
+import (
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func findOptionsObject(argsNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	pathFound := false
+
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+
+		if !pathFound {
+			if child.Kind() == "string" {
+				pathFound = true
+			}
+			continue
+		}
+
+		if child.Kind() == "object" {
+			return child
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func extractSchemaFromOptions(optionsNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	for i := uint(0); i < optionsNode.ChildCount(); i++ {
+		child := optionsNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "schema" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				pairChild := child.Child(j)
+				if pairChild.Kind() == "object" {
+					return pairChild
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaFromRouteObject(objNode *tree_sitter.Node, source []byte) *tree_sitter.Node {
+	for i := uint(0); i < objNode.ChildCount(); i++ {
+		child := objNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "schema" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				pairChild := child.Child(j)
+				if pairChild.Kind() == "object" {
+					return pairChild
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaBody(schemaNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < schemaNode.ChildCount(); i++ {
+		child := schemaNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "body" {
+			return extractSchemaValue(child, source)
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaQuery(schemaNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < schemaNode.ChildCount(); i++ {
+		child := schemaNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "querystring" || key == "query" {
+			return extractSchemaValue(child, source)
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaParams(schemaNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < schemaNode.ChildCount(); i++ {
+		child := schemaNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "params" {
+			return extractSchemaValue(child, source)
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaResponse(schemaNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < schemaNode.ChildCount(); i++ {
+		child := schemaNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "response" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				pairChild := child.Child(j)
+				if pairChild.Kind() == "object" {
+					return extractFirstResponseSchema(pairChild, source)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func extractFirstResponseSchema(responseNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < responseNode.ChildCount(); i++ {
+		child := responseNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+		if key == "200" || key == "201" || key == "default" {
+			schema := extractSchemaValue(child, source)
+			if schema != nil {
+				return schema
+			}
+		}
+	}
+
+	for i := uint(0); i < responseNode.ChildCount(); i++ {
+		child := responseNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		schema := extractSchemaValue(child, source)
+		if schema != nil {
+			return schema
+		}
+	}
+
+	return nil
+}
+
+func extractSchemaValue(pairNode *tree_sitter.Node, source []byte) *model.ObjectModel {
+	for i := uint(0); i < pairNode.ChildCount(); i++ {
+		child := pairNode.Child(i)
+		if child.Kind() == "object" {
+			return parseJSONSchemaObject(child, source)
+		}
+		if child.Kind() == "identifier" {
+			return model.SingleModel(child.Utf8Text(source))
+		}
+	}
+
+	return nil
+}
+
+func parseJSONSchemaObject(node *tree_sitter.Node, source []byte) *model.ObjectModel {
+	schemaType := ""
+	var propertiesNode *tree_sitter.Node
+	var itemsNode *tree_sitter.Node
+	requiredFields := make(map[string]bool)
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		key := extractPairKey(child, source)
+
+		switch key {
+		case "type":
+			schemaType = extractPairStringValue(child, source)
+		case "properties":
+			for j := uint(0); j < child.ChildCount(); j++ {
+				pairChild := child.Child(j)
+				if pairChild.Kind() == "object" {
+					propertiesNode = pairChild
+				}
+			}
+		case "items":
+			for j := uint(0); j < child.ChildCount(); j++ {
+				pairChild := child.Child(j)
+				if pairChild.Kind() == "object" {
+					itemsNode = pairChild
+				}
+			}
+		case "required":
+			requiredFields = extractRequiredArray(child, source)
+		}
+	}
+
+	switch schemaType {
+	case "string":
+		return model.SingleModel(model.JsonTypeString)
+	case "integer":
+		return model.SingleModel(model.JsonTypeInt)
+	case "number":
+		return model.SingleModel(model.JsonTypeDouble)
+	case "boolean":
+		return model.SingleModel(model.JsonTypeBoolean)
+	case "null":
+		return model.SingleModel(model.JsonTypeNull)
+	case "array":
+		if itemsNode != nil {
+			itemModel := parseJSONSchemaObject(itemsNode, source)
+			return model.ArrayModel(itemModel)
+		}
+		return model.ArrayModel(model.NullModel())
+	case "object":
+		if propertiesNode != nil {
+			return parseJSONSchemaProperties(propertiesNode, source, requiredFields)
+		}
+		return model.EmptyObject()
+	default:
+		if propertiesNode != nil {
+			return parseJSONSchemaProperties(propertiesNode, source, requiredFields)
+		}
+		return model.EmptyObject()
+	}
+}
+
+func parseJSONSchemaProperties(propsNode *tree_sitter.Node, source []byte, requiredFields map[string]bool) *model.ObjectModel {
+	fields := make(map[string]*model.FieldModel)
+
+	for i := uint(0); i < propsNode.ChildCount(); i++ {
+		child := propsNode.Child(i)
+		if child.Kind() != "pair" {
+			continue
+		}
+
+		propName := extractPairKey(child, source)
+		if propName == "" {
+			continue
+		}
+
+		var propModel *model.ObjectModel
+		for j := uint(0); j < child.ChildCount(); j++ {
+			pairChild := child.Child(j)
+			if pairChild.Kind() == "object" {
+				propModel = parseJSONSchemaObject(pairChild, source)
+				break
+			}
+		}
+
+		if propModel == nil {
+			propType := extractPairStringValue(child, source)
+			if propType != "" {
+				propModel = mapJSONSchemaType(propType)
+			} else {
+				propModel = model.SingleModel(model.JsonTypeString)
+			}
+		}
+
+		_, required := requiredFields[propName]
+		fields[propName] = &model.FieldModel{
+			Model:    propModel,
+			Required: required,
+		}
+	}
+
+	if len(fields) == 0 {
+		return model.EmptyObject()
+	}
+
+	return model.ObjectModelFrom(fields)
+}
+
+func extractRequiredArray(pairNode *tree_sitter.Node, source []byte) map[string]bool {
+	required := make(map[string]bool)
+
+	for i := uint(0); i < pairNode.ChildCount(); i++ {
+		child := pairNode.Child(i)
+		if child.Kind() == "array" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				arrChild := child.Child(j)
+				if arrChild.Kind() == "string" {
+					fieldName := unquoteJSString(arrChild.Utf8Text(source))
+					required[fieldName] = true
+				}
+			}
+		}
+	}
+
+	return required
+}
+
+func mapJSONSchemaType(schemaType string) *model.ObjectModel {
+	switch schemaType {
+	case "string":
+		return model.SingleModel(model.JsonTypeString)
+	case "integer":
+		return model.SingleModel(model.JsonTypeInt)
+	case "number":
+		return model.SingleModel(model.JsonTypeDouble)
+	case "boolean":
+		return model.SingleModel(model.JsonTypeBoolean)
+	case "null":
+		return model.SingleModel(model.JsonTypeNull)
+	case "array":
+		return model.ArrayModel(model.NullModel())
+	case "object":
+		return model.EmptyObject()
+	default:
+		return model.SingleModel(schemaType)
+	}
+}
+
+func extractPairKey(pairNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < pairNode.ChildCount(); i++ {
+		child := pairNode.Child(i)
+		if child.Kind() == "property_identifier" {
+			return child.Utf8Text(source)
+		}
+		if child.Kind() == "string" {
+			return unquoteJSString(child.Utf8Text(source))
+		}
+		if child.Kind() == "number" {
+			return child.Utf8Text(source)
+		}
+	}
+
+	return ""
+}
+
+func extractPairStringValue(pairNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < pairNode.ChildCount(); i++ {
+		child := pairNode.Child(i)
+		if child.Kind() == "string" {
+			return unquoteJSString(child.Utf8Text(source))
+		}
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+	}
+
+	return ""
+}

--- a/api-collector-node/fastify/testdata/schema/app.js
+++ b/api-collector-node/fastify/testdata/schema/app.js
@@ -1,0 +1,77 @@
+const fastify = require('fastify')({ logger: true });
+
+/**
+ * listUsers returns all users.
+ */
+fastify.get('/users', {
+    schema: {
+        querystring: {
+            type: 'object',
+            properties: {
+                limit: { type: 'integer' },
+                offset: { type: 'integer' }
+            }
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    users: { type: 'array' },
+                    total: { type: 'integer' }
+                }
+            }
+        }
+    }
+}, listUsers);
+
+/**
+ * createUser creates a new user.
+ */
+fastify.post('/users', {
+    schema: {
+        body: {
+            type: 'object',
+            required: ['name', 'email'],
+            properties: {
+                name: { type: 'string' },
+                email: { type: 'string' },
+                age: { type: 'integer' }
+            }
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                    name: { type: 'string' },
+                    email: { type: 'string' }
+                }
+            }
+        }
+    }
+}, createUser);
+
+/**
+ * getUser returns a single user by ID.
+ */
+fastify.get('/users/:id', {
+    schema: {
+        params: {
+            type: 'object',
+            properties: {
+                id: { type: 'string' }
+            }
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                    name: { type: 'string' }
+                }
+            }
+        }
+    }
+}, getUser);
+
+fastify.listen({ port: 3000 });

--- a/api-collector-node/fastify/testdata/typed/app.ts
+++ b/api-collector-node/fastify/testdata/typed/app.ts
@@ -1,0 +1,48 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+
+interface CreateUserRequest {
+    name: string;
+    email: string;
+    age?: number;
+}
+
+interface UserResponse {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface ListUsersResponse {
+    users: UserResponse[];
+    total: number;
+}
+
+/**
+ * listUsers returns all users.
+ */
+fastify.get('/users', async (request: FastifyRequest, reply: FastifyReply) => {
+    return { users: [], total: 0 };
+});
+
+/**
+ * createUser creates a new user.
+ */
+fastify.post('/users', async (request: FastifyRequest<{ Body: CreateUserRequest }>, reply: FastifyReply) => {
+    const { name, email } = request.body;
+    return { id: 1, name, email };
+});
+
+/**
+ * getUser returns a single user by ID.
+ */
+fastify.get('/users/:id', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+    return { id: request.params.id };
+});
+
+/**
+ * updateUser updates an existing user.
+ */
+fastify.put('/users/:id', async (request: FastifyRequest<{ Params: { id: string }; Body: CreateUserRequest }>, reply: FastifyReply) => {
+    const { name, email } = request.body;
+    return { id: 1, name, email };
+});

--- a/api-collector-node/fastify/types.go
+++ b/api-collector-node/fastify/types.go
@@ -1,0 +1,8 @@
+package fastify
+
+type FastifyHandlerInfo struct {
+	ReqBodyType string
+	ResBodyType string
+	QueryType   string
+	ParamsType  string
+}


### PR DESCRIPTION
Resolves #94

Add detailed request/response type resolution to the Node.js Fastify parser, producing structured field-level schemas for request bodies and response bodies.

## Changes

- fastify/types.go: FastifyHandlerInfo struct for handler type metadata
- fastify/schema.go: JSON Schema extraction from Fastify route options
- fastify/resolver.go: Handler type analysis and TypeScript type resolution
- fastify/parser.go: TypeScript file support, schema extraction, type resolution
- Test data and comprehensive tests for schema and typed routes

## Type Resolution Strategy

1. JSON Schema extraction (priority): Parse schema option with body/response/querystring/params
2. TypeScript generics (fallback): Analyze FastifyRequest/FastifyReply generic type parameters