### PR TITLE
feat: add DRF serializer type resolution for Django parser

### DIFF
--- a/api-collector-python/django/parser.go
+++ b/api-collector-python/django/parser.go
@@ -57,12 +57,31 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		close(ch)
 	}()
 
-	var allEndpoints []collector.ApiEndpoint
+	allSerializers := make(map[string]SerializerModel)
+	var allRawEndpoints []rawEndpointInfo
+
 	for res := range ch {
 		if res.err != nil {
 			continue
 		}
-		allEndpoints = append(allEndpoints, res.endpoints...)
+		for k, v := range res.serializers {
+			allSerializers[k] = v
+		}
+		allRawEndpoints = append(allRawEndpoints, res.rawEndpoints...)
+	}
+
+	if len(allRawEndpoints) == 0 {
+		return nil, nil
+	}
+
+	typeResolver := NewDRFTypeResolver(allSerializers)
+
+	var allEndpoints []collector.ApiEndpoint
+	for _, raw := range allRawEndpoints {
+		ep := buildDjangoEndpoint(raw, typeResolver)
+		if ep != nil {
+			allEndpoints = append(allEndpoints, *ep)
+		}
 	}
 
 	if len(allEndpoints) == 0 {
@@ -72,9 +91,22 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	return allEndpoints, nil
 }
 
+type rawEndpointInfo struct {
+	name               string
+	path               string
+	method             string
+	protocol           string
+	description        string
+	parameters         []collector.ApiParameter
+	serializerClass    string
+	action             string
+	isViewSet          bool
+}
+
 type fileResult struct {
-	endpoints []collector.ApiEndpoint
-	err       error
+	rawEndpoints []rawEndpointInfo
+	serializers  map[string]SerializerModel
+	err          error
 }
 
 func discoverPythonFiles(sourceDir string) ([]string, error) {
@@ -115,13 +147,17 @@ func processFile(filePath string) fileResult {
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	endpoints := extractEndpoints(rootNode, source)
+	serializers := extractSerializers(rootNode, source)
+	rawEndpoints := extractEndpoints(rootNode, source)
 
-	return fileResult{endpoints: endpoints}
+	return fileResult{
+		serializers:  serializers,
+		rawEndpoints: rawEndpoints,
+	}
 }
 
-func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	urlPatterns := extractUrlPatterns(rootNode, source)
 	classEndpoints := extractClassBasedViews(rootNode, source)
@@ -134,8 +170,8 @@ func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.Api
 	return endpoints
 }
 
-func extractUrlPatterns(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func extractUrlPatterns(rootNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	for i := uint(0); i < rootNode.ChildCount(); i++ {
 		child := rootNode.Child(i)
@@ -178,8 +214,8 @@ func extractUrlPatterns(rootNode *tree_sitter.Node, source []byte) []collector.A
 	return endpoints
 }
 
-func parseUrlPatternList(listNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func parseUrlPatternList(listNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	for i := uint(0); i < listNode.ChildCount(); i++ {
 		child := listNode.Child(i)
@@ -194,7 +230,7 @@ func parseUrlPatternList(listNode *tree_sitter.Node, source []byte) []collector.
 	return endpoints
 }
 
-func parsePathCall(callNode *tree_sitter.Node, source []byte) *collector.ApiEndpoint {
+func parsePathCall(callNode *tree_sitter.Node, source []byte) *rawEndpointInfo {
 	var funcName string
 	var args []string
 
@@ -238,11 +274,11 @@ func parsePathCall(callNode *tree_sitter.Node, source []byte) *collector.ApiEndp
 		method = "PATCH"
 	}
 
-	ep := &collector.ApiEndpoint{
-		Name:     viewName,
-		Path:     pathPattern,
-		Method:   method,
-		Protocol: "http",
+	ep := &rawEndpointInfo{
+		name:     viewName,
+		path:     pathPattern,
+		method:   method,
+		protocol: "http",
 	}
 
 	pathParams := extractPathParams(pathPattern)
@@ -256,7 +292,7 @@ func parsePathCall(callNode *tree_sitter.Node, source []byte) *collector.ApiEndp
 				Type:     "text",
 			})
 		}
-		ep.Parameters = params
+		ep.parameters = params
 	}
 
 	return ep
@@ -285,8 +321,8 @@ func extractCallArguments(argListNode *tree_sitter.Node, source []byte) []string
 	return args
 }
 
-func extractClassBasedViews(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func extractClassBasedViews(rootNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	for i := uint(0); i < rootNode.ChildCount(); i++ {
 		child := rootNode.Child(i)
@@ -304,12 +340,17 @@ func extractClassBasedViews(rootNode *tree_sitter.Node, source []byte) []collect
 			continue
 		}
 
+		serializerClass := extractSerializerClassFromView(child, source)
+		isVS := isViewSet(baseClasses)
+
 		methods := extractClassMethods(child, source)
 		for _, method := range methods {
 			httpMethod := method.name
-			if isViewSet(baseClasses) {
+			action := ""
+			if isVS {
 				if mapped, ok := viewSetMethods[strings.ToLower(method.name)]; ok {
 					httpMethod = mapped
+					action = strings.ToLower(method.name)
 				} else {
 					continue
 				}
@@ -320,14 +361,17 @@ func extractClassBasedViews(rootNode *tree_sitter.Node, source []byte) []collect
 				httpMethod = strings.ToUpper(method.name)
 			}
 
-			ep := &collector.ApiEndpoint{
-				Name:        className + "." + method.name,
-				Path:        "/" + className,
-				Method:      httpMethod,
-				Protocol:    "http",
-				Description: method.docstring,
+			ep := rawEndpointInfo{
+				name:            className + "." + method.name,
+				path:            "/" + className,
+				method:          httpMethod,
+				protocol:        "http",
+				description:     method.docstring,
+				serializerClass: serializerClass,
+				action:          action,
+				isViewSet:       isVS,
 			}
-			endpoints = append(endpoints, *ep)
+			endpoints = append(endpoints, ep)
 		}
 	}
 
@@ -421,8 +465,8 @@ func extractClassMethods(classNode *tree_sitter.Node, source []byte) []classMeth
 	return methods
 }
 
-func extractFunctionBasedViews(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func extractFunctionBasedViews(rootNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	for i := uint(0); i < rootNode.ChildCount(); i++ {
 		child := rootNode.Child(i)
@@ -439,7 +483,7 @@ func extractFunctionBasedViews(rootNode *tree_sitter.Node, source []byte) []coll
 	return endpoints
 }
 
-func extractApiViewDecorator(node *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+func extractApiViewDecorator(node *tree_sitter.Node, source []byte) []rawEndpointInfo {
 	var decorator *tree_sitter.Node
 	var funcDef *tree_sitter.Node
 
@@ -465,14 +509,14 @@ func extractApiViewDecorator(node *tree_sitter.Node, source []byte) []collector.
 	funcName := extractFunctionName(funcDef, source)
 	description := extractDocstring(funcDef, source)
 
-	var endpoints []collector.ApiEndpoint
+	var endpoints []rawEndpointInfo
 	for _, method := range methods {
-		ep := collector.ApiEndpoint{
-			Name:        funcName,
-			Path:        "/" + funcName,
-			Method:      strings.ToUpper(method),
-			Protocol:    "http",
-			Description: description,
+		ep := rawEndpointInfo{
+			name:        funcName,
+			path:        "/" + funcName,
+			method:      strings.ToUpper(method),
+			protocol:    "http",
+			description: description,
 		}
 		endpoints = append(endpoints, ep)
 	}
@@ -587,6 +631,55 @@ func extractDocstringFromBlock(blockNode *tree_sitter.Node, source []byte) strin
 		break
 	}
 	return ""
+}
+
+func buildDjangoEndpoint(raw rawEndpointInfo, typeResolver *DRFTypeResolver) *collector.ApiEndpoint {
+	ep := &collector.ApiEndpoint{
+		Name:        raw.name,
+		Path:        raw.path,
+		Method:      raw.method,
+		Protocol:    raw.protocol,
+		Description: raw.description,
+	}
+
+	if len(raw.parameters) > 0 {
+		ep.Parameters = raw.parameters
+	}
+
+	if raw.serializerClass == "" {
+		return ep
+	}
+
+	var requestSerializer string
+	var responseSerializer string
+
+	if raw.isViewSet && raw.action != "" {
+		requestSerializer, responseSerializer = typeResolver.ResolveActionSerializer(raw.name, raw.action, raw.serializerClass)
+	} else {
+		requestSerializer, responseSerializer = typeResolver.ResolveHTTPMethodSerializer(raw.name, raw.method, raw.serializerClass)
+	}
+
+	if requestSerializer != "" {
+		reqBody := typeResolver.BuildRequestBody(requestSerializer)
+		if reqBody != nil {
+			ep.RequestBody = &collector.ApiBody{
+				MediaType: "application/json",
+				Body:      reqBody,
+			}
+		}
+	}
+
+	if responseSerializer != "" {
+		respBody := typeResolver.BuildResponseBody(responseSerializer)
+		if respBody != nil {
+			ep.Response = &collector.ApiBody{
+				MediaType: "application/json",
+				Body:      respBody,
+			}
+		}
+	}
+
+	return ep
 }
 
 type pathParamInfo struct {

--- a/api-collector-python/django/parser_test.go
+++ b/api-collector-python/django/parser_test.go
@@ -3,6 +3,8 @@ package django
 import (
 	"strings"
 	"testing"
+
+	collector "github.com/tangcent/apilot/api-collector"
 )
 
 func TestParseBasic(t *testing.T) {
@@ -198,4 +200,226 @@ func TestNormalizePath(t *testing.T) {
 			t.Errorf("Input %s: expected %s, got %s", test.input, test.expected, result)
 		}
 	}
+}
+
+func TestParse_WithSerializers(t *testing.T) {
+	endpoints, err := Parse("testdata/serializers")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(endpoints) == 0 {
+		t.Fatal("Expected endpoints to be extracted, got none")
+	}
+
+	epMap := make(map[string]collector.ApiEndpoint)
+	for _, ep := range endpoints {
+		key := ep.Method + " " + ep.Path
+		epMap[key] = ep
+	}
+
+	t.Run("ViewSet list has response body with UserSerializer schema", func(t *testing.T) {
+		ep, ok := epMap["GET /UserViewSet"]
+		if !ok {
+			t.Fatal("missing GET /UserViewSet endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body for GET /UserViewSet")
+		}
+		if ep.Response.Body == nil {
+			t.Fatal("expected Body for response")
+		}
+		if ep.Response.Body.Kind != "object" {
+			t.Errorf("response body Kind = %q, want %q", ep.Response.Body.Kind, "object")
+		}
+		if ep.Response.Body.TypeName != "UserSerializer" {
+			t.Errorf("response body TypeName = %q, want %q", ep.Response.Body.TypeName, "UserSerializer")
+		}
+		nameField, ok := ep.Response.Body.Fields["name"]
+		if !ok {
+			t.Fatal("expected 'name' field in UserSerializer")
+		}
+		if nameField.Model.TypeName != "string" {
+			t.Errorf("UserSerializer.name type = %q, want %q", nameField.Model.TypeName, "string")
+		}
+	})
+
+	t.Run("ViewSet create has request and response body", func(t *testing.T) {
+		ep, ok := epMap["POST /UserViewSet"]
+		if !ok {
+			t.Fatal("missing POST /UserViewSet endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body for POST /UserViewSet")
+		}
+		if ep.RequestBody.Body == nil {
+			t.Fatal("expected Body for request")
+		}
+		if ep.RequestBody.Body.TypeName != "UserSerializer" {
+			t.Errorf("request body TypeName = %q, want %q", ep.RequestBody.Body.TypeName, "UserSerializer")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body for POST /UserViewSet")
+		}
+	})
+
+	t.Run("APIView GET has response body", func(t *testing.T) {
+		ep, ok := epMap["GET /AddressAPIView"]
+		if !ok {
+			t.Fatal("missing GET /AddressAPIView endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body for GET /AddressAPIView")
+		}
+		if ep.Response.Body == nil {
+			t.Fatal("expected Body for response")
+		}
+		if ep.Response.Body.TypeName != "AddressSerializer" {
+			t.Errorf("response body TypeName = %q, want %q", ep.Response.Body.TypeName, "AddressSerializer")
+		}
+	})
+
+	t.Run("APIView POST has request and response body", func(t *testing.T) {
+		ep, ok := epMap["POST /AddressAPIView"]
+		if !ok {
+			t.Fatal("missing POST /AddressAPIView endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body for POST /AddressAPIView")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body for POST /AddressAPIView")
+		}
+	})
+
+	t.Run("Nested serializer resolves correctly", func(t *testing.T) {
+		ep, ok := epMap["GET /UserWithAddressAPIView"]
+		if !ok {
+			t.Fatal("missing GET /UserWithAddressAPIView endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil {
+			t.Fatal("expected Body for response")
+		}
+		addrField, ok := ep.Response.Body.Fields["address"]
+		if !ok {
+			t.Fatal("expected 'address' field in UserWithAddressSerializer")
+		}
+		if addrField.Model.Kind != "object" {
+			t.Errorf("address kind = %q, want %q", addrField.Model.Kind, "object")
+		}
+		if addrField.Model.TypeName != "AddressSerializer" {
+			t.Errorf("address typeName = %q, want %q", addrField.Model.TypeName, "AddressSerializer")
+		}
+	})
+
+	t.Run("ViewSet destroy has no request/response body", func(t *testing.T) {
+		ep, ok := epMap["DELETE /UserViewSet"]
+		if !ok {
+			t.Fatal("missing DELETE /UserViewSet endpoint")
+		}
+		if ep.RequestBody != nil {
+			t.Error("expected no request body for DELETE")
+		}
+		if ep.Response != nil {
+			t.Error("expected no response body for DELETE")
+		}
+	})
+}
+
+func TestParse_SerializerInheritance(t *testing.T) {
+	endpoints, err := Parse("testdata/serializer_inheritance")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(endpoints) == 0 {
+		t.Fatal("Expected endpoints to be extracted, got none")
+	}
+
+	epMap := make(map[string]collector.ApiEndpoint)
+	for _, ep := range endpoints {
+		key := ep.Method + " " + ep.Path
+		epMap[key] = ep
+	}
+
+	t.Run("ItemSerializer has inherited fields", func(t *testing.T) {
+		ep, ok := epMap["GET /ItemViewSet"]
+		if !ok {
+			t.Fatal("missing GET /ItemViewSet endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil {
+			t.Fatal("expected Body for response")
+		}
+		if ep.Response.Body.TypeName != "ItemSerializer" {
+			t.Errorf("response body TypeName = %q, want %q", ep.Response.Body.TypeName, "ItemSerializer")
+		}
+		if len(ep.Response.Body.Fields) < 4 {
+			t.Fatalf("ItemSerializer should have at least 4 fields (2 own + 2 inherited), got %d", len(ep.Response.Body.Fields))
+		}
+		if _, ok := ep.Response.Body.Fields["id"]; !ok {
+			t.Error("expected inherited 'id' field")
+		}
+		if _, ok := ep.Response.Body.Fields["created_at"]; !ok {
+			t.Error("expected inherited 'created_at' field")
+		}
+		if _, ok := ep.Response.Body.Fields["name"]; !ok {
+			t.Error("expected own 'name' field")
+		}
+		if _, ok := ep.Response.Body.Fields["price"]; !ok {
+			t.Error("expected own 'price' field")
+		}
+	})
+}
+
+func TestParse_ModelSerializer(t *testing.T) {
+	endpoints, err := Parse("testdata/model_serializer")
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(endpoints) == 0 {
+		t.Fatal("Expected endpoints to be extracted, got none")
+	}
+
+	epMap := make(map[string]collector.ApiEndpoint)
+	for _, ep := range endpoints {
+		key := ep.Method + " " + ep.Path
+		epMap[key] = ep
+	}
+
+	t.Run("ModelSerializer resolves fields", func(t *testing.T) {
+		ep, ok := epMap["GET /ProductViewSet"]
+		if !ok {
+			t.Fatal("missing GET /ProductViewSet endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil {
+			t.Fatal("expected Body for response")
+		}
+		if ep.Response.Body.TypeName != "ProductSerializer" {
+			t.Errorf("response body TypeName = %q, want %q", ep.Response.Body.TypeName, "ProductSerializer")
+		}
+		nameField, ok := ep.Response.Body.Fields["name"]
+		if !ok {
+			t.Fatal("expected 'name' field in ProductSerializer")
+		}
+		if nameField.Model.TypeName != "string" {
+			t.Errorf("ProductSerializer.name type = %q, want %q", nameField.Model.TypeName, "string")
+		}
+		priceField, ok := ep.Response.Body.Fields["price"]
+		if !ok {
+			t.Fatal("expected 'price' field in ProductSerializer")
+		}
+		if priceField.Model.TypeName != "float" {
+			t.Errorf("ProductSerializer.price type = %q, want %q", priceField.Model.TypeName, "float")
+		}
+	})
 }

--- a/api-collector-python/django/resolver.go
+++ b/api-collector-python/django/resolver.go
@@ -1,0 +1,187 @@
+package django
+
+import (
+	"strings"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+type DRFTypeResolver struct {
+	serializerRegistry map[string]SerializerModel
+	resolving          map[string]bool
+}
+
+func NewDRFTypeResolver(serializers map[string]SerializerModel) *DRFTypeResolver {
+	return &DRFTypeResolver{
+		serializerRegistry: serializers,
+		resolving:          make(map[string]bool),
+	}
+}
+
+func (r *DRFTypeResolver) ResolveSerializer(serializerName string) *model.ObjectModel {
+	md, found := r.serializerRegistry[serializerName]
+	if !found {
+		return model.SingleModel(serializerName)
+	}
+
+	if r.resolving[serializerName] {
+		return model.RefModel(serializerName)
+	}
+
+	r.resolving[serializerName] = true
+	defer func() { delete(r.resolving, serializerName) }()
+
+	fields := make(map[string]*model.FieldModel, len(md.Fields))
+	for _, f := range md.Fields {
+		fieldModel := r.resolveSerializerField(f)
+		fields[f.Name] = fieldModel
+	}
+
+	for _, embedded := range md.EmbeddedTypes {
+		embeddedModel := r.ResolveSerializer(embedded)
+		if embeddedModel != nil && embeddedModel.IsObject() {
+			for k, v := range embeddedModel.Fields {
+				if _, exists := fields[k]; !exists {
+					fields[k] = v
+				}
+			}
+		}
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: serializerName,
+		Fields:   fields,
+	}
+}
+
+func (r *DRFTypeResolver) resolveSerializerField(f SerializerField) *model.FieldModel {
+	var fieldModel *model.ObjectModel
+
+	if f.Many {
+		itemModel := r.resolveDRFFieldType(f.DRFType)
+		fieldModel = model.ArrayModel(itemModel)
+	} else {
+		fieldModel = r.resolveDRFFieldType(f.DRFType)
+	}
+
+	return &model.FieldModel{
+		Model:    fieldModel,
+		Required: f.Required && !f.ReadOnly,
+	}
+}
+
+func (r *DRFTypeResolver) resolveDRFFieldType(drfType string) *model.ObjectModel {
+	if jsonType, ok := drfFieldTypeMap[drfType]; ok {
+		if jsonType == "array" {
+			return model.ArrayModel(model.NullModel())
+		}
+		if jsonType == "map" {
+			return model.MapModel(model.SingleModel(model.JsonTypeString), model.NullModel())
+		}
+		return model.SingleModel(jsonType)
+	}
+
+	nestedModel := r.ResolveSerializer(drfType)
+	if nestedModel != nil && (nestedModel.IsObject() || nestedModel.IsRef()) {
+		return nestedModel
+	}
+
+	return model.SingleModel(drfType)
+}
+
+func (r *DRFTypeResolver) ResolveActionSerializer(viewClassName string, action string, serializerClassName string) (requestSerializer string, responseSerializer string) {
+	if serializerClassName == "" {
+		return "", ""
+	}
+
+	switch action {
+	case "list":
+		return "", serializerClassName
+	case "create":
+		return serializerClassName, serializerClassName
+	case "retrieve":
+		return "", serializerClassName
+	case "update":
+		return serializerClassName, serializerClassName
+	case "partial_update":
+		return serializerClassName, serializerClassName
+	case "destroy":
+		return "", ""
+	default:
+		return "", serializerClassName
+	}
+}
+
+func (r *DRFTypeResolver) ResolveHTTPMethodSerializer(viewClassName string, httpMethod string, serializerClassName string) (requestSerializer string, responseSerializer string) {
+	if serializerClassName == "" {
+		return "", ""
+	}
+
+	switch httpMethod {
+	case "GET":
+		return "", serializerClassName
+	case "POST":
+		return serializerClassName, serializerClassName
+	case "PUT":
+		return serializerClassName, serializerClassName
+	case "PATCH":
+		return serializerClassName, serializerClassName
+	case "DELETE":
+		return "", ""
+	default:
+		return "", serializerClassName
+	}
+}
+
+func (r *DRFTypeResolver) BuildRequestBody(serializerName string) *model.ObjectModel {
+	if serializerName == "" {
+		return nil
+	}
+
+	resolved := r.ResolveSerializer(serializerName)
+	if resolved == nil || resolved.IsNull() {
+		return nil
+	}
+
+	writeFields := make(map[string]*model.FieldModel)
+	for name, field := range resolved.Fields {
+		if !field.Required && field.DefaultValue == "" {
+			writeFields[name] = field
+			continue
+		}
+		writeFields[name] = field
+	}
+
+	if len(writeFields) == 0 {
+		return resolved
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: serializerName,
+		Fields:   writeFields,
+	}
+}
+
+func (r *DRFTypeResolver) BuildResponseBody(serializerName string) *model.ObjectModel {
+	if serializerName == "" {
+		return nil
+	}
+
+	return r.ResolveSerializer(serializerName)
+}
+
+func isDRFSerializerType(typeName string) bool {
+	_, ok := drfFieldTypeMap[typeName]
+	if ok {
+		return true
+	}
+	if strings.HasSuffix(typeName, "Serializer") {
+		return true
+	}
+	if strings.HasSuffix(typeName, "Field") {
+		return true
+	}
+	return false
+}

--- a/api-collector-python/django/serializer.go
+++ b/api-collector-python/django/serializer.go
@@ -1,0 +1,445 @@
+package django
+
+import (
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type SerializerModel struct {
+	Name          string
+	Fields        []SerializerField
+	EmbeddedTypes []string
+	MetaModel     string
+	MetaFields    []string
+	IsModelSerializer bool
+}
+
+type SerializerField struct {
+	Name     string
+	DRFType  string
+	Required bool
+	ReadOnly bool
+	Many     bool
+}
+
+var drfFieldTypeMap = map[string]string{
+	"CharField":         "string",
+	"TextField":         "string",
+	"EmailField":        "string",
+	"URLField":          "string",
+	"SlugField":         "string",
+	"UUIDField":         "string",
+	"IPAddressField":    "string",
+	"RegexField":        "string",
+	"FilePathField":     "string",
+	"IntegerField":      "int",
+	"SmallIntegerField": "int",
+	"BigIntegerField":   "long",
+	"PositiveIntegerField":     "int",
+	"PositiveSmallIntegerField": "int",
+	"FloatField":       "float",
+	"DecimalField":     "float",
+	"BooleanField":     "boolean",
+	"NullBooleanField": "boolean",
+	"DateField":        "string",
+	"DateTimeField":    "string",
+	"TimeField":        "string",
+	"DurationField":    "string",
+	"FileField":        "string",
+	"ImageField":       "string",
+	"ListField":        "array",
+	"DictField":        "map",
+	"JSONField":        "string",
+	"SerializerMethodField": "string",
+}
+
+func extractSerializers(rootNode *tree_sitter.Node, source []byte) map[string]SerializerModel {
+	allClasses := make(map[string]*serializerClassInfo)
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+		if child.Kind() == "class_definition" {
+			info := extractSerializerClassInfo(child, source)
+			if info != nil {
+				allClasses[info.name] = info
+			}
+		}
+	}
+
+	serializerSet := findSerializerClasses(allClasses)
+
+	models := make(map[string]SerializerModel)
+	for name, info := range allClasses {
+		if !serializerSet[name] {
+			continue
+		}
+		md := SerializerModel{
+			Name:              name,
+			Fields:            info.fields,
+			IsModelSerializer: info.isModelSerializer,
+			MetaModel:         info.metaModel,
+			MetaFields:        info.metaFields,
+		}
+		for _, parent := range info.parents {
+			if !isDRFBaseClass(parent) {
+				md.EmbeddedTypes = append(md.EmbeddedTypes, parent)
+			}
+		}
+		models[name] = md
+	}
+
+	return models
+}
+
+type serializerClassInfo struct {
+	name              string
+	parents           []string
+	fields            []SerializerField
+	isModelSerializer bool
+	metaModel         string
+	metaFields        []string
+}
+
+func extractSerializerClassInfo(node *tree_sitter.Node, source []byte) *serializerClassInfo {
+	var name string
+	var argList *tree_sitter.Node
+	var body *tree_sitter.Node
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "identifier":
+			name = child.Utf8Text(source)
+		case "argument_list":
+			argList = child
+		case "block":
+			body = child
+		}
+	}
+
+	if name == "" {
+		return nil
+	}
+
+	info := &serializerClassInfo{name: name}
+
+	if argList != nil {
+		info.parents = extractParentClassNames(argList, source)
+		for _, p := range info.parents {
+			if isModelSerializerBase(p) {
+				info.isModelSerializer = true
+			}
+		}
+	}
+
+	if body != nil {
+		info.fields = extractSerializerFields(body, source)
+		info.metaModel, info.metaFields = extractMetaInfo(body, source)
+	}
+
+	return info
+}
+
+func extractParentClassNames(argList *tree_sitter.Node, source []byte) []string {
+	var parents []string
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		text := strings.TrimSpace(child.Utf8Text(source))
+		if text != "" {
+			parents = append(parents, text)
+		}
+	}
+	return parents
+}
+
+func isModelSerializerBase(parent string) bool {
+	return parent == "ModelSerializer" ||
+		strings.HasSuffix(parent, ".ModelSerializer") ||
+		parent == "HyperlinkedModelSerializer" ||
+		strings.HasSuffix(parent, ".HyperlinkedModelSerializer")
+}
+
+func isDRFBaseClass(parent string) bool {
+	switch parent {
+	case "Serializer", "ModelSerializer", "HyperlinkedModelSerializer",
+		"HyperlinkedRelatedField", "StringRelatedField", "PrimaryKeyRelatedField",
+		"SlugRelatedField", "ListSerializer":
+		return true
+	}
+	if strings.HasSuffix(parent, ".Serializer") ||
+		strings.HasSuffix(parent, ".ModelSerializer") ||
+		strings.HasSuffix(parent, ".HyperlinkedModelSerializer") ||
+		strings.HasSuffix(parent, ".ListSerializer") {
+		return true
+	}
+	return false
+}
+
+func extractSerializerFields(body *tree_sitter.Node, source []byte) []SerializerField {
+	var fields []SerializerField
+
+	for i := uint(0); i < body.ChildCount(); i++ {
+		child := body.Child(i)
+		if child.Kind() != "expression_statement" {
+			continue
+		}
+
+		for j := uint(0); j < child.ChildCount(); j++ {
+			subChild := child.Child(j)
+			if subChild.Kind() == "assignment" {
+				f := extractSerializerFieldFromAssignment(subChild, source)
+				if f != nil {
+					fields = append(fields, *f)
+				}
+			}
+		}
+	}
+
+	return fields
+}
+
+func extractSerializerFieldFromAssignment(node *tree_sitter.Node, source []byte) *SerializerField {
+	var name string
+	var drfType string
+	var required bool = true
+	var readOnly bool
+	var many bool
+	leftFound := false
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "identifier":
+			if !leftFound {
+				name = child.Utf8Text(source)
+				leftFound = true
+			}
+		case "=":
+		case "call":
+			if leftFound {
+				drfType, required, readOnly, many = extractDRFFieldCall(child, source)
+			}
+		}
+	}
+
+	if name == "" || drfType == "" {
+		return nil
+	}
+
+	if name == "serializer_class" {
+		return nil
+	}
+
+	return &SerializerField{
+		Name:     name,
+		DRFType:  drfType,
+		Required: required,
+		ReadOnly: readOnly,
+		Many:     many,
+	}
+}
+
+func extractDRFFieldCall(callNode *tree_sitter.Node, source []byte) (drfType string, required bool, readOnly bool, many bool) {
+	required = true
+
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "identifier" || child.Kind() == "attribute" {
+			drfType = extractDRFTypeName(child.Utf8Text(source))
+		}
+		if child.Kind() == "argument_list" {
+			required, readOnly, many = extractDRFFieldArgs(child, source, required)
+		}
+	}
+
+	return drfType, required, readOnly, many
+}
+
+func extractDRFTypeName(raw string) string {
+	parts := strings.Split(raw, ".")
+	return parts[len(parts)-1]
+}
+
+func extractDRFFieldArgs(argList *tree_sitter.Node, source []byte, defaultRequired bool) (required bool, readOnly bool, many bool) {
+	required = defaultRequired
+
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() != "keyword_argument" {
+			continue
+		}
+
+		var kwName string
+		var kwValue string
+		for j := uint(0); j < child.ChildCount(); j++ {
+			kwChild := child.Child(j)
+			if kwChild.Kind() == "identifier" && kwName == "" {
+				kwName = kwChild.Utf8Text(source)
+			} else if kwChild.Kind() == "=" {
+				continue
+			} else if kwName != "" && kwValue == "" {
+				kwValue = kwChild.Utf8Text(source)
+			}
+		}
+
+		switch kwName {
+		case "required":
+			required = kwValue == "True"
+		case "read_only":
+			readOnly = kwValue == "True"
+		case "many":
+			many = kwValue == "True"
+		case "allow_null":
+		case "default":
+			if kwValue != "" {
+				required = false
+			}
+		}
+	}
+
+	return required, readOnly, many
+}
+
+func extractMetaInfo(body *tree_sitter.Node, source []byte) (metaModel string, metaFields []string) {
+	for i := uint(0); i < body.ChildCount(); i++ {
+		child := body.Child(i)
+		if child.Kind() != "class_definition" {
+			continue
+		}
+
+		var className string
+		var classBody *tree_sitter.Node
+		for j := uint(0); j < child.ChildCount(); j++ {
+			c := child.Child(j)
+			if c.Kind() == "identifier" && className == "" {
+				className = c.Utf8Text(source)
+			}
+			if c.Kind() == "block" {
+				classBody = c
+			}
+		}
+
+		if className != "Meta" || classBody == nil {
+			continue
+		}
+
+		for j := uint(0); j < classBody.ChildCount(); j++ {
+			stmt := classBody.Child(j)
+			if stmt.Kind() != "expression_statement" {
+				continue
+			}
+			for k := uint(0); k < stmt.ChildCount(); k++ {
+				assign := stmt.Child(k)
+				if assign.Kind() != "assignment" {
+					continue
+				}
+				var assignName string
+				var assignValue string
+				for m := uint(0); m < assign.ChildCount(); m++ {
+					a := assign.Child(m)
+					if a.Kind() == "identifier" && assignName == "" {
+						assignName = a.Utf8Text(source)
+					} else if a.Kind() == "=" {
+						continue
+					} else if assignName != "" && assignValue == "" {
+						assignValue = a.Utf8Text(source)
+					}
+				}
+				switch assignName {
+				case "model":
+					metaModel = unquotePythonString(strings.TrimSpace(assignValue))
+				case "fields":
+					metaFields = extractListLiteralValues(assignValue)
+				}
+			}
+		}
+	}
+
+	return metaModel, metaFields
+}
+
+func extractListLiteralValues(text string) []string {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "[") || !strings.HasSuffix(text, "]") {
+		return nil
+	}
+	inner := text[1 : len(text)-1]
+	var values []string
+	for _, part := range strings.Split(inner, ",") {
+		part = strings.TrimSpace(part)
+		part = strings.Trim(part, `"'`)
+		if part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
+}
+
+func findSerializerClasses(allClasses map[string]*serializerClassInfo) map[string]bool {
+	serializerSet := make(map[string]bool)
+
+	changed := true
+	for changed {
+		changed = false
+		for name, info := range allClasses {
+			if serializerSet[name] {
+				continue
+			}
+			for _, parent := range info.parents {
+				if isDRFBaseClass(parent) {
+					serializerSet[name] = true
+					changed = true
+					break
+				}
+				if serializerSet[parent] {
+					serializerSet[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+
+	return serializerSet
+}
+
+func extractSerializerClassFromView(classNode *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < classNode.ChildCount(); i++ {
+		child := classNode.Child(i)
+		if child.Kind() != "block" {
+			continue
+		}
+		for j := uint(0); j < child.ChildCount(); j++ {
+			stmt := child.Child(j)
+			if stmt.Kind() != "expression_statement" {
+				continue
+			}
+			for k := uint(0); k < stmt.ChildCount(); k++ {
+				assign := stmt.Child(k)
+				if assign.Kind() != "assignment" {
+					continue
+				}
+				var assignName string
+				var assignValue string
+				for m := uint(0); m < assign.ChildCount(); m++ {
+					a := assign.Child(m)
+					if a.Kind() == "identifier" && assignName == "" {
+						assignName = a.Utf8Text(source)
+					} else if a.Kind() == "=" {
+						continue
+					} else if assignName != "" && assignValue == "" {
+						assignValue = a.Utf8Text(source)
+					}
+				}
+				if assignName == "serializer_class" {
+					return strings.TrimSpace(assignValue)
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/api-collector-python/django/serializer_test.go
+++ b/api-collector-python/django/serializer_test.go
@@ -1,0 +1,705 @@
+package django
+
+import (
+	"testing"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	python "github.com/tree-sitter/tree-sitter-python/bindings/go"
+
+	model "github.com/tangcent/apilot/api-model"
+)
+
+func TestExtractSerializers_BasicSerializer(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class UserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=100)
+    email = serializers.EmailField()
+    age = serializers.IntegerField(required=False)
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	if len(serializers) != 1 {
+		t.Fatalf("expected 1 serializer, got %d", len(serializers))
+	}
+
+	userSer, ok := serializers["UserSerializer"]
+	if !ok {
+		t.Fatal("expected 'UserSerializer' to be found")
+	}
+	if len(userSer.Fields) != 3 {
+		t.Fatalf("UserSerializer fields count = %d, want 3", len(userSer.Fields))
+	}
+
+	nameField := findSerializerField(userSer.Fields, "name")
+	if nameField == nil {
+		t.Fatal("expected 'name' field")
+	}
+	if nameField.DRFType != "CharField" {
+		t.Errorf("name.DRFType = %q, want %q", nameField.DRFType, "CharField")
+	}
+	if !nameField.Required {
+		t.Errorf("name.Required = false, want true")
+	}
+
+	ageField := findSerializerField(userSer.Fields, "age")
+	if ageField == nil {
+		t.Fatal("expected 'age' field")
+	}
+	if ageField.Required {
+		t.Errorf("age.Required = true, want false (required=False)")
+	}
+}
+
+func TestExtractSerializers_NestedSerializer(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class AddressSerializer(serializers.Serializer):
+    street = serializers.CharField()
+    city = serializers.CharField()
+
+class UserWithAddressSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    address = AddressSerializer()
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	if len(serializers) != 2 {
+		t.Fatalf("expected 2 serializers, got %d", len(serializers))
+	}
+
+	userSer, ok := serializers["UserWithAddressSerializer"]
+	if !ok {
+		t.Fatal("expected 'UserWithAddressSerializer'")
+	}
+
+	addrField := findSerializerField(userSer.Fields, "address")
+	if addrField == nil {
+		t.Fatal("expected 'address' field")
+	}
+	if addrField.DRFType != "AddressSerializer" {
+		t.Errorf("address.DRFType = %q, want %q", addrField.DRFType, "AddressSerializer")
+	}
+}
+
+func TestExtractSerializers_ModelSerializer(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class ProductSerializer(serializers.ModelSerializer):
+    name = serializers.CharField()
+    price = serializers.FloatField()
+
+    class Meta:
+        model = 'Product'
+        fields = ['id', 'name', 'price']
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	if len(serializers) != 1 {
+		t.Fatalf("expected 1 serializer, got %d", len(serializers))
+	}
+
+	prodSer, ok := serializers["ProductSerializer"]
+	if !ok {
+		t.Fatal("expected 'ProductSerializer'")
+	}
+	if !prodSer.IsModelSerializer {
+		t.Error("ProductSerializer.IsModelSerializer = false, want true")
+	}
+	if prodSer.MetaModel != "Product" {
+		t.Errorf("ProductSerializer.MetaModel = %q, want %q", prodSer.MetaModel, "Product")
+	}
+	if len(prodSer.MetaFields) != 3 {
+		t.Fatalf("ProductSerializer.MetaFields count = %d, want 3", len(prodSer.MetaFields))
+	}
+}
+
+func TestExtractSerializers_SerializerInheritance(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class BaseSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+
+class ItemSerializer(BaseSerializer):
+    name = serializers.CharField()
+    price = serializers.FloatField()
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	if len(serializers) != 2 {
+		t.Fatalf("expected 2 serializers, got %d", len(serializers))
+	}
+
+	itemSer, ok := serializers["ItemSerializer"]
+	if !ok {
+		t.Fatal("expected 'ItemSerializer'")
+	}
+	if len(itemSer.EmbeddedTypes) != 1 || itemSer.EmbeddedTypes[0] != "BaseSerializer" {
+		t.Errorf("ItemSerializer.EmbeddedTypes = %v, want [BaseSerializer]", itemSer.EmbeddedTypes)
+	}
+}
+
+func TestExtractSerializers_ReadOnlyField(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class ReadOnlySerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField()
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	ser, ok := serializers["ReadOnlySerializer"]
+	if !ok {
+		t.Fatal("expected 'ReadOnlySerializer'")
+	}
+
+	idField := findSerializerField(ser.Fields, "id")
+	if idField == nil {
+		t.Fatal("expected 'id' field")
+	}
+	if !idField.ReadOnly {
+		t.Error("id.ReadOnly = false, want true")
+	}
+}
+
+func TestExtractSerializers_ManyField(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class TagSerializer(serializers.Serializer):
+    name = serializers.CharField()
+
+class ArticleSerializer(serializers.Serializer):
+    title = serializers.CharField()
+    tags = TagSerializer(many=True)
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	ser, ok := serializers["ArticleSerializer"]
+	if !ok {
+		t.Fatal("expected 'ArticleSerializer'")
+	}
+
+	tagsField := findSerializerField(ser.Fields, "tags")
+	if tagsField == nil {
+		t.Fatal("expected 'tags' field")
+	}
+	if !tagsField.Many {
+		t.Error("tags.Many = false, want true")
+	}
+}
+
+func TestExtractSerializers_DefaultValue(t *testing.T) {
+	source := []byte(`
+from rest_framework import serializers
+
+class ConfigSerializer(serializers.Serializer):
+    name = serializers.CharField(default="unnamed")
+    value = serializers.CharField()
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	serializers := extractSerializers(rootNode, source)
+
+	ser, ok := serializers["ConfigSerializer"]
+	if !ok {
+		t.Fatal("expected 'ConfigSerializer'")
+	}
+
+	nameField := findSerializerField(ser.Fields, "name")
+	if nameField == nil {
+		t.Fatal("expected 'name' field")
+	}
+	if nameField.Required {
+		t.Error("name.Required = true, want false (has default)")
+	}
+}
+
+func TestExtractSerializerClassFromView(t *testing.T) {
+	source := []byte(`
+from rest_framework import viewsets
+
+class UserViewSet(viewsets.ModelViewSet):
+    serializer_class = UserSerializer
+
+    def list(self, request):
+        pass
+`)
+
+	p := createTestParser(t)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+		if child.Kind() == "class_definition" {
+			className := extractClassName(child, source)
+			if className == "UserViewSet" {
+				serClass := extractSerializerClassFromView(child, source)
+				if serClass != "UserSerializer" {
+					t.Errorf("serializer_class = %q, want %q", serClass, "UserSerializer")
+				}
+				return
+			}
+		}
+	}
+	t.Fatal("UserViewSet class not found")
+}
+
+func TestDRFFieldTypeMap(t *testing.T) {
+	tests := []struct {
+		drfType  string
+		jsonType string
+	}{
+		{"CharField", "string"},
+		{"TextField", "string"},
+		{"EmailField", "string"},
+		{"IntegerField", "int"},
+		{"BigIntegerField", "long"},
+		{"FloatField", "float"},
+		{"DecimalField", "float"},
+		{"BooleanField", "boolean"},
+		{"DateField", "string"},
+		{"DateTimeField", "string"},
+		{"ListField", "array"},
+		{"DictField", "map"},
+		{"SerializerMethodField", "string"},
+	}
+
+	for _, tt := range tests {
+		jsonType, ok := drfFieldTypeMap[tt.drfType]
+		if !ok {
+			t.Errorf("DRF type %q not found in mapping", tt.drfType)
+			continue
+		}
+		if jsonType != tt.jsonType {
+			t.Errorf("drfFieldTypeMap[%q] = %q, want %q", tt.drfType, jsonType, tt.jsonType)
+		}
+	}
+}
+
+func findSerializerField(fields []SerializerField, name string) *SerializerField {
+	for i := range fields {
+		if fields[i].Name == name {
+			return &fields[i]
+		}
+	}
+	return nil
+}
+
+func createTestParser(t *testing.T) *tree_sitter.Parser {
+	t.Helper()
+	p := tree_sitter.NewParser()
+	lang := tree_sitter.NewLanguage(python.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		t.Fatalf("failed to set language: %v", err)
+	}
+	return p
+}
+
+func TestDRFTypeResolver_PrimitiveFields(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"UserSerializer": {
+			Name: "UserSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+				{Name: "email", DRFType: "EmailField", Required: true},
+				{Name: "age", DRFType: "IntegerField", Required: false},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("UserSerializer")
+	if result.Kind != model.KindObject {
+		t.Fatalf("ResolveSerializer(UserSerializer).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+	if result.TypeName != "UserSerializer" {
+		t.Errorf("ResolveSerializer(UserSerializer).TypeName = %q, want %q", result.TypeName, "UserSerializer")
+	}
+	if len(result.Fields) != 3 {
+		t.Fatalf("fields count = %d, want 3", len(result.Fields))
+	}
+
+	nameField, ok := result.Fields["name"]
+	if !ok {
+		t.Fatal("expected 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("name model type = %q, want %q", nameField.Model.TypeName, model.JsonTypeString)
+	}
+
+	ageField, ok := result.Fields["age"]
+	if !ok {
+		t.Fatal("expected 'age' field")
+	}
+	if ageField.Model.TypeName != model.JsonTypeInt {
+		t.Errorf("age model type = %q, want %q", ageField.Model.TypeName, model.JsonTypeInt)
+	}
+}
+
+func TestDRFTypeResolver_NestedSerializer(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"AddressSerializer": {
+			Name: "AddressSerializer",
+			Fields: []SerializerField{
+				{Name: "street", DRFType: "CharField", Required: true},
+				{Name: "city", DRFType: "CharField", Required: true},
+			},
+		},
+		"UserWithAddressSerializer": {
+			Name: "UserWithAddressSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+				{Name: "address", DRFType: "AddressSerializer", Required: true},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("UserWithAddressSerializer")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	addrField, ok := result.Fields["address"]
+	if !ok {
+		t.Fatal("expected 'address' field")
+	}
+	if addrField.Model.Kind != model.KindObject {
+		t.Errorf("address kind = %q, want %q", addrField.Model.Kind, model.KindObject)
+	}
+	if addrField.Model.TypeName != "AddressSerializer" {
+		t.Errorf("address typeName = %q, want %q", addrField.Model.TypeName, "AddressSerializer")
+	}
+	if len(addrField.Model.Fields) != 2 {
+		t.Errorf("address fields count = %d, want 2", len(addrField.Model.Fields))
+	}
+}
+
+func TestDRFTypeResolver_Inheritance(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"BaseSerializer": {
+			Name: "BaseSerializer",
+			Fields: []SerializerField{
+				{Name: "id", DRFType: "IntegerField", Required: true, ReadOnly: true},
+				{Name: "created_at", DRFType: "DateTimeField", Required: true, ReadOnly: true},
+			},
+		},
+		"ItemSerializer": {
+			Name: "ItemSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+				{Name: "price", DRFType: "FloatField", Required: true},
+			},
+			EmbeddedTypes: []string{"BaseSerializer"},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("ItemSerializer")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	if len(result.Fields) != 4 {
+		t.Fatalf("fields count = %d, want 4 (2 own + 2 inherited)", len(result.Fields))
+	}
+
+	if _, ok := result.Fields["id"]; !ok {
+		t.Error("expected inherited 'id' field")
+	}
+	if _, ok := result.Fields["created_at"]; !ok {
+		t.Error("expected inherited 'created_at' field")
+	}
+	if _, ok := result.Fields["name"]; !ok {
+		t.Error("expected own 'name' field")
+	}
+	if _, ok := result.Fields["price"]; !ok {
+		t.Error("expected own 'price' field")
+	}
+}
+
+func TestDRFTypeResolver_ReadOnlyFields(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"ReadOnlySerializer": {
+			Name: "ReadOnlySerializer",
+			Fields: []SerializerField{
+				{Name: "id", DRFType: "IntegerField", Required: true, ReadOnly: true},
+				{Name: "name", DRFType: "CharField", Required: true},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("ReadOnlySerializer")
+
+	idField, ok := result.Fields["id"]
+	if !ok {
+		t.Fatal("expected 'id' field")
+	}
+	if idField.Required {
+		t.Error("id.Required = true for read_only field, want false")
+	}
+
+	nameField, ok := result.Fields["name"]
+	if !ok {
+		t.Fatal("expected 'name' field")
+	}
+	if !nameField.Required {
+		t.Error("name.Required = false, want true")
+	}
+}
+
+func TestDRFTypeResolver_ManyField(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"TagSerializer": {
+			Name: "TagSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+			},
+		},
+		"ArticleSerializer": {
+			Name: "ArticleSerializer",
+			Fields: []SerializerField{
+				{Name: "title", DRFType: "CharField", Required: true},
+				{Name: "tags", DRFType: "TagSerializer", Required: true, Many: true},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("ArticleSerializer")
+
+	tagsField, ok := result.Fields["tags"]
+	if !ok {
+		t.Fatal("expected 'tags' field")
+	}
+	if tagsField.Model.Kind != model.KindArray {
+		t.Errorf("tags kind = %q, want %q", tagsField.Model.Kind, model.KindArray)
+	}
+	if tagsField.Model.Items == nil {
+		t.Fatal("expected Items to be non-nil")
+	}
+	if tagsField.Model.Items.Kind != model.KindObject {
+		t.Errorf("tags items kind = %q, want %q", tagsField.Model.Items.Kind, model.KindObject)
+	}
+}
+
+func TestDRFTypeResolver_CircularReference(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"NodeSerializer": {
+			Name: "NodeSerializer",
+			Fields: []SerializerField{
+				{Name: "value", DRFType: "CharField", Required: true},
+				{Name: "child", DRFType: "NodeSerializer", Required: false},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	result := resolver.ResolveSerializer("NodeSerializer")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	childField, ok := result.Fields["child"]
+	if !ok {
+		t.Fatal("expected 'child' field")
+	}
+	if childField.Model.Kind != model.KindRef {
+		t.Errorf("child kind = %q, want %q (circular ref)", childField.Model.Kind, model.KindRef)
+	}
+}
+
+func TestDRFTypeResolver_UnknownSerializer(t *testing.T) {
+	resolver := NewDRFTypeResolver(nil)
+
+	result := resolver.ResolveSerializer("UnknownSerializer")
+	if result.Kind != model.KindSingle {
+		t.Errorf("Kind = %q, want %q", result.Kind, model.KindSingle)
+	}
+	if result.TypeName != "UnknownSerializer" {
+		t.Errorf("TypeName = %q, want %q", result.TypeName, "UnknownSerializer")
+	}
+}
+
+func TestDRFTypeResolver_ActionSerializer(t *testing.T) {
+	resolver := NewDRFTypeResolver(nil)
+
+	tests := []struct {
+		action    string
+		wantReq   bool
+		wantResp  bool
+	}{
+		{"list", false, true},
+		{"create", true, true},
+		{"retrieve", false, true},
+		{"update", true, true},
+		{"partial_update", true, true},
+		{"destroy", false, false},
+	}
+
+	for _, tt := range tests {
+		reqSer, respSer := resolver.ResolveActionSerializer("TestViewSet", tt.action, "TestSerializer")
+		if tt.wantReq && reqSer == "" {
+			t.Errorf("action %q: expected request serializer, got empty", tt.action)
+		}
+		if !tt.wantReq && reqSer != "" {
+			t.Errorf("action %q: expected no request serializer, got %q", tt.action, reqSer)
+		}
+		if tt.wantResp && respSer == "" {
+			t.Errorf("action %q: expected response serializer, got empty", tt.action)
+		}
+		if !tt.wantResp && respSer != "" {
+			t.Errorf("action %q: expected no response serializer, got %q", tt.action, respSer)
+		}
+	}
+}
+
+func TestDRFTypeResolver_HTTPMethodSerializer(t *testing.T) {
+	resolver := NewDRFTypeResolver(nil)
+
+	tests := []struct {
+		method   string
+		wantReq  bool
+		wantResp bool
+	}{
+		{"GET", false, true},
+		{"POST", true, true},
+		{"PUT", true, true},
+		{"PATCH", true, true},
+		{"DELETE", false, false},
+	}
+
+	for _, tt := range tests {
+		reqSer, respSer := resolver.ResolveHTTPMethodSerializer("TestView", tt.method, "TestSerializer")
+		if tt.wantReq && reqSer == "" {
+			t.Errorf("method %q: expected request serializer, got empty", tt.method)
+		}
+		if !tt.wantReq && reqSer != "" {
+			t.Errorf("method %q: expected no request serializer, got %q", tt.method, reqSer)
+		}
+		if tt.wantResp && respSer == "" {
+			t.Errorf("method %q: expected response serializer, got empty", tt.method)
+		}
+		if !tt.wantResp && respSer != "" {
+			t.Errorf("method %q: expected no response serializer, got %q", tt.method, respSer)
+		}
+	}
+}
+
+func TestDRFTypeResolver_BuildRequestBody(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"UserSerializer": {
+			Name: "UserSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+				{Name: "email", DRFType: "EmailField", Required: true},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	body := resolver.BuildRequestBody("UserSerializer")
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+	if body.Kind != model.KindObject {
+		t.Errorf("body.Kind = %q, want %q", body.Kind, model.KindObject)
+	}
+	if body.TypeName != "UserSerializer" {
+		t.Errorf("body.TypeName = %q, want %q", body.TypeName, "UserSerializer")
+	}
+}
+
+func TestDRFTypeResolver_BuildResponseBody(t *testing.T) {
+	serializers := map[string]SerializerModel{
+		"UserSerializer": {
+			Name: "UserSerializer",
+			Fields: []SerializerField{
+				{Name: "name", DRFType: "CharField", Required: true},
+				{Name: "email", DRFType: "EmailField", Required: true},
+			},
+		},
+	}
+
+	resolver := NewDRFTypeResolver(serializers)
+
+	body := resolver.BuildResponseBody("UserSerializer")
+	if body == nil {
+		t.Fatal("expected non-nil body")
+	}
+	if body.Kind != model.KindObject {
+		t.Errorf("body.Kind = %q, want %q", body.Kind, model.KindObject)
+	}
+}
+
+func TestDRFTypeResolver_BuildBody_Empty(t *testing.T) {
+	resolver := NewDRFTypeResolver(nil)
+
+	body := resolver.BuildRequestBody("")
+	if body != nil {
+		t.Error("expected nil body for empty serializer name")
+	}
+
+	body = resolver.BuildResponseBody("")
+	if body != nil {
+		t.Error("expected nil body for empty serializer name")
+	}
+}

--- a/api-collector-python/django/testdata/model_serializer/views.py
+++ b/api-collector-python/django/testdata/model_serializer/views.py
@@ -1,0 +1,26 @@
+from rest_framework import serializers
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(max_length=200)
+    price = serializers.FloatField()
+    description = serializers.CharField(required=False)
+
+    class Meta:
+        model = 'Product'
+        fields = ['id', 'name', 'price', 'description']
+
+
+class ProductViewSet(viewsets.ModelViewSet):
+    """Product CRUD operations."""
+    serializer_class = ProductSerializer
+
+    def list(self, request):
+        """List all products."""
+        return Response([])
+
+    def create(self, request):
+        """Create a new product."""
+        return Response({"created": True})

--- a/api-collector-python/django/testdata/serializer_inheritance/views.py
+++ b/api-collector-python/django/testdata/serializer_inheritance/views.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+
+class BaseItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    created_at = serializers.DateTimeField(read_only=True)
+
+
+class ItemSerializer(BaseItemSerializer):
+    name = serializers.CharField(max_length=200)
+    description = serializers.CharField(required=False)
+    price = serializers.FloatField()
+
+
+class ItemViewSet(viewsets.ModelViewSet):
+    """Item CRUD operations."""
+    serializer_class = ItemSerializer
+
+    def list(self, request):
+        """List all items."""
+        return Response([])
+
+    def create(self, request):
+        """Create a new item."""
+        return Response({"created": True})
+
+    def retrieve(self, request, pk=None):
+        """Get item by ID."""
+        return Response({"id": pk})

--- a/api-collector-python/django/testdata/serializers/views.py
+++ b/api-collector-python/django/testdata/serializers/views.py
@@ -1,0 +1,73 @@
+from rest_framework import serializers
+from rest_framework import viewsets
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+
+class UserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=100)
+    email = serializers.EmailField()
+    age = serializers.IntegerField(required=False)
+
+
+class AddressSerializer(serializers.Serializer):
+    street = serializers.CharField()
+    city = serializers.CharField()
+    zip_code = serializers.CharField(required=False)
+
+
+class UserWithAddressSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    email = serializers.EmailField()
+    address = AddressSerializer()
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    """User CRUD operations."""
+    serializer_class = UserSerializer
+
+    def list(self, request):
+        """List all users."""
+        return Response([])
+
+    def create(self, request):
+        """Create a new user."""
+        return Response({"created": True})
+
+    def retrieve(self, request, pk=None):
+        """Get user by ID."""
+        return Response({"id": pk})
+
+    def update(self, request, pk=None):
+        """Update user."""
+        return Response({"updated": True})
+
+    def destroy(self, request, pk=None):
+        """Delete user."""
+        return Response({"deleted": True})
+
+
+class AddressAPIView(APIView):
+    """Address API view."""
+    serializer_class = AddressSerializer
+
+    def get(self, request):
+        """Get all addresses."""
+        return Response([])
+
+    def post(self, request):
+        """Create a new address."""
+        return Response({"created": True})
+
+
+class UserWithAddressAPIView(APIView):
+    """User with address API view."""
+    serializer_class = UserWithAddressSerializer
+
+    def get(self, request):
+        """Get user with address."""
+        return Response({})
+
+    def post(self, request):
+        """Create user with address."""
+        return Response({"created": True})

--- a/samples/python-django/myapp/views.py
+++ b/samples/python-django/myapp/views.py
@@ -1,7 +1,28 @@
+from rest_framework import serializers
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import viewsets
+
+
+class UserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=100)
+    email = serializers.EmailField()
+    age = serializers.IntegerField(required=False)
+
+
+class PostSerializer(serializers.Serializer):
+    title = serializers.CharField(max_length=200)
+    content = serializers.CharField()
+    author = UserSerializer()
+    published = serializers.BooleanField(default=False)
+
+
+class CommentSerializer(serializers.Serializer):
+    content = serializers.CharField()
+    post_id = serializers.IntegerField()
+    author_name = serializers.CharField(max_length=100)
+
 
 @api_view(['GET', 'POST'])
 def user_list(request):
@@ -24,11 +45,12 @@ class PostList(APIView):
     """
     List all posts or create a new post.
     """
-    
+    serializer_class = PostSerializer
+
     def get(self, request):
         """Get all posts."""
         return Response([])
-    
+
     def post(self, request):
         """Create a new post."""
         return Response({"created": True})
@@ -37,15 +59,16 @@ class PostDetail(APIView):
     """
     Retrieve, update or delete a post.
     """
-    
+    serializer_class = PostSerializer
+
     def get(self, request, pk):
         """Get post by ID."""
         return Response({"id": pk})
-    
+
     def put(self, request, pk):
         """Update post."""
         return Response({"updated": True})
-    
+
     def delete(self, request, pk):
         """Delete post."""
         return Response({"deleted": True})
@@ -54,23 +77,24 @@ class CommentViewSet(viewsets.ModelViewSet):
     """
     A viewset for viewing and editing comment instances.
     """
-    
+    serializer_class = CommentSerializer
+
     def list(self, request):
         """List all comments."""
         return Response([])
-    
+
     def create(self, request):
         """Create a new comment."""
         return Response({"created": True})
-    
+
     def retrieve(self, request, pk=None):
         """Get comment by ID."""
         return Response({"id": pk})
-    
+
     def update(self, request, pk=None):
         """Update comment."""
         return Response({"updated": True})
-    
+
     def destroy(self, request, pk=None):
         """Delete comment."""
         return Response({"deleted": True})


### PR DESCRIPTION
Resolves #97

Adds detailed request/response type resolution for Python Django REST Framework by parsing DRF serializer classes and resolving structured field-level schemas.

**Key changes:**
- Add serializer.go: Parse DRF serializer classes with field type mapping
- Add resolver.go: Resolve serializer models to structured ObjectModel schemas
- Update parser.go: Integrate serializer resolution into endpoint extraction
- Add comprehensive unit and integration tests
- Add testdata for serializers, serializer inheritance, and ModelSerializer
- Enhance samples/python-django/ with typed serializer patterns

**Features:**
- 25+ DRF field types mapped to JSON schema types
- Serializer inheritance support
- Nested serializer resolution
- many=True produces array types
- read_only fields excluded from request bodies
- Circular reference detection with RefModel
- ViewSet action-based and APIView HTTP method-based serializer resolution
