### PR TITLE
feat(flask): add detailed request/response type resolution

### DIFF
--- a/api-collector-python/fastapi/parser.go
+++ b/api-collector-python/fastapi/parser.go
@@ -140,7 +140,7 @@ func processFile(filePath string) fileResult {
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	models := extractPydanticModels(rootNode, source)
+	models := ExtractPydanticModels(rootNode, source)
 	rawEndpoints := extractRawEndpoints(rootNode, source)
 
 	return fileResult{
@@ -578,7 +578,7 @@ func extractSingleParameter(paramNode *tree_sitter.Node, source []byte, path str
 	}
 
 	if p.typeAnnotation != "" && p.in != "body" && p.in != "path" && p.in != "header" && p.in != "cookie" && p.in != "form" {
-		if isPydanticModelType(p.typeAnnotation) {
+		if IsPydanticModelType(p.typeAnnotation) {
 			p.in = "body"
 		}
 	}
@@ -586,8 +586,8 @@ func extractSingleParameter(paramNode *tree_sitter.Node, source []byte, path str
 	return p
 }
 
-func isPydanticModelType(typeText string) bool {
-	baseName, _ := parsePythonGenericType(typeText)
+func IsPydanticModelType(typeText string) bool {
+	baseName, _ := ParsePythonGenericType(typeText)
 	if pythonPrimitives[baseName] != "" {
 		return false
 	}

--- a/api-collector-python/fastapi/resolver.go
+++ b/api-collector-python/fastapi/resolver.go
@@ -46,7 +46,7 @@ var pythonMapTypes = map[string]bool{
 	"DefaultDict": true,
 }
 
-func extractPydanticModels(rootNode *tree_sitter.Node, source []byte) map[string]PydanticModel {
+func ExtractPydanticModels(rootNode *tree_sitter.Node, source []byte) map[string]PydanticModel {
 	allClasses := make(map[string]*classInfo)
 
 	for i := uint(0); i < rootNode.ChildCount(); i++ {
@@ -343,7 +343,7 @@ func (r *PythonTypeResolver) Resolve(typeText string) *model.ObjectModel {
 		return model.NullModel()
 	}
 
-	baseName, typeArgs := parsePythonGenericType(typeText)
+	baseName, typeArgs := ParsePythonGenericType(typeText)
 
 	if baseName == "Optional" {
 		if len(typeArgs) > 0 {
@@ -465,7 +465,7 @@ func (r *PythonTypeResolver) resolveFieldModel(f PydanticField) *model.FieldMode
 	}
 }
 
-func parsePythonGenericType(typeText string) (string, []string) {
+func ParsePythonGenericType(typeText string) (string, []string) {
 	idx := strings.Index(typeText, "[")
 	if idx == -1 {
 		return typeText, nil

--- a/api-collector-python/fastapi/resolver_test.go
+++ b/api-collector-python/fastapi/resolver_test.go
@@ -277,17 +277,17 @@ func TestParsePythonGenericType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		base, args := parsePythonGenericType(tt.input)
+		base, args := ParsePythonGenericType(tt.input)
 		if base != tt.base {
-			t.Errorf("parsePythonGenericType(%q) base = %q, want %q", tt.input, base, tt.base)
+			t.Errorf("ParsePythonGenericType(%q) base = %q, want %q", tt.input, base, tt.base)
 		}
 		if len(args) != len(tt.args) {
-			t.Errorf("parsePythonGenericType(%q) args count = %d, want %d", tt.input, len(args), len(tt.args))
+			t.Errorf("ParsePythonGenericType(%q) args count = %d, want %d", tt.input, len(args), len(tt.args))
 			continue
 		}
 		for i, arg := range args {
 			if arg != tt.args[i] {
-				t.Errorf("parsePythonGenericType(%q) args[%d] = %q, want %q", tt.input, i, arg, tt.args[i])
+				t.Errorf("ParsePythonGenericType(%q) args[%d] = %q, want %q", tt.input, i, arg, tt.args[i])
 			}
 		}
 	}
@@ -360,7 +360,7 @@ class NotAModel:
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	models := extractPydanticModels(rootNode, source)
+	models := ExtractPydanticModels(rootNode, source)
 
 	if len(models) != 2 {
 		t.Fatalf("expected 2 Pydantic models, got %d", len(models))
@@ -405,7 +405,7 @@ class User(BaseEntity):
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	models := extractPydanticModels(rootNode, source)
+	models := ExtractPydanticModels(rootNode, source)
 
 	if len(models) != 2 {
 		t.Fatalf("expected 2 models, got %d", len(models))

--- a/api-collector-python/flask/marshmallow.go
+++ b/api-collector-python/flask/marshmallow.go
@@ -1,0 +1,362 @@
+package flask
+
+import (
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+type MarshmallowModel struct {
+	Name          string
+	Fields        []MarshmallowField
+	EmbeddedTypes []string
+}
+
+type MarshmallowField struct {
+	Name      string
+	FieldType string
+	Required  bool
+	Many      bool
+	Nested    string
+}
+
+var marshmallowFieldTypeMap = map[string]string{
+	"String":  "string",
+	"Str":     "string",
+	"Integer": "int",
+	"Int":     "int",
+	"Float":   "float",
+	"Boolean": "boolean",
+	"Bool":    "boolean",
+	"DateTime": "string",
+	"Date":    "string",
+	"Time":    "string",
+	"Email":   "string",
+	"URL":     "string",
+	"Url":     "string",
+	"UUID":    "string",
+	"IP":      "string",
+	"IPv4":    "string",
+	"IPv6":    "string",
+	"MAC":     "string",
+	"Decimal": "float",
+	"Raw":     "string",
+	"Dict":    "map",
+	"List":    "array",
+	"Tuple":   "array",
+	"Nested":  "object",
+	"Method":  "string",
+	"Function": "string",
+	"Constant": "string",
+	"File":    "string",
+}
+
+func extractMarshmallowSchemas(rootNode *tree_sitter.Node, source []byte) map[string]MarshmallowModel {
+	allClasses := make(map[string]*marshmallowClassInfo)
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+		if child.Kind() == "class_definition" {
+			info := extractMarshmallowClassInfo(child, source)
+			if info != nil {
+				allClasses[info.name] = info
+			}
+		}
+	}
+
+	schemaSet := findMarshmallowSchemas(allClasses)
+
+	models := make(map[string]MarshmallowModel)
+	for name, info := range allClasses {
+		if !schemaSet[name] {
+			continue
+		}
+		md := MarshmallowModel{
+			Name:   name,
+			Fields: info.fields,
+		}
+		for _, parent := range info.parents {
+			if !isMarshmallowBaseClass(parent) {
+				md.EmbeddedTypes = append(md.EmbeddedTypes, parent)
+			}
+		}
+		models[name] = md
+	}
+
+	return models
+}
+
+type marshmallowClassInfo struct {
+	name    string
+	parents []string
+	fields  []MarshmallowField
+}
+
+func extractMarshmallowClassInfo(node *tree_sitter.Node, source []byte) *marshmallowClassInfo {
+	var name string
+	var argList *tree_sitter.Node
+	var body *tree_sitter.Node
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "identifier":
+			name = child.Utf8Text(source)
+		case "argument_list":
+			argList = child
+		case "block":
+			body = child
+		}
+	}
+
+	if name == "" {
+		return nil
+	}
+
+	info := &marshmallowClassInfo{name: name}
+
+	if argList != nil {
+		info.parents = extractMarshmallowParentClasses(argList, source)
+	}
+
+	if body != nil {
+		info.fields = extractMarshmallowFields(body, source)
+	}
+
+	return info
+}
+
+func extractMarshmallowParentClasses(argList *tree_sitter.Node, source []byte) []string {
+	var parents []string
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		text := strings.TrimSpace(child.Utf8Text(source))
+		if text != "" {
+			parents = append(parents, text)
+		}
+	}
+	return parents
+}
+
+func findMarshmallowSchemas(allClasses map[string]*marshmallowClassInfo) map[string]bool {
+	schemaSet := make(map[string]bool)
+
+	changed := true
+	for changed {
+		changed = false
+		for name, info := range allClasses {
+			if schemaSet[name] {
+				continue
+			}
+			for _, parent := range info.parents {
+				if isMarshmallowBaseClass(parent) {
+					schemaSet[name] = true
+					changed = true
+					break
+				}
+				if schemaSet[parent] {
+					schemaSet[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+
+	return schemaSet
+}
+
+func isMarshmallowBaseClass(parent string) bool {
+	switch parent {
+	case "Schema", "ModelSchema", "TableSchema",
+		"SQLAlchemyAutoSchema", "SQLAlchemySchema",
+		"HyperlinkRelatedField":
+		return true
+	}
+	if strings.HasSuffix(parent, ".Schema") ||
+		strings.HasSuffix(parent, ".ModelSchema") ||
+		strings.HasSuffix(parent, ".SQLAlchemyAutoSchema") ||
+		strings.HasSuffix(parent, ".SQLAlchemySchema") {
+		return true
+	}
+	return false
+}
+
+func extractMarshmallowFields(body *tree_sitter.Node, source []byte) []MarshmallowField {
+	var fields []MarshmallowField
+
+	for i := uint(0); i < body.ChildCount(); i++ {
+		child := body.Child(i)
+		if child.Kind() != "expression_statement" {
+			continue
+		}
+
+		for j := uint(0); j < child.ChildCount(); j++ {
+			subChild := child.Child(j)
+			if subChild.Kind() == "assignment" {
+				f := extractMarshmallowFieldFromAssignment(subChild, source)
+				if f != nil {
+					fields = append(fields, *f)
+				}
+			}
+		}
+	}
+
+	return fields
+}
+
+func extractMarshmallowFieldFromAssignment(assignNode *tree_sitter.Node, source []byte) *MarshmallowField {
+	var name string
+	var rightSide *tree_sitter.Node
+
+	for i := uint(0); i < assignNode.ChildCount(); i++ {
+		child := assignNode.Child(i)
+		switch child.Kind() {
+		case "identifier":
+			if name == "" {
+				name = child.Utf8Text(source)
+			}
+		case "=":
+			// skip
+		default:
+			if name != "" && rightSide == nil {
+				rightSide = child
+			}
+		}
+	}
+
+	if name == "" || rightSide == nil {
+		return nil
+	}
+
+	if rightSide.Kind() == "call" {
+		return extractMarshmallowFieldFromCall(name, rightSide, source)
+	}
+
+	return nil
+}
+
+func extractMarshmallowFieldFromCall(name string, callNode *tree_sitter.Node, source []byte) *MarshmallowField {
+	var fieldType string
+	var required bool = true
+	var many bool
+	var nested string
+
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "attribute" {
+			fieldType = extractMarshmallowFieldTypeName(child, source)
+		} else if child.Kind() == "identifier" {
+			fieldType = child.Utf8Text(source)
+		} else if child.Kind() == "argument_list" {
+			required, many, nested = extractMarshmallowFieldArgs(child, source, fieldType)
+		}
+	}
+
+	if fieldType == "" {
+		return nil
+	}
+
+	if _, ok := marshmallowFieldTypeMap[fieldType]; !ok && nested == "" {
+		nested = fieldType
+		fieldType = "Nested"
+	}
+
+	return &MarshmallowField{
+		Name:      name,
+		FieldType: fieldType,
+		Required:  required,
+		Many:      many,
+		Nested:    nested,
+	}
+}
+
+func extractMarshmallowFieldTypeName(attrNode *tree_sitter.Node, source []byte) string {
+	var obj string
+	var attr string
+
+	for i := uint(0); i < attrNode.ChildCount(); i++ {
+		child := attrNode.Child(i)
+		if child.Kind() == "." {
+			continue
+		}
+		if child.Kind() == "identifier" {
+			if obj == "" {
+				obj = child.Utf8Text(source)
+			} else {
+				attr = child.Utf8Text(source)
+			}
+		}
+		if child.Kind() == "attribute" {
+			innerAttr := extractMarshmallowFieldTypeName(child, source)
+			if innerAttr != "" {
+				attr = innerAttr
+			}
+		}
+	}
+
+	if attr != "" {
+		return attr
+	}
+	return obj
+}
+
+func extractMarshmallowFieldArgs(argList *tree_sitter.Node, source []byte, fieldType string) (required bool, many bool, nested string) {
+	required = true
+
+	if fieldType == "Nested" {
+		for i := uint(0); i < argList.ChildCount(); i++ {
+			child := argList.Child(i)
+			if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+				continue
+			}
+			if child.Kind() == "identifier" && nested == "" {
+				nested = child.Utf8Text(source)
+			}
+			if child.Kind() == "keyword_argument" {
+				kwName, kwValue := extractKeywordArg(child, source)
+				switch kwName {
+				case "required":
+					required = kwValue != "False"
+				case "many":
+					many = kwValue == "True"
+				case "nested":
+					nested = kwValue
+				}
+			}
+		}
+		return required, many, nested
+	}
+
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() == "keyword_argument" {
+			kwName, kwValue := extractKeywordArg(child, source)
+			switch kwName {
+			case "required":
+				required = kwValue != "False"
+			case "many":
+				many = kwValue == "True"
+			case "nested":
+				nested = kwValue
+			}
+		}
+	}
+
+	return required, many, nested
+}
+
+func extractKeywordArg(kwArgNode *tree_sitter.Node, source []byte) (name string, value string) {
+	for i := uint(0); i < kwArgNode.ChildCount(); i++ {
+		child := kwArgNode.Child(i)
+		if child.Kind() == "identifier" && name == "" {
+			name = child.Utf8Text(source)
+		} else if child.Kind() != "=" && name != "" && value == "" {
+			value = child.Utf8Text(source)
+		}
+	}
+	return name, value
+}

--- a/api-collector-python/flask/parser.go
+++ b/api-collector-python/flask/parser.go
@@ -11,6 +11,9 @@ import (
 	python "github.com/tree-sitter/tree-sitter-python/bindings/go"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
+
+	"github.com/tangcent/apilot/api-collector-python/fastapi"
 )
 
 func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
@@ -36,12 +39,35 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		close(ch)
 	}()
 
-	var allEndpoints []collector.ApiEndpoint
+	allPydanticModels := make(map[string]fastapi.PydanticModel)
+	allMarshmallowSchemas := make(map[string]MarshmallowModel)
+	var allRawEndpoints []rawEndpointInfo
+
 	for res := range ch {
 		if res.err != nil {
 			continue
 		}
-		allEndpoints = append(allEndpoints, res.endpoints...)
+		for k, v := range res.pydanticModels {
+			allPydanticModels[k] = v
+		}
+		for k, v := range res.marshmallowSchemas {
+			allMarshmallowSchemas[k] = v
+		}
+		allRawEndpoints = append(allRawEndpoints, res.rawEndpoints...)
+	}
+
+	if len(allRawEndpoints) == 0 {
+		return nil, nil
+	}
+
+	typeResolver := NewFlaskTypeResolver(allPydanticModels, allMarshmallowSchemas)
+
+	var allEndpoints []collector.ApiEndpoint
+	for _, raw := range allRawEndpoints {
+		ep := buildEndpoint(raw, typeResolver)
+		if ep != nil {
+			allEndpoints = append(allEndpoints, *ep)
+		}
 	}
 
 	if len(allEndpoints) == 0 {
@@ -51,9 +77,24 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	return allEndpoints, nil
 }
 
+type rawEndpointInfo struct {
+	method          string
+	path            string
+	funcName        string
+	description     string
+	params          []funcParam
+	requestBodyType string
+	responseType    string
+	expectModel     string
+	marshalModel    string
+	requestPattern  string
+}
+
 type fileResult struct {
-	endpoints []collector.ApiEndpoint
-	err       error
+	rawEndpoints       []rawEndpointInfo
+	pydanticModels     map[string]fastapi.PydanticModel
+	marshmallowSchemas map[string]MarshmallowModel
+	err                error
 }
 
 func discoverPythonFiles(sourceDir string) ([]string, error) {
@@ -94,28 +135,36 @@ func processFile(filePath string) fileResult {
 	defer tree.Close()
 
 	rootNode := tree.RootNode()
-	endpoints := extractEndpoints(rootNode, source)
+	pydanticModels := fastapi.ExtractPydanticModels(rootNode, source)
+	marshmallowSchemas := extractMarshmallowSchemas(rootNode, source)
+	rawEndpoints := extractRawEndpoints(rootNode, source)
 
-	return fileResult{endpoints: endpoints}
+	return fileResult{
+		pydanticModels:     pydanticModels,
+		marshmallowSchemas: marshmallowSchemas,
+		rawEndpoints:       rawEndpoints,
+	}
 }
 
-func extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
-	var endpoints []collector.ApiEndpoint
+func extractRawEndpoints(rootNode *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
 
 	for i := uint(0); i < rootNode.ChildCount(); i++ {
 		child := rootNode.Child(i)
-		if child.Kind() != "decorated_definition" {
-			continue
+		switch child.Kind() {
+		case "decorated_definition":
+			eps := extractDecoratedDefinition(child, source)
+			endpoints = append(endpoints, eps...)
+		case "class_definition":
+			eps := extractClassDefinition(child, source)
+			endpoints = append(endpoints, eps...)
 		}
-
-		eps := extractDecoratedDefinition(child, source)
-		endpoints = append(endpoints, eps...)
 	}
 
 	return endpoints
 }
 
-func extractDecoratedDefinition(node *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+func extractDecoratedDefinition(node *tree_sitter.Node, source []byte) []rawEndpointInfo {
 	var decorator *tree_sitter.Node
 	var funcDef *tree_sitter.Node
 
@@ -133,72 +182,298 @@ func extractDecoratedDefinition(node *tree_sitter.Node, source []byte) []collect
 		return nil
 	}
 
-	routeInfo := extractDecoratorInfo(decorator, source)
+	routeInfo := extractDecoratorRouteInfo(decorator, source)
 	if routeInfo.path == "" {
 		return nil
 	}
 
 	funcName := extractFunctionName(funcDef, source)
 	description := extractDocstring(funcDef, source)
+	params := extractFunctionParameters(funcDef, source, routeInfo.path)
+	returnType := extractReturnType(funcDef, source)
+	requestPattern := detectRequestPattern(funcDef, source)
+	expectModel, marshalModel := extractRESTXDecoratorInfo(decorator, source)
 
-	var endpoints []collector.ApiEndpoint
+	var requestBodyType string
+	requestBodyType = detectRequestBodyType(funcDef, source, params)
+
+	var endpoints []rawEndpointInfo
 
 	for _, method := range routeInfo.methods {
 		path := convertFlaskPathToStandard(routeInfo.path)
-		ep := &collector.ApiEndpoint{
-			Name:        funcName,
-			Path:        path,
-			Method:      strings.ToUpper(method),
-			Protocol:    "http",
-			Description: description,
+		raw := rawEndpointInfo{
+			method:          strings.ToUpper(method),
+			path:            path,
+			funcName:        funcName,
+			description:     description,
+			params:          params,
+			requestBodyType: requestBodyType,
+			responseType:    returnType,
+			expectModel:     expectModel,
+			marshalModel:    marshalModel,
+			requestPattern:  requestPattern,
 		}
-
-		pathParams := extractPathParams(path)
-		pathParamNames := make(map[string]bool)
-		for _, p := range pathParams {
-			pathParamNames[p.name] = true
-		}
-
-		params := extractFunctionParameters(funcDef, source, path)
-
-		paramSet := make(map[string]bool)
-		var allParams []collector.ApiParameter
-
-		for _, p := range pathParams {
-			allParams = append(allParams, collector.ApiParameter{
-				Name:     p.name,
-				In:       "path",
-				Required: true,
-				Type:     "text",
-			})
-			paramSet[p.name+"|path"] = true
-		}
-
-		for _, p := range params {
-			if pathParamNames[p.name] && p.in == "query" {
-				p.in = "path"
-				p.required = true
-			}
-			key := p.name + "|" + p.in
-			if !paramSet[key] {
-				allParams = append(allParams, collector.ApiParameter{
-					Name:     p.name,
-					In:       p.in,
-					Required: p.required,
-					Type:     p.typ,
-				})
-				paramSet[key] = true
-			}
-		}
-
-		if len(allParams) > 0 {
-			ep.Parameters = allParams
-		}
-
-		endpoints = append(endpoints, *ep)
+		endpoints = append(endpoints, raw)
 	}
 
 	return endpoints
+}
+
+func extractClassDefinition(node *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var className string
+	var body *tree_sitter.Node
+	var argList *tree_sitter.Node
+
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		switch child.Kind() {
+		case "identifier":
+			className = child.Utf8Text(source)
+		case "argument_list":
+			argList = child
+		case "block":
+			body = child
+		}
+	}
+
+	if className == "" || body == nil {
+		return nil
+	}
+
+	if !isRESTXResourceClass(argList, source) {
+		return nil
+	}
+
+	return extractRESTXResourceEndpoints(className, body, source)
+}
+
+func isRESTXResourceClass(argList *tree_sitter.Node, source []byte) bool {
+	if argList == nil {
+		return false
+	}
+
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		text := strings.TrimSpace(child.Utf8Text(source))
+		if text == "Resource" || strings.HasSuffix(text, ".Resource") {
+			return true
+		}
+	}
+	return false
+}
+
+func extractRESTXResourceEndpoints(className string, body *tree_sitter.Node, source []byte) []rawEndpointInfo {
+	var endpoints []rawEndpointInfo
+
+	for i := uint(0); i < body.ChildCount(); i++ {
+		child := body.Child(i)
+		if child.Kind() != "decorated_definition" {
+			continue
+		}
+
+		var decorator *tree_sitter.Node
+		var funcDef *tree_sitter.Node
+
+		for j := uint(0); j < child.ChildCount(); j++ {
+			subChild := child.Child(j)
+			switch subChild.Kind() {
+			case "decorator":
+				decorator = subChild
+			case "function_definition":
+				funcDef = subChild
+			}
+		}
+
+		if funcDef == nil {
+			continue
+		}
+
+		methodName := extractFunctionName(funcDef, source)
+		method := restxMethodToHTTP(methodName)
+		if method == "" {
+			continue
+		}
+
+		description := extractDocstring(funcDef, source)
+		params := extractFunctionParameters(funcDef, source, "")
+		returnType := extractReturnType(funcDef, source)
+		requestPattern := detectRequestPattern(funcDef, source)
+		requestBodyType := detectRequestBodyType(funcDef, source, params)
+
+		var expectModel, marshalModel string
+		if decorator != nil {
+			expectModel, marshalModel = extractRESTXDecoratorInfo(decorator, source)
+		}
+
+		raw := rawEndpointInfo{
+			method:          method,
+			path:            "/" + toSnakeCase(className),
+			funcName:        methodName,
+			description:     description,
+			params:          params,
+			requestBodyType: requestBodyType,
+			responseType:    returnType,
+			expectModel:     expectModel,
+			marshalModel:    marshalModel,
+			requestPattern:  requestPattern,
+		}
+		endpoints = append(endpoints, raw)
+	}
+
+	return endpoints
+}
+
+func restxMethodToHTTP(methodName string) string {
+	switch strings.ToLower(methodName) {
+	case "get":
+		return "GET"
+	case "post":
+		return "POST"
+	case "put":
+		return "PUT"
+	case "delete":
+		return "DELETE"
+	case "patch":
+		return "PATCH"
+	default:
+		return ""
+	}
+}
+
+func toSnakeCase(s string) string {
+	var result []byte
+	for i, c := range s {
+		if c >= 'A' && c <= 'Z' {
+			if i > 0 {
+				result = append(result, '_')
+			}
+			result = append(result, byte(c+'a'-'A'))
+		} else {
+			result = append(result, byte(c))
+		}
+	}
+	return string(result)
+}
+
+func buildEndpoint(raw rawEndpointInfo, typeResolver *FlaskTypeResolver) *collector.ApiEndpoint {
+	ep := &collector.ApiEndpoint{
+		Name:        raw.funcName,
+		Path:        raw.path,
+		Method:      raw.method,
+		Protocol:    "http",
+		Description: raw.description,
+	}
+
+	pathParams := extractPathParams(raw.path)
+	pathParamNames := make(map[string]bool)
+	for _, p := range pathParams {
+		pathParamNames[p.name] = true
+	}
+
+	paramSet := make(map[string]bool)
+	var allParams []collector.ApiParameter
+	var bodyParams []funcParam
+
+	for _, p := range pathParams {
+		allParams = append(allParams, collector.ApiParameter{
+			Name:     p.name,
+			In:       "path",
+			Required: true,
+			Type:     "text",
+		})
+		paramSet[p.name+"|path"] = true
+	}
+
+	for _, p := range raw.params {
+		if pathParamNames[p.name] && p.in == "query" {
+			p.in = "path"
+			p.required = true
+		}
+
+		if p.in == "body" && p.typeAnnotation != "" {
+			bodyParams = append(bodyParams, p)
+			continue
+		}
+
+		key := p.name + "|" + p.in
+		if !paramSet[key] {
+			allParams = append(allParams, collector.ApiParameter{
+				Name:     p.name,
+				In:       p.in,
+				Required: p.required,
+				Type:     p.typ,
+			})
+			paramSet[key] = true
+		}
+	}
+
+	if len(allParams) > 0 {
+		ep.Parameters = allParams
+	}
+
+	requestBodyType := raw.expectModel
+	if requestBodyType == "" {
+		requestBodyType = raw.requestBodyType
+	}
+	if requestBodyType == "" && len(bodyParams) == 1 && bodyParams[0].typeAnnotation != "" {
+		requestBodyType = bodyParams[0].typeAnnotation
+	}
+
+	if requestBodyType != "" {
+		resolvedBody := typeResolver.Resolve(requestBodyType)
+		if resolvedBody != nil && !resolvedBody.IsNull() {
+			mediaType := "application/json"
+			if raw.requestPattern == "form" {
+				mediaType = "application/x-www-form-urlencoded"
+			}
+			ep.RequestBody = &collector.ApiBody{
+				MediaType: mediaType,
+				Body:      resolvedBody,
+			}
+		}
+	} else if len(bodyParams) > 1 {
+		fields := make(map[string]*model.FieldModel)
+		for _, bp := range bodyParams {
+			var fieldModel *model.ObjectModel
+			if bp.typeAnnotation != "" {
+				fieldModel = typeResolver.Resolve(bp.typeAnnotation)
+			} else {
+				fieldModel = model.SingleModel(model.JsonTypeString)
+			}
+			fields[bp.name] = &model.FieldModel{
+				Model:    fieldModel,
+				Required: bp.required,
+			}
+		}
+		ep.RequestBody = &collector.ApiBody{
+			MediaType: "application/json",
+			Body: &model.ObjectModel{
+				Kind:     model.KindObject,
+				TypeName: "object",
+				Fields:   fields,
+			},
+		}
+	}
+
+	responseType := raw.marshalModel
+	if responseType == "" {
+		responseType = raw.responseType
+	}
+
+	if responseType != "" {
+		resolvedResponse := typeResolver.Resolve(responseType)
+		if resolvedResponse != nil && !resolvedResponse.IsNull() {
+			ep.Response = &collector.ApiBody{
+				MediaType: "application/json",
+				Body:      resolvedResponse,
+			}
+		}
+	}
+
+	return ep
 }
 
 type routeInfo struct {
@@ -206,7 +481,7 @@ type routeInfo struct {
 	methods []string
 }
 
-func extractDecoratorInfo(decorator *tree_sitter.Node, source []byte) routeInfo {
+func extractDecoratorRouteInfo(decorator *tree_sitter.Node, source []byte) routeInfo {
 	for i := uint(0); i < decorator.ChildCount(); i++ {
 		child := decorator.Child(i)
 		if child.Kind() == "@" {
@@ -252,7 +527,13 @@ func resolveCallExpression(callNode *tree_sitter.Node, source []byte) routeInfo 
 			}
 		}
 		if child.Kind() == "argument_list" {
-			path, methods = extractArguments(child, source)
+			p, m := extractArguments(child, source)
+			if p != "" {
+				path = p
+			}
+			if len(m) > 0 {
+				methods = m
+			}
 		}
 	}
 
@@ -345,6 +626,82 @@ func extractMethodList(listNode *tree_sitter.Node, source []byte) []string {
 	return methods
 }
 
+func extractRESTXDecoratorInfo(decorator *tree_sitter.Node, source []byte) (expectModel string, marshalModel string) {
+	for i := uint(0); i < decorator.ChildCount(); i++ {
+		child := decorator.Child(i)
+		if child.Kind() == "@" {
+			continue
+		}
+		if child.Kind() == "call" {
+			e, m := extractRESTXCallInfo(child, source)
+			if e != "" {
+				expectModel = e
+			}
+			if m != "" {
+				marshalModel = m
+			}
+		}
+		for j := uint(0); j < child.ChildCount(); j++ {
+			subChild := child.Child(j)
+			if subChild.Kind() == "call" {
+				e, m := extractRESTXCallInfo(subChild, source)
+				if e != "" {
+					expectModel = e
+				}
+				if m != "" {
+					marshalModel = m
+				}
+			}
+		}
+	}
+	return expectModel, marshalModel
+}
+
+func extractRESTXCallInfo(callNode *tree_sitter.Node, source []byte) (expectModel string, marshalModel string) {
+	var funcName string
+
+	for i := uint(0); i < callNode.ChildCount(); i++ {
+		child := callNode.Child(i)
+		if child.Kind() == "identifier" {
+			funcName = child.Utf8Text(source)
+		}
+		if child.Kind() == "attribute" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				attrChild := child.Child(j)
+				if attrChild.Kind() == "identifier" {
+					funcName = attrChild.Utf8Text(source)
+				}
+			}
+		}
+		if child.Kind() == "argument_list" {
+			switch funcName {
+			case "expect":
+				expectModel = extractFirstIdentifierArg(child, source)
+			case "marshal_with":
+				marshalModel = extractFirstIdentifierArg(child, source)
+			}
+		}
+	}
+
+	return expectModel, marshalModel
+}
+
+func extractFirstIdentifierArg(argList *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < argList.ChildCount(); i++ {
+		child := argList.Child(i)
+		if child.Kind() == "(" || child.Kind() == ")" || child.Kind() == "," {
+			continue
+		}
+		if child.Kind() == "identifier" {
+			return child.Utf8Text(source)
+		}
+		if child.Kind() == "attribute" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
 func extractFunctionName(funcDef *tree_sitter.Node, source []byte) string {
 	for i := uint(0); i < funcDef.ChildCount(); i++ {
 		child := funcDef.Child(i)
@@ -382,10 +739,11 @@ func extractDocstringFromBlock(blockNode *tree_sitter.Node, source []byte) strin
 }
 
 type funcParam struct {
-	name     string
-	in       string
-	required bool
-	typ      string
+	name           string
+	in             string
+	required       bool
+	typ            string
+	typeAnnotation string
 }
 
 func extractFunctionParameters(funcDef *tree_sitter.Node, source []byte, path string) []funcParam {
@@ -413,6 +771,9 @@ func extractParameters(paramsNode *tree_sitter.Node, source []byte, path string)
 
 		if child.Kind() == "identifier" {
 			name := child.Utf8Text(source)
+			if isSpecialFlaskParam(name) {
+				continue
+			}
 			in := "query"
 			if isNameInPath(name, path) {
 				in = "path"
@@ -425,7 +786,7 @@ func extractParameters(paramsNode *tree_sitter.Node, source []byte, path string)
 			})
 		} else if child.Kind() == "typed_parameter" || child.Kind() == "default_parameter" || child.Kind() == "typed_default_parameter" {
 			param := extractSingleParameter(child, source, path)
-			if param.name != "" {
+			if param.name != "" && !isSpecialFlaskParam(param.name) {
 				params = append(params, param)
 			}
 		}
@@ -449,6 +810,13 @@ func extractSingleParameter(paramNode *tree_sitter.Node, source []byte, path str
 			if p.name == "" {
 				p.name = child.Utf8Text(source)
 			}
+		case "type":
+			typeText := child.Utf8Text(source)
+			p.typeAnnotation = typeText
+			p.typ = simplifyType(typeText)
+			if isComplexType(typeText) {
+				p.in = "body"
+			}
 		case "=":
 			p.required = false
 		}
@@ -460,6 +828,162 @@ func extractSingleParameter(paramNode *tree_sitter.Node, source []byte, path str
 	}
 
 	return p
+}
+
+func isSpecialFlaskParam(name string) bool {
+	switch name {
+	case "self", "cls", "request", "response", "db", "session":
+		return true
+	}
+	return false
+}
+
+func isComplexType(typeText string) bool {
+	if fastapi.IsPydanticModelType(typeText) {
+		return true
+	}
+	if strings.HasSuffix(typeText, "Schema") {
+		return true
+	}
+	base, args := fastapi.ParsePythonGenericType(typeText)
+	if len(args) > 0 {
+		for _, arg := range args {
+			if fastapi.IsPydanticModelType(arg) || strings.HasSuffix(arg, "Schema") {
+				return true
+			}
+		}
+	}
+	if base == "list" || base == "List" || base == "dict" || base == "Dict" {
+		return true
+	}
+	return false
+}
+
+func simplifyType(typeText string) string {
+	switch strings.ToLower(typeText) {
+	case "str", "string":
+		return "text"
+	case "int", "integer":
+		return "int"
+	case "float":
+		return "float"
+	case "bool", "boolean":
+		return "boolean"
+	default:
+		return typeText
+	}
+}
+
+func extractReturnType(funcDef *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < funcDef.ChildCount(); i++ {
+		child := funcDef.Child(i)
+		if child.Kind() == "type" {
+			return child.Utf8Text(source)
+		}
+	}
+	return ""
+}
+
+func detectRequestPattern(funcDef *tree_sitter.Node, source []byte) string {
+	block := findBlock(funcDef)
+	if block == nil {
+		return ""
+	}
+
+	pattern := scanBlockForRequestPattern(block, source)
+	return pattern
+}
+
+func findBlock(funcDef *tree_sitter.Node) *tree_sitter.Node {
+	for i := uint(0); i < funcDef.ChildCount(); i++ {
+		child := funcDef.Child(i)
+		if child.Kind() == "block" {
+			return child
+		}
+	}
+	return nil
+}
+
+func scanBlockForRequestPattern(block *tree_sitter.Node, source []byte) string {
+	var found string
+
+	for i := uint(0); i < block.ChildCount(); i++ {
+		child := block.Child(i)
+		text := child.Utf8Text(source)
+
+		if strings.Contains(text, "request.json") || strings.Contains(text, "request.get_json()") {
+			if found == "" || found == "json" {
+				found = "json"
+			}
+		}
+		if strings.Contains(text, "request.form") {
+			if found == "" || found == "form" {
+				found = "form"
+			}
+		}
+		if strings.Contains(text, "request.args") {
+			if found == "" {
+				found = "query"
+			}
+		}
+		if strings.Contains(text, "request.files") {
+			if found == "" || found == "files" {
+				found = "files"
+			}
+		}
+	}
+
+	return found
+}
+
+func detectRequestBodyType(funcDef *tree_sitter.Node, source []byte, params []funcParam) string {
+	for _, p := range params {
+		if p.in == "body" && p.typeAnnotation != "" {
+			return p.typeAnnotation
+		}
+	}
+
+	block := findBlock(funcDef)
+	if block == nil {
+		return ""
+	}
+
+	return inferRequestBodyFromPattern(block, source)
+}
+
+func inferRequestBodyFromPattern(block *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < block.ChildCount(); i++ {
+		child := block.Child(i)
+		text := child.Utf8Text(source)
+
+		if strings.Contains(text, "request.json") || strings.Contains(text, "request.get_json()") {
+			return inferTypeFromAssignment(child, source)
+		}
+	}
+	return ""
+}
+
+func inferTypeFromAssignment(stmt *tree_sitter.Node, source []byte) string {
+	for i := uint(0); i < stmt.ChildCount(); i++ {
+		child := stmt.Child(i)
+		if child.Kind() == "assignment" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				assignChild := child.Child(j)
+				if assignChild.Kind() == "type" {
+					return assignChild.Utf8Text(source)
+				}
+			}
+		}
+		if child.Kind() == "annotated_assignment" {
+			for j := uint(0); j < child.ChildCount(); j++ {
+				assignChild := child.Child(j)
+				if assignChild.Kind() == "type" {
+					return assignChild.Utf8Text(source)
+				}
+			}
+		}
+	}
+	return ""
 }
 
 type pathParamInfo struct {

--- a/api-collector-python/flask/parser_test.go
+++ b/api-collector-python/flask/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	collector "github.com/tangcent/apilot/api-collector"
+	model "github.com/tangcent/apilot/api-model"
 )
 
 func TestParse_BasicRoutes(t *testing.T) {
@@ -104,6 +105,202 @@ func TestParse_BasicRoutes(t *testing.T) {
 		Parameters: []collector.ApiParameter{
 			{Name: "id", In: "path", Required: true, Type: "text"},
 		},
+	})
+}
+
+func TestParse_TypedRoutes(t *testing.T) {
+	endpoints, err := Parse(filepath.Join("testdata", "typed"))
+	if err != nil {
+		t.Fatalf("typed routes should not error: %v", err)
+	}
+
+	endpointMap := make(map[string]*collector.ApiEndpoint)
+	for i := range endpoints {
+		key := endpoints[i].Method + " " + endpoints[i].Path
+		endpointMap[key] = &endpoints[i]
+	}
+
+	t.Run("POST /users - Pydantic request/response", func(t *testing.T) {
+		ep, ok := endpointMap["POST /users"]
+		if !ok {
+			t.Fatal("expected POST /users endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body")
+		}
+		if ep.RequestBody.MediaType != "application/json" {
+			t.Errorf("RequestBody.MediaType = %q, want %q", ep.RequestBody.MediaType, "application/json")
+		}
+		if ep.RequestBody.Body == nil || ep.RequestBody.Body.TypeName != "UserCreate" {
+			t.Errorf("RequestBody.Body.TypeName = %q, want %q", ep.RequestBody.Body.TypeName, "UserCreate")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil || ep.Response.Body.TypeName != "UserResponse" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "UserResponse")
+		}
+	})
+
+	t.Run("GET /users/{id} - typed path param + response", func(t *testing.T) {
+		ep, ok := endpointMap["GET /users/{id}"]
+		if !ok {
+			t.Fatal("expected GET /users/{id} endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil || ep.Response.Body.TypeName != "UserResponse" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "UserResponse")
+		}
+		hasPathParam := false
+		for _, p := range ep.Parameters {
+			if p.Name == "id" && p.In == "path" {
+				hasPathParam = true
+				break
+			}
+		}
+		if !hasPathParam {
+			t.Error("expected 'id' path parameter")
+		}
+	})
+
+	t.Run("PUT /users/{id} - typed path param + body + response", func(t *testing.T) {
+		ep, ok := endpointMap["PUT /users/{id}"]
+		if !ok {
+			t.Fatal("expected PUT /users/{id} endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body")
+		}
+		if ep.RequestBody.Body == nil || ep.RequestBody.Body.TypeName != "UserCreate" {
+			t.Errorf("RequestBody.Body.TypeName = %q, want %q", ep.RequestBody.Body.TypeName, "UserCreate")
+		}
+		if ep.Response == nil || ep.Response.Body.TypeName != "UserResponse" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "UserResponse")
+		}
+	})
+
+	t.Run("POST /marshmallow/users - Marshmallow request/response", func(t *testing.T) {
+		ep, ok := endpointMap["POST /marshmallow/users"]
+		if !ok {
+			t.Fatal("expected POST /marshmallow/users endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body")
+		}
+		if ep.RequestBody.Body == nil || ep.RequestBody.Body.TypeName != "UserSchema" {
+			t.Errorf("RequestBody.Body.TypeName = %q, want %q", ep.RequestBody.Body.TypeName, "UserSchema")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil || ep.Response.Body.TypeName != "UserSchema" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "UserSchema")
+		}
+	})
+
+	t.Run("GET /marshmallow/items - Marshmallow response only", func(t *testing.T) {
+		ep, ok := endpointMap["GET /marshmallow/items"]
+		if !ok {
+			t.Fatal("expected GET /marshmallow/items endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body == nil || ep.Response.Body.TypeName != "ItemSchema" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "ItemSchema")
+		}
+	})
+
+	t.Run("GET /users/{id}/items - list response type", func(t *testing.T) {
+		ep, ok := endpointMap["GET /users/{id}/items"]
+		if !ok {
+			t.Fatal("expected GET /users/{id}/items endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body.Kind != model.KindArray {
+			t.Errorf("Response.Body.Kind = %q, want %q", ep.Response.Body.Kind, model.KindArray)
+		}
+		if ep.Response.Body.Items == nil || ep.Response.Body.Items.TypeName != "ItemResponse" {
+			t.Errorf("Response.Body.Items.TypeName = %q, want %q", ep.Response.Body.Items.TypeName, "ItemResponse")
+		}
+	})
+
+	t.Run("POST /users/batch - list request/response type", func(t *testing.T) {
+		ep, ok := endpointMap["POST /users/batch"]
+		if !ok {
+			t.Fatal("expected POST /users/batch endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body")
+		}
+		if ep.RequestBody.Body.Kind != model.KindArray {
+			t.Errorf("RequestBody.Body.Kind = %q, want %q", ep.RequestBody.Body.Kind, model.KindArray)
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body.Kind != model.KindArray {
+			t.Errorf("Response.Body.Kind = %q, want %q", ep.Response.Body.Kind, model.KindArray)
+		}
+	})
+
+	t.Run("GET /health - dict response type", func(t *testing.T) {
+		ep, ok := endpointMap["GET /health"]
+		if !ok {
+			t.Fatal("expected GET /health endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body.Kind != model.KindMap {
+			t.Errorf("Response.Body.Kind = %q, want %q", ep.Response.Body.Kind, model.KindMap)
+		}
+	})
+
+	t.Run("POST /no-type - no type annotations", func(t *testing.T) {
+		ep, ok := endpointMap["POST /no-type"]
+		if !ok {
+			t.Fatal("expected POST /no-type endpoint")
+		}
+		if ep.RequestBody != nil {
+			t.Error("expected no request body for untyped endpoint")
+		}
+		if ep.Response != nil {
+			t.Error("expected no response body for untyped endpoint")
+		}
+	})
+
+	t.Run("GET /optional-response - union response type", func(t *testing.T) {
+		ep, ok := endpointMap["GET /optional-response"]
+		if !ok {
+			t.Fatal("expected GET /optional-response endpoint")
+		}
+		if ep.Response == nil {
+			t.Fatal("expected response body")
+		}
+		if ep.Response.Body.TypeName != "UserResponse" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "UserResponse")
+		}
+	})
+
+	t.Run("Blueprint endpoints with types", func(t *testing.T) {
+		ep, ok := endpointMap["POST /products"]
+		if !ok {
+			t.Fatal("expected POST /products endpoint")
+		}
+		if ep.RequestBody == nil {
+			t.Fatal("expected request body")
+		}
+		if ep.RequestBody.Body == nil || ep.RequestBody.Body.TypeName != "ItemCreate" {
+			t.Errorf("RequestBody.Body.TypeName = %q, want %q", ep.RequestBody.Body.TypeName, "ItemCreate")
+		}
+		if ep.Response == nil || ep.Response.Body.TypeName != "ItemResponse" {
+			t.Errorf("Response.Body.TypeName = %q, want %q", ep.Response.Body.TypeName, "ItemResponse")
+		}
 	})
 }
 

--- a/api-collector-python/flask/resolver.go
+++ b/api-collector-python/flask/resolver.go
@@ -1,0 +1,133 @@
+package flask
+
+import (
+	"strings"
+
+	model "github.com/tangcent/apilot/api-model"
+
+	"github.com/tangcent/apilot/api-collector-python/fastapi"
+)
+
+type FlaskTypeResolver struct {
+	pythonResolver      *fastapi.PythonTypeResolver
+	marshmallowRegistry map[string]MarshmallowModel
+	resolving           map[string]bool
+}
+
+func NewFlaskTypeResolver(pydanticModels map[string]fastapi.PydanticModel, marshmallowSchemas map[string]MarshmallowModel) *FlaskTypeResolver {
+	return &FlaskTypeResolver{
+		pythonResolver:      fastapi.NewPythonTypeResolver(pydanticModels),
+		marshmallowRegistry: marshmallowSchemas,
+		resolving:           make(map[string]bool),
+	}
+}
+
+func (r *FlaskTypeResolver) Resolve(typeText string) *model.ObjectModel {
+	if typeText == "" {
+		return model.NullModel()
+	}
+
+	typeText = strings.TrimSpace(typeText)
+
+	if md, found := r.marshmallowRegistry[typeText]; found {
+		return r.resolveMarshmallowSchema(typeText, md)
+	}
+
+	if strings.Contains(typeText, " | ") {
+		return r.resolveUnionSyntax(typeText)
+	}
+
+	return r.pythonResolver.Resolve(typeText)
+}
+
+func (r *FlaskTypeResolver) resolveUnionSyntax(typeText string) *model.ObjectModel {
+	parts := strings.Split(typeText, " | ")
+	nonNoneParts := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" && p != "None" && p != "NoneType" {
+			nonNoneParts = append(nonNoneParts, p)
+		}
+	}
+	if len(nonNoneParts) == 1 {
+		return r.Resolve(nonNoneParts[0])
+	}
+	if len(nonNoneParts) > 1 {
+		return model.SingleModel(strings.Join(nonNoneParts, " | "))
+	}
+	return model.NullModel()
+}
+
+func (r *FlaskTypeResolver) resolveMarshmallowSchema(name string, md MarshmallowModel) *model.ObjectModel {
+	if r.resolving[name] {
+		return model.RefModel(name)
+	}
+
+	r.resolving[name] = true
+	defer func() { delete(r.resolving, name) }()
+
+	fields := make(map[string]*model.FieldModel, len(md.Fields))
+	for _, f := range md.Fields {
+		fieldModel := r.resolveMarshmallowField(f)
+		fields[f.Name] = fieldModel
+	}
+
+	for _, embedded := range md.EmbeddedTypes {
+		embeddedModel := r.Resolve(embedded)
+		if embeddedModel != nil && embeddedModel.IsObject() {
+			for k, v := range embeddedModel.Fields {
+				if _, exists := fields[k]; !exists {
+					fields[k] = v
+				}
+			}
+		}
+	}
+
+	return &model.ObjectModel{
+		Kind:     model.KindObject,
+		TypeName: name,
+		Fields:   fields,
+	}
+}
+
+func (r *FlaskTypeResolver) resolveMarshmallowField(f MarshmallowField) *model.FieldModel {
+	var fieldModel *model.ObjectModel
+
+	if f.Nested != "" {
+		nestedModel := r.Resolve(f.Nested)
+		if f.Many {
+			fieldModel = model.ArrayModel(nestedModel)
+		} else {
+			fieldModel = nestedModel
+		}
+	} else if f.Many {
+		itemModel := r.resolveMarshmallowFieldType(f.FieldType)
+		fieldModel = model.ArrayModel(itemModel)
+	} else {
+		fieldModel = r.resolveMarshmallowFieldType(f.FieldType)
+	}
+
+	return &model.FieldModel{
+		Model:    fieldModel,
+		Required: f.Required,
+	}
+}
+
+func (r *FlaskTypeResolver) resolveMarshmallowFieldType(fieldType string) *model.ObjectModel {
+	if jsonType, ok := marshmallowFieldTypeMap[fieldType]; ok {
+		if jsonType == "array" {
+			return model.ArrayModel(model.NullModel())
+		}
+		if jsonType == "map" {
+			return model.MapModel(model.SingleModel(model.JsonTypeString), model.NullModel())
+		}
+		return model.SingleModel(jsonType)
+	}
+
+	nestedModel := r.Resolve(fieldType)
+	if nestedModel != nil && (nestedModel.IsObject() || nestedModel.IsRef()) {
+		return nestedModel
+	}
+
+	return model.SingleModel(fieldType)
+}

--- a/api-collector-python/flask/resolver_test.go
+++ b/api-collector-python/flask/resolver_test.go
@@ -1,0 +1,345 @@
+package flask
+
+import (
+	"testing"
+
+	model "github.com/tangcent/apilot/api-model"
+
+	"github.com/tangcent/apilot/api-collector-python/fastapi"
+)
+
+func TestFlaskTypeResolver_PydanticModel(t *testing.T) {
+	pydanticModels := map[string]fastapi.PydanticModel{
+		"UserCreate": {
+			Name: "UserCreate",
+			Fields: []fastapi.PydanticField{
+				{Name: "name", Type: "str", Required: true},
+				{Name: "email", Type: "str", Required: true},
+				{Name: "age", Type: "int", Required: true},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(pydanticModels, nil)
+
+	result := resolver.Resolve("UserCreate")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserCreate).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+	if result.TypeName != "UserCreate" {
+		t.Errorf("Resolve(UserCreate).TypeName = %q, want %q", result.TypeName, "UserCreate")
+	}
+	if len(result.Fields) != 3 {
+		t.Fatalf("Resolve(UserCreate).Fields count = %d, want 3", len(result.Fields))
+	}
+
+	nameField, ok := result.Fields["name"]
+	if !ok {
+		t.Fatal("expected 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("UserCreate.name type = %q, want %q", nameField.Model.TypeName, model.JsonTypeString)
+	}
+
+	ageField, ok := result.Fields["age"]
+	if !ok {
+		t.Fatal("expected 'age' field")
+	}
+	if ageField.Model.TypeName != model.JsonTypeInt {
+		t.Errorf("UserCreate.age type = %q, want %q", ageField.Model.TypeName, model.JsonTypeInt)
+	}
+}
+
+func TestFlaskTypeResolver_MarshmallowSchema(t *testing.T) {
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"UserSchema": {
+			Name: "UserSchema",
+			Fields: []MarshmallowField{
+				{Name: "id", FieldType: "Int", Required: false},
+				{Name: "name", FieldType: "Str", Required: true},
+				{Name: "email", FieldType: "Email", Required: true},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(nil, marshmallowSchemas)
+
+	result := resolver.Resolve("UserSchema")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserSchema).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+	if result.TypeName != "UserSchema" {
+		t.Errorf("Resolve(UserSchema).TypeName = %q, want %q", result.TypeName, "UserSchema")
+	}
+	if len(result.Fields) != 3 {
+		t.Fatalf("Resolve(UserSchema).Fields count = %d, want 3", len(result.Fields))
+	}
+
+	nameField, ok := result.Fields["name"]
+	if !ok {
+		t.Fatal("expected 'name' field")
+	}
+	if nameField.Model.TypeName != model.JsonTypeString {
+		t.Errorf("UserSchema.name type = %q, want %q", nameField.Model.TypeName, model.JsonTypeString)
+	}
+	if !nameField.Required {
+		t.Error("UserSchema.name should be required")
+	}
+
+	idField, ok := result.Fields["id"]
+	if !ok {
+		t.Fatal("expected 'id' field")
+	}
+	if idField.Model.TypeName != model.JsonTypeInt {
+		t.Errorf("UserSchema.id type = %q, want %q", idField.Model.TypeName, model.JsonTypeInt)
+	}
+	if idField.Required {
+		t.Error("UserSchema.id should not be required")
+	}
+}
+
+func TestFlaskTypeResolver_MarshmallowNested(t *testing.T) {
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"AddressSchema": {
+			Name: "AddressSchema",
+			Fields: []MarshmallowField{
+				{Name: "street", FieldType: "Str", Required: true},
+				{Name: "city", FieldType: "Str", Required: true},
+			},
+		},
+		"UserSchema": {
+			Name: "UserSchema",
+			Fields: []MarshmallowField{
+				{Name: "name", FieldType: "Str", Required: true},
+				{Name: "address", FieldType: "Nested", Required: true, Nested: "AddressSchema"},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(nil, marshmallowSchemas)
+
+	result := resolver.Resolve("UserSchema")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserSchema).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	addrField, ok := result.Fields["address"]
+	if !ok {
+		t.Fatal("expected 'address' field")
+	}
+	if addrField.Model.Kind != model.KindObject {
+		t.Errorf("UserSchema.address kind = %q, want %q", addrField.Model.Kind, model.KindObject)
+	}
+	if addrField.Model.TypeName != "AddressSchema" {
+		t.Errorf("UserSchema.address typeName = %q, want %q", addrField.Model.TypeName, "AddressSchema")
+	}
+}
+
+func TestFlaskTypeResolver_MarshmallowListField(t *testing.T) {
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"ItemSchema": {
+			Name: "ItemSchema",
+			Fields: []MarshmallowField{
+				{Name: "id", FieldType: "Int", Required: false},
+				{Name: "title", FieldType: "Str", Required: true},
+				{Name: "tags", FieldType: "List", Required: false, Many: true},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(nil, marshmallowSchemas)
+
+	result := resolver.Resolve("ItemSchema")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(ItemSchema).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	tagsField, ok := result.Fields["tags"]
+	if !ok {
+		t.Fatal("expected 'tags' field")
+	}
+	if tagsField.Model.Kind != model.KindArray {
+		t.Errorf("ItemSchema.tags kind = %q, want %q", tagsField.Model.Kind, model.KindArray)
+	}
+}
+
+func TestFlaskTypeResolver_MarshmallowNestedMany(t *testing.T) {
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"TagSchema": {
+			Name: "TagSchema",
+			Fields: []MarshmallowField{
+				{Name: "name", FieldType: "Str", Required: true},
+			},
+		},
+		"ItemSchema": {
+			Name: "ItemSchema",
+			Fields: []MarshmallowField{
+				{Name: "title", FieldType: "Str", Required: true},
+				{Name: "tags", FieldType: "Nested", Required: false, Many: true, Nested: "TagSchema"},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(nil, marshmallowSchemas)
+
+	result := resolver.Resolve("ItemSchema")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(ItemSchema).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	tagsField, ok := result.Fields["tags"]
+	if !ok {
+		t.Fatal("expected 'tags' field")
+	}
+	if tagsField.Model.Kind != model.KindArray {
+		t.Errorf("ItemSchema.tags kind = %q, want %q", tagsField.Model.Kind, model.KindArray)
+	}
+	if tagsField.Model.Items == nil || tagsField.Model.Items.TypeName != "TagSchema" {
+		t.Errorf("ItemSchema.tags items typeName = %q, want %q", tagsField.Model.Items.TypeName, "TagSchema")
+	}
+}
+
+func TestFlaskTypeResolver_MixedPydanticAndMarshmallow(t *testing.T) {
+	pydanticModels := map[string]fastapi.PydanticModel{
+		"UserCreate": {
+			Name: "UserCreate",
+			Fields: []fastapi.PydanticField{
+				{Name: "name", Type: "str", Required: true},
+				{Name: "email", Type: "str", Required: true},
+			},
+		},
+	}
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"UserSchema": {
+			Name: "UserSchema",
+			Fields: []MarshmallowField{
+				{Name: "id", FieldType: "Int", Required: false},
+				{Name: "name", FieldType: "Str", Required: true},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(pydanticModels, marshmallowSchemas)
+
+	pydanticResult := resolver.Resolve("UserCreate")
+	if pydanticResult.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserCreate).Kind = %q, want %q", pydanticResult.Kind, model.KindObject)
+	}
+	if pydanticResult.TypeName != "UserCreate" {
+		t.Errorf("Resolve(UserCreate).TypeName = %q, want %q", pydanticResult.TypeName, "UserCreate")
+	}
+
+	marshmallowResult := resolver.Resolve("UserSchema")
+	if marshmallowResult.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserSchema).Kind = %q, want %q", marshmallowResult.Kind, model.KindObject)
+	}
+	if marshmallowResult.TypeName != "UserSchema" {
+		t.Errorf("Resolve(UserSchema).TypeName = %q, want %q", marshmallowResult.TypeName, "UserSchema")
+	}
+}
+
+func TestFlaskTypeResolver_Primitives(t *testing.T) {
+	resolver := NewFlaskTypeResolver(nil, nil)
+
+	tests := []struct {
+		input    string
+		kind     model.ObjectModelKind
+		typeName string
+	}{
+		{"str", model.KindSingle, model.JsonTypeString},
+		{"int", model.KindSingle, model.JsonTypeInt},
+		{"float", model.KindSingle, model.JsonTypeFloat},
+		{"bool", model.KindSingle, model.JsonTypeBoolean},
+	}
+
+	for _, tt := range tests {
+		result := resolver.Resolve(tt.input)
+		if result.Kind != tt.kind {
+			t.Errorf("Resolve(%q).Kind = %q, want %q", tt.input, result.Kind, tt.kind)
+		}
+		if result.TypeName != tt.typeName {
+			t.Errorf("Resolve(%q).TypeName = %q, want %q", tt.input, result.TypeName, tt.typeName)
+		}
+	}
+}
+
+func TestFlaskTypeResolver_ListOfPydanticModel(t *testing.T) {
+	pydanticModels := map[string]fastapi.PydanticModel{
+		"Item": {
+			Name: "Item",
+			Fields: []fastapi.PydanticField{
+				{Name: "id", Type: "int", Required: true},
+				{Name: "name", Type: "str", Required: true},
+			},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(pydanticModels, nil)
+
+	result := resolver.Resolve("list[Item]")
+	if result.Kind != model.KindArray {
+		t.Fatalf("Resolve(list[Item]).Kind = %q, want %q", result.Kind, model.KindArray)
+	}
+	if result.Items == nil {
+		t.Fatal("expected Items to be non-nil")
+	}
+	if result.Items.Kind != model.KindObject {
+		t.Errorf("list[Item].Items.Kind = %q, want %q", result.Items.Kind, model.KindObject)
+	}
+	if result.Items.TypeName != "Item" {
+		t.Errorf("list[Item].Items.TypeName = %q, want %q", result.Items.TypeName, "Item")
+	}
+}
+
+func TestFlaskTypeResolver_EmptyType(t *testing.T) {
+	resolver := NewFlaskTypeResolver(nil, nil)
+
+	result := resolver.Resolve("")
+	if !result.IsNull() {
+		t.Errorf("Resolve('') should be null, got kind=%q typeName=%q", result.Kind, result.TypeName)
+	}
+}
+
+func TestFlaskTypeResolver_MarshmallowInheritance(t *testing.T) {
+	marshmallowSchemas := map[string]MarshmallowModel{
+		"BaseSchema": {
+			Name: "BaseSchema",
+			Fields: []MarshmallowField{
+				{Name: "id", FieldType: "Int", Required: true},
+				{Name: "created_at", FieldType: "DateTime", Required: true},
+			},
+		},
+		"UserSchema": {
+			Name: "UserSchema",
+			Fields: []MarshmallowField{
+				{Name: "name", FieldType: "Str", Required: true},
+				{Name: "email", FieldType: "Email", Required: true},
+			},
+			EmbeddedTypes: []string{"BaseSchema"},
+		},
+	}
+
+	resolver := NewFlaskTypeResolver(nil, marshmallowSchemas)
+
+	result := resolver.Resolve("UserSchema")
+	if result.Kind != model.KindObject {
+		t.Fatalf("Resolve(UserSchema).Kind = %q, want %q", result.Kind, model.KindObject)
+	}
+
+	if len(result.Fields) != 4 {
+		t.Fatalf("Resolve(UserSchema).Fields count = %d, want 4 (2 own + 2 inherited)", len(result.Fields))
+	}
+
+	if _, ok := result.Fields["id"]; !ok {
+		t.Error("expected inherited 'id' field")
+	}
+	if _, ok := result.Fields["created_at"]; !ok {
+		t.Error("expected inherited 'created_at' field")
+	}
+	if _, ok := result.Fields["name"]; !ok {
+		t.Error("expected own 'name' field")
+	}
+	if _, ok := result.Fields["email"]; !ok {
+		t.Error("expected own 'email' field")
+	}
+}

--- a/api-collector-python/flask/testdata/typed/app.py
+++ b/api-collector-python/flask/testdata/typed/app.py
@@ -1,0 +1,140 @@
+from flask import Flask, Blueprint, request
+from pydantic import BaseModel
+from marshmallow import Schema, fields
+
+app = Flask(__name__)
+
+
+class UserCreate(BaseModel):
+    name: str
+    email: str
+    age: int
+
+
+class UserResponse(BaseModel):
+    id: int
+    name: str
+    email: str
+
+
+class ItemCreate(BaseModel):
+    title: str
+    price: float
+    description: str = ""
+
+
+class ItemResponse(BaseModel):
+    id: int
+    title: str
+    price: float
+
+
+class UserSchema(Schema):
+    id = fields.Int()
+    name = fields.Str(required=True)
+    email = fields.Email(required=True)
+
+
+class ItemSchema(Schema):
+    id = fields.Int()
+    title = fields.Str(required=True)
+    price = fields.Float(required=True)
+
+
+class NestedItemSchema(Schema):
+    id = fields.Int()
+    title = fields.Str(required=True)
+    tags = fields.List(fields.Str())
+
+
+@app.route('/users', methods=['POST'])
+def create_user(body: UserCreate) -> UserResponse:
+    """createUser creates a new user."""
+    pass
+
+
+@app.route('/users/<id>', methods=['GET'])
+def get_user(id: int) -> UserResponse:
+    """getUser returns a single user by ID."""
+    pass
+
+
+@app.route('/users/<id>', methods=['PUT'])
+def update_user(id: int, body: UserCreate) -> UserResponse:
+    """updateUser updates an existing user."""
+    pass
+
+
+@app.route('/items', methods=['POST'])
+def create_item(body: ItemCreate) -> ItemResponse:
+    """createItem creates a new item."""
+    pass
+
+
+@app.route('/items/<id>', methods=['GET'])
+def get_item(id: int) -> ItemResponse:
+    """getItem returns a single item by ID."""
+    pass
+
+
+@app.route('/marshmallow/users', methods=['POST'])
+def create_user_marshmallow(body: UserSchema) -> UserSchema:
+    """createUserMarshmallow creates a user using Marshmallow schema."""
+    pass
+
+
+@app.route('/marshmallow/items', methods=['GET'])
+def list_items_marshmallow() -> ItemSchema:
+    """listItemsMarshmallow lists items using Marshmallow schema."""
+    pass
+
+
+@app.route('/marshmallow/nested', methods=['GET'])
+def get_nested_item() -> NestedItemSchema:
+    """getNestedItem returns a nested item using Marshmallow schema."""
+    pass
+
+
+@app.route('/users/<id>/items', methods=['GET'])
+def list_user_items(id: int) -> list[ItemResponse]:
+    """listUserItems returns all items for a user."""
+    pass
+
+
+@app.route('/users/batch', methods=['POST'])
+def batch_create_users(body: list[UserCreate]) -> list[UserResponse]:
+    """batchCreateUsers creates multiple users."""
+    pass
+
+
+@app.route('/health', methods=['GET'])
+def health_check() -> dict:
+    """healthCheck returns service health status."""
+    pass
+
+
+@app.route('/no-type', methods=['POST'])
+def no_type_endpoint():
+    """noTypeEndpoint has no type annotations."""
+    pass
+
+
+@app.route('/optional-response', methods=['GET'])
+def optional_response() -> UserResponse | None:
+    """optionalResponse may return a user or None."""
+    pass
+
+
+bp = Blueprint('api', __name__, url_prefix='/api/v2')
+
+
+@bp.route('/products', methods=['POST'])
+def create_product(body: ItemCreate) -> ItemResponse:
+    """createProduct creates a new product."""
+    pass
+
+
+@bp.route('/products/<id>', methods=['GET'])
+def get_product(id: int) -> ItemResponse:
+    """getProduct returns a product by ID."""
+    pass


### PR DESCRIPTION
Implements #98 - Add detailed request/response type resolution to the Python Flask parser.