### PR TITLE
feat: per-project Postman workspace/collection binding with smart mode detection

### DIFF
--- a/api-formatter-postman/client.go
+++ b/api-formatter-postman/client.go
@@ -112,6 +112,9 @@ func (c PostmanClient) CreateCollection(workspaceID string, col model.Collection
 		if err := json.Unmarshal(respBody, &apiErr); err != nil {
 			apiErr.Message = string(respBody)
 		}
+		if apiErr.Name == "" && apiErr.Message == "" {
+			apiErr.Message = fmt.Sprintf("empty response body (%d bytes): %s", len(respBody), string(respBody))
+		}
 		return nil, &apiErr
 	}
 
@@ -178,4 +181,5 @@ type APIResult struct {
 	CollectionID  string `json:"collectionId,omitempty"`
 	CollectionUID string `json:"collectionUid,omitempty"`
 	CollectionURL string `json:"collectionUrl,omitempty"`
+	Action        string `json:"action,omitempty"`
 }

--- a/api-formatter-postman/formatter.go
+++ b/api-formatter-postman/formatter.go
@@ -13,19 +13,25 @@ import (
 
 const postmanSchema = "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 
-// Params holds postman-specific formatting options.
+const (
+	ExportModeCreateNew      = "CREATE_NEW"
+	ExportModeUpdateExisting = "UPDATE_EXISTING"
+)
+
 type Params struct {
 	CollectionName string `json:"collectionName"`
 	BaseURL        string `json:"baseURL"`
 	Mode           string `json:"mode"`
 	PostmanAPIKey  string `json:"postmanAPIKey"`
 	WorkspaceID    string `json:"workspaceId"`
+	CollectionUID  string `json:"collectionUid"`
+	ProjectName    string `json:"projectName"`
+	ExportMode     string `json:"exportMode"`
+	OutputPath     string `json:"outputPath"`
 }
 
-// PostmanFormatter formats endpoints as a Postman Collection v2.1 JSON document.
 type PostmanFormatter struct{}
 
-// New returns a new PostmanFormatter.
 func New() formatter.Formatter { return &PostmanFormatter{} }
 
 func (f *PostmanFormatter) Name() string { return "postman" }
@@ -37,12 +43,14 @@ func (f *PostmanFormatter) RequiredSettings() []formatter.SettingDef {
 			Description: "Postman API key for pushing collections to the Postman API",
 			Required:    false,
 		},
+		{
+			Key:         "postman.export.mode",
+			Description: "Postman export mode: CREATE_NEW (always create new collection) or UPDATE_EXISTING (update previously exported collection per project)",
+			Required:    false,
+		},
 	}
 }
 
-// Format converts endpoints into a Postman Collection v2.1 JSON document.
-// Endpoints are grouped by their Folder field into Postman folders.
-// An empty endpoints slice returns a valid empty collection.
 func (f *PostmanFormatter) Format(endpoints []apimodel.ApiEndpoint, opts formatter.FormatOptions) ([]byte, error) {
 	var p Params
 	if err := opts.DecodeParams(&p); err != nil {
@@ -56,14 +64,14 @@ func (f *PostmanFormatter) Format(endpoints []apimodel.ApiEndpoint, opts formatt
 	}
 
 	apiKey := resolveAPIKey(p, opts)
+	exportMode := resolveExportMode(p, opts)
 
 	col := buildCollection(endpoints, p)
 
-	if p.Mode == "api" {
-		if apiKey == "" {
-			return nil, fmt.Errorf("postman api key is required for api mode. Set it with: apilot set postman.api.key <value>")
-		}
-		return pushToPostmanAPI(apiKey, p.WorkspaceID, col)
+	mode := resolveMode(p, apiKey)
+
+	if mode == "api" {
+		return pushToPostmanAPI(apiKey, exportMode, p.ProjectName, p.CollectionUID, p.WorkspaceID, opts.Collections, col)
 	}
 
 	return json.MarshalIndent(col, "", "  ")
@@ -110,17 +118,87 @@ func resolveAPIKey(p Params, opts formatter.FormatOptions) string {
 	return p.PostmanAPIKey
 }
 
-func pushToPostmanAPI(apiKey string, workspaceID string, col model.Collection) ([]byte, error) {
+func resolveMode(p Params, apiKey string) string {
+	if p.Mode != "" {
+		return strings.ToLower(p.Mode)
+	}
+	if p.OutputPath != "" {
+		return "file"
+	}
+	if apiKey != "" {
+		return "api"
+	}
+	return "file"
+}
+
+func resolveExportMode(p Params, opts formatter.FormatOptions) string {
+	if p.ExportMode != "" {
+		return strings.ToUpper(p.ExportMode)
+	}
+	if opts.Settings != nil {
+		if mode := opts.Settings.Get("postman.export.mode"); mode != "" {
+			return strings.ToUpper(mode)
+		}
+	}
+	return ExportModeCreateNew
+}
+
+func pushToPostmanAPI(apiKey string, exportMode string, projectName string, paramCollectionUID string, paramWorkspaceID string, store formatter.CollectionStore, col model.Collection) ([]byte, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("postman api key is required for api mode. Set it with: apilot set postman.api.key <value>")
+	}
 	client := newPostmanClient(apiKey)
+
+	workspaceID := paramWorkspaceID
+	collectionUID := paramCollectionUID
+
+	if collectionUID == "" && exportMode == ExportModeUpdateExisting && projectName != "" && store != nil {
+		binding, err := store.GetBinding(projectName)
+		if err == nil && binding != nil {
+			collectionUID = binding.CollectionUID
+			if binding.WorkspaceID != "" && workspaceID == "" {
+				workspaceID = binding.WorkspaceID
+			}
+		}
+	}
+
+	if collectionUID != "" {
+		result, err := client.UpdateCollection(collectionUID, col)
+		if err != nil {
+			return nil, fmt.Errorf("updating collection in postman api: %w", err)
+		}
+		if projectName != "" && store != nil {
+			_ = store.SetBinding(projectName, formatter.CollectionBinding{
+				WorkspaceID:   workspaceID,
+				CollectionUID: result.Collection.UID,
+			})
+		}
+		apiResult := APIResult{
+			CollectionID:  result.Collection.ID,
+			CollectionUID: result.Collection.UID,
+			CollectionURL: fmt.Sprintf("https://go.postman.co/collection/%s", result.Collection.UID),
+			Action:        "updated",
+		}
+		return json.MarshalIndent(apiResult, "", "  ")
+	}
+
 	result, err := client.CreateCollection(workspaceID, col)
 	if err != nil {
 		return nil, fmt.Errorf("pushing to postman api: %w", err)
+	}
+
+	if projectName != "" && store != nil {
+		_ = store.SetBinding(projectName, formatter.CollectionBinding{
+			WorkspaceID:   workspaceID,
+			CollectionUID: result.Collection.UID,
+		})
 	}
 
 	apiResult := APIResult{
 		CollectionID:  result.Collection.ID,
 		CollectionUID: result.Collection.UID,
 		CollectionURL: fmt.Sprintf("https://go.postman.co/collection/%s", result.Collection.UID),
+		Action:        "created",
 	}
 	return json.MarshalIndent(apiResult, "", "  ")
 }

--- a/api-formatter-postman/formatter_test.go
+++ b/api-formatter-postman/formatter_test.go
@@ -606,14 +606,21 @@ func TestRequiredSettings(t *testing.T) {
 	}
 
 	settings := sp.RequiredSettings()
-	if len(settings) != 1 {
-		t.Fatalf("Expected 1 setting, got %d", len(settings))
+	if len(settings) != 2 {
+		t.Fatalf("Expected 2 settings, got %d", len(settings))
 	}
-	if settings[0].Key != "postman.api.key" {
-		t.Errorf("Expected key 'postman.api.key', got %q", settings[0].Key)
+
+	expectedKeys := []string{"postman.api.key", "postman.export.mode"}
+	for i, expected := range expectedKeys {
+		if settings[i].Key != expected {
+			t.Errorf("settings[%d].Key = %q, want %q", i, settings[i].Key, expected)
+		}
 	}
-	if settings[0].Required {
-		t.Error("postman.api.key should not be required (formatter works in file mode)")
+
+	for _, s := range settings {
+		if s.Required {
+			t.Errorf("setting %q should not be required (formatter works in file mode)", s.Key)
+		}
 	}
 }
 
@@ -670,6 +677,60 @@ func TestResolveAPIKey_None(t *testing.T) {
 	key := resolveAPIKey(p, opts)
 	if key != "" {
 		t.Errorf("Expected empty string when no key configured, got %q", key)
+	}
+}
+
+func TestResolveExportMode_Default(t *testing.T) {
+	p := Params{}
+	opts := formatter.FormatOptions{}
+
+	mode := resolveExportMode(p, opts)
+	if mode != ExportModeCreateNew {
+		t.Errorf("Expected %q, got %q", ExportModeCreateNew, mode)
+	}
+}
+
+func TestResolveExportMode_FromParams(t *testing.T) {
+	p := Params{ExportMode: "UPDATE_EXISTING"}
+	opts := formatter.FormatOptions{}
+
+	mode := resolveExportMode(p, opts)
+	if mode != ExportModeUpdateExisting {
+		t.Errorf("Expected %q, got %q", ExportModeUpdateExisting, mode)
+	}
+}
+
+func TestResolveExportMode_FromSettings(t *testing.T) {
+	p := Params{}
+	opts := formatter.FormatOptions{
+		Settings: &mapSettings{"postman.export.mode": "UPDATE_EXISTING"},
+	}
+
+	mode := resolveExportMode(p, opts)
+	if mode != ExportModeUpdateExisting {
+		t.Errorf("Expected %q, got %q", ExportModeUpdateExisting, mode)
+	}
+}
+
+func TestResolveExportMode_ParamsTakesPrecedence(t *testing.T) {
+	p := Params{ExportMode: "CREATE_NEW"}
+	opts := formatter.FormatOptions{
+		Settings: &mapSettings{"postman.export.mode": "UPDATE_EXISTING"},
+	}
+
+	mode := resolveExportMode(p, opts)
+	if mode != ExportModeCreateNew {
+		t.Errorf("Params should take precedence over settings, got %q", mode)
+	}
+}
+
+func TestResolveExportMode_CaseInsensitive(t *testing.T) {
+	p := Params{ExportMode: "update_existing"}
+	opts := formatter.FormatOptions{}
+
+	mode := resolveExportMode(p, opts)
+	if mode != ExportModeUpdateExisting {
+		t.Errorf("Expected %q (uppercased), got %q", ExportModeUpdateExisting, mode)
 	}
 }
 
@@ -804,3 +865,59 @@ func TestFormat_ArrayModelBody(t *testing.T) {
 type mapSettings map[string]string
 
 func (s mapSettings) Get(key string) string { return s[key] }
+
+func TestResolveMode_ExplicitMode(t *testing.T) {
+	p := Params{Mode: "api"}
+	mode := resolveMode(p, "some-key")
+	if mode != "api" {
+		t.Errorf("Expected 'api', got %q", mode)
+	}
+}
+
+func TestResolveMode_ExplicitFileMode(t *testing.T) {
+	p := Params{Mode: "file"}
+	mode := resolveMode(p, "some-key")
+	if mode != "file" {
+		t.Errorf("Expected 'file', got %q", mode)
+	}
+}
+
+func TestResolveMode_AutoAPIKey(t *testing.T) {
+	p := Params{}
+	mode := resolveMode(p, "PMAK-xxxx")
+	if mode != "api" {
+		t.Errorf("Expected 'api' when API key is available, got %q", mode)
+	}
+}
+
+func TestResolveMode_AutoNoKey(t *testing.T) {
+	p := Params{}
+	mode := resolveMode(p, "")
+	if mode != "file" {
+		t.Errorf("Expected 'file' when no API key, got %q", mode)
+	}
+}
+
+func TestResolveMode_ExplicitOverridesAuto(t *testing.T) {
+	p := Params{Mode: "file"}
+	mode := resolveMode(p, "PMAK-xxxx")
+	if mode != "file" {
+		t.Errorf("Explicit mode should override auto-detection, got %q", mode)
+	}
+}
+
+func TestResolveMode_OutputPathForcesFile(t *testing.T) {
+	p := Params{OutputPath: "collection.json"}
+	mode := resolveMode(p, "PMAK-xxxx")
+	if mode != "file" {
+		t.Errorf("OutputPath should force file mode even with API key, got %q", mode)
+	}
+}
+
+func TestResolveMode_ExplicitAPIOverridesOutputPath(t *testing.T) {
+	p := Params{Mode: "api", OutputPath: "collection.json"}
+	mode := resolveMode(p, "PMAK-xxxx")
+	if mode != "api" {
+		t.Errorf("Explicit api mode should override OutputPath, got %q", mode)
+	}
+}

--- a/api-formatter/formatter.go
+++ b/api-formatter/formatter.go
@@ -37,14 +37,10 @@ func (noopSettings) Get(string) string { return "" }
 //
 //	FormatOptions{Params: json.RawMessage(`{"variant":"detailed","baseURL":"https://api.example.com"}`)}
 type FormatOptions struct {
-	// Params holds formatter-specific configuration as raw JSON.
-	// Formatters unmarshal this into their own typed struct using DecodeParams.
-	Params json.RawMessage `json:"params,omitempty"`
+	Params   json.RawMessage `json:"params,omitempty"`
+	Settings Settings        `json:"-"`
 
-	// Settings provides access to persistent user settings (e.g. API keys).
-	// Settings are injected by the engine at runtime; formatters call Settings.Get(key).
-	// Not serialized — omitted from JSON marshaling.
-	Settings Settings `json:"-"`
+	Collections CollectionStore `json:"-"`
 }
 
 // DecodeParams unmarshals Params into v.
@@ -64,4 +60,14 @@ type SettingDef struct {
 
 type SettingsProvider interface {
 	RequiredSettings() []SettingDef
+}
+
+type CollectionBinding struct {
+	WorkspaceID   string `json:"workspaceId,omitempty"`
+	CollectionUID string `json:"collectionUid,omitempty"`
+}
+
+type CollectionStore interface {
+	GetBinding(project string) (*CollectionBinding, error)
+	SetBinding(project string, binding CollectionBinding) error
 }

--- a/api-master/config/collections.go
+++ b/api-master/config/collections.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	formatter "github.com/tangcent/apilot/api-formatter"
+)
+
+type FileCollectionStore struct{}
+
+var _ formatter.CollectionStore = (*FileCollectionStore)(nil)
+
+func NewCollectionStore() *FileCollectionStore {
+	return &FileCollectionStore{}
+}
+
+func (s *FileCollectionStore) GetBinding(project string) (*formatter.CollectionBinding, error) {
+	bindings, err := loadCollectionBindings()
+	if err != nil {
+		return nil, err
+	}
+	if b, ok := bindings[project]; ok {
+		return &formatter.CollectionBinding{
+			WorkspaceID:   b.WorkspaceID,
+			CollectionUID: b.CollectionUID,
+		}, nil
+	}
+	return nil, nil
+}
+
+func (s *FileCollectionStore) SetBinding(project string, binding formatter.CollectionBinding) error {
+	bindingsMu.Lock()
+	defer bindingsMu.Unlock()
+	bindings, err := loadCollectionBindings()
+	if err != nil {
+		return err
+	}
+	bindings[project] = collectionEntry{
+		WorkspaceID:   binding.WorkspaceID,
+		CollectionUID: binding.CollectionUID,
+	}
+	return saveCollectionBindings(bindings)
+}
+
+type collectionEntry struct {
+	WorkspaceID   string `json:"workspaceId,omitempty"`
+	CollectionUID string `json:"collectionUid,omitempty"`
+}
+
+type collectionBindings map[string]collectionEntry
+
+var bindingsMu sync.Mutex
+
+func CollectionsFilePath() string {
+	dir := ConfigDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "postman_collections.json")
+}
+
+func loadCollectionBindings() (collectionBindings, error) {
+	path := CollectionsFilePath()
+	if path == "" {
+		return collectionBindings{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return collectionBindings{}, nil
+		}
+		return nil, err
+	}
+	var bindings collectionBindings
+	if err := json.Unmarshal(data, &bindings); err != nil {
+		return collectionBindings{}, nil
+	}
+	if bindings == nil {
+		bindings = collectionBindings{}
+	}
+	return bindings, nil
+}
+
+func saveCollectionBindings(bindings collectionBindings) error {
+	path := CollectionsFilePath()
+	if path == "" {
+		return fmt.Errorf("cannot determine config path")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(bindings, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func RemoveCollectionBinding(project string) error {
+	bindingsMu.Lock()
+	defer bindingsMu.Unlock()
+	bindings, err := loadCollectionBindings()
+	if err != nil {
+		return err
+	}
+	delete(bindings, project)
+	return saveCollectionBindings(bindings)
+}
+
+func ListCollectionBindings() (map[string]formatter.CollectionBinding, error) {
+	entries, err := loadCollectionBindings()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]formatter.CollectionBinding, len(entries))
+	for k, v := range entries {
+		result[k] = formatter.CollectionBinding{
+			WorkspaceID:   v.WorkspaceID,
+			CollectionUID: v.CollectionUID,
+		}
+	}
+	return result, nil
+}

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -2,9 +2,11 @@
 package engine
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	collector "github.com/tangcent/apilot/api-collector"
@@ -49,11 +51,31 @@ func Run(cfg Config) error {
 		return checkErr
 	}
 
+	projectName := resolveProjectName(cfg.SourceDir)
+
 	opts := formatter.FormatOptions{
-		Settings: settings,
+		Settings:    settings,
+		Collections: config.NewCollectionStore(),
 	}
 	if cfg.FormatParams != "" {
 		opts.Params = []byte(cfg.FormatParams)
+	}
+	if projectName != "" || cfg.OutputPath != "" {
+		var existing map[string]any
+		if len(opts.Params) > 0 {
+			_ = json.Unmarshal(opts.Params, &existing)
+		}
+		if existing == nil {
+			existing = map[string]any{}
+		}
+		if projectName != "" {
+			existing["projectName"] = projectName
+		}
+		if cfg.OutputPath != "" {
+			existing["outputPath"] = cfg.OutputPath
+		}
+		merged, _ := json.Marshal(existing)
+		opts.Params = merged
 	}
 	output, err := f.Format(endpoints, opts)
 	if err != nil {
@@ -137,6 +159,8 @@ func RunCLI() {
 		handleSet(args[1:])
 	case "get":
 		handleGet(args[1:])
+	case "collections":
+		handleCollections(args[1:])
 	case "export":
 		handleExport(args[1:])
 	case "--help", "-h", "help":
@@ -211,7 +235,63 @@ func handleGet(args []string) {
 		fmt.Fprintf(os.Stderr, "Setting %q not found\n", key)
 		os.Exit(1)
 	}
-	fmt.Println(value)
+	if isSensitiveKey(key) {
+		fmt.Println(maskValue(value))
+	} else {
+		fmt.Println(value)
+	}
+}
+
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	return strings.Contains(lower, "key") ||
+		strings.Contains(lower, "token") ||
+		strings.Contains(lower, "secret") ||
+		strings.Contains(lower, "password") ||
+		strings.Contains(lower, "apikey")
+}
+
+func handleCollections(args []string) {
+	if len(args) == 0 {
+		listCollections()
+		return
+	}
+	subcmd := args[0]
+	switch subcmd {
+	case "list", "ls":
+		listCollections()
+	case "remove", "rm":
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "Usage: apilot collections remove <project-name>\n")
+			os.Exit(1)
+		}
+		if err := config.RemoveCollectionBinding(args[1]); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Removed collection binding for %q\n", args[1])
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown collections subcommand: %s\n", subcmd)
+		fmt.Fprintf(os.Stderr, "Usage: apilot collections [list|remove]\n")
+		os.Exit(1)
+	}
+}
+
+func listCollections() {
+	bindings, err := config.ListCollectionBindings()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if len(bindings) == 0 {
+		fmt.Println("No collection bindings configured.")
+		fmt.Println("Bindings are automatically saved when you export with postman.export.mode=UPDATE_EXISTING")
+		return
+	}
+	fmt.Println("Project collection bindings:")
+	for project, binding := range bindings {
+		fmt.Printf("  %s: workspace=%s collection=%s\n", project, binding.WorkspaceID, binding.CollectionUID)
+	}
 }
 
 func handleExport(args []string) {
@@ -243,7 +323,11 @@ func handleExport(args []string) {
 	}
 
 	reordered := reorderArgs(args)
-	fs.Parse(reordered)
+	if err := fs.Parse(reordered); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		printExportHelp()
+		os.Exit(1)
+	}
 
 	if pluginRegistry == "" {
 		pluginRegistry = config.DefaultPluginRegistryPath()
@@ -319,6 +403,7 @@ func printHelp() {
 	fmt.Println("  settings                      List settings required by formatters")
 	fmt.Println("  set <key> <value>             Set a configuration value")
 	fmt.Println("  get <key>                     Get a configuration value")
+	fmt.Println("  collections [list|remove]     Manage project-to-collection bindings")
 	fmt.Println("")
 	fmt.Println("Run 'apilot export --help' for export flags.")
 	fmt.Println("")
@@ -396,4 +481,12 @@ func reorderArgs(args []string) []string {
 		}
 	}
 	return append(flags, positional...)
+}
+
+func resolveProjectName(sourceDir string) string {
+	abs, err := filepath.Abs(sourceDir)
+	if err != nil {
+		abs = sourceDir
+	}
+	return filepath.Base(abs)
 }

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -389,7 +389,7 @@ func TestRunCLI_SetAndGetCommand(t *testing.T) {
 	originalArgs := os.Args
 	defer func() { os.Args = originalArgs }()
 
-	os.Args = []string{"apilot", "set", "test.cli.key", "test-cli-value"}
+	os.Args = []string{"apilot", "set", "test.cli.value", "test-cli-value"}
 
 	var setOutput bytes.Buffer
 	setStdout := os.Stdout
@@ -402,11 +402,11 @@ func TestRunCLI_SetAndGetCommand(t *testing.T) {
 	os.Stdout = setStdout
 	setOutput.ReadFrom(r)
 
-	if !strings.Contains(setOutput.String(), "Set test.cli.key") {
-		t.Errorf("Expected 'Set test.cli.key' in output, got: %s", setOutput.String())
+	if !strings.Contains(setOutput.String(), "Set test.cli.value") {
+		t.Errorf("Expected 'Set test.cli.value' in output, got: %s", setOutput.String())
 	}
 
-	os.Args = []string{"apilot", "get", "test.cli.key"}
+	os.Args = []string{"apilot", "get", "test.cli.value"}
 
 	var getOutput bytes.Buffer
 	getStdout := os.Stdout
@@ -421,6 +421,40 @@ func TestRunCLI_SetAndGetCommand(t *testing.T) {
 
 	if !strings.Contains(getOutput.String(), "test-cli-value") {
 		t.Errorf("Expected 'test-cli-value' in output, got: %s", getOutput.String())
+	}
+}
+
+func TestRunCLI_GetMasksSensitiveKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := tmpDir + "/config"
+	os.Setenv("APILOT_CONFIG_DIR", configDir)
+	defer os.Unsetenv("APILOT_CONFIG_DIR")
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	os.Args = []string{"apilot", "set", "postman.api.key", "PMAK-12345678-abcdef"}
+	RunCLI()
+
+	os.Args = []string{"apilot", "get", "postman.api.key"}
+
+	var getOutput bytes.Buffer
+	getStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	RunCLI()
+
+	w.Close()
+	os.Stdout = getStdout
+	getOutput.ReadFrom(r)
+
+	output := getOutput.String()
+	if strings.Contains(output, "PMAK-12345678-abcdef") {
+		t.Errorf("Sensitive key should be masked, got plain value: %s", output)
+	}
+	if !strings.Contains(output, "****") {
+		t.Errorf("Expected masked output with ****, got: %s", output)
 	}
 }
 

--- a/skills/apilot/SKILL.md
+++ b/skills/apilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apilot
-version: 0.1.1
+version: 0.4.0
 description: "Navigate your APIs. Automatically scans source code (Java/Spring, Go/Gin, Node.js/Express, Python/FastAPI) and exports API endpoints to Postman collections, Markdown docs, or cURL commands. Use when the user needs to extract APIs from code, generate API documentation, create Postman collections, or export API endpoints from a codebase."
 metadata:
   requires:
@@ -15,7 +15,10 @@ APilot automatically discovers API endpoints in your source code and exports the
 ## Quick Start
 
 ```bash
-# Export to Postman collection
+# Export directly to Postman (recommended)
+apilot export ./my-service --formatter postman --params '{"mode":"api"}'
+
+# Export to Postman collection JSON file
 apilot export ./my-service --formatter postman --output api.postman_collection.json
 
 # Generate Markdown documentation
@@ -35,6 +38,7 @@ Scan source code and export API endpoints.
 - `--collector <name>` — Collector to use (auto-detected if omitted)
 - `--formatter <name>` — Output format: `markdown`, `curl`, `postman` (default: `markdown`)
 - `--format <variant>` — Format variant: `simple`, `detailed` (default: `simple`)
+- `--params <json>` — Formatter-specific params as JSON
 - `--output <path>` — Output file path (default: stdout)
 
 **Examples:**
@@ -43,6 +47,9 @@ Scan source code and export API endpoints.
 # Auto-detect language and export to Postman
 apilot export ./backend --formatter postman --output collection.json
 
+# Push directly to Postman cloud
+apilot export ./backend --formatter postman --params '{"mode":"api"}'
+
 # Generate detailed Markdown docs
 apilot export ./backend --formatter markdown --format detailed --output API.md
 
@@ -50,21 +57,47 @@ apilot export ./backend --formatter markdown --format detailed --output API.md
 apilot export ./backend --formatter curl
 ```
 
+### `apilot set <key> <value>`
+
+Persist a configuration value.
+
+```bash
+apilot set postman.api.key PMAK-xxxx
+apilot set postman.export.mode UPDATE_EXISTING
+```
+
+### `apilot get <key>`
+
+Read a configuration value.
+
+```bash
+apilot get postman.api.key
+apilot get postman.export.mode
+```
+
+### `apilot settings`
+
+List all settings required by registered formatters.
+
+### `apilot collections [list|remove]`
+
+Manage project-to-collection bindings (auto-saved when using UPDATE_EXISTING mode).
+
+```bash
+# List all project collection bindings
+apilot collections
+
+# Remove a binding for a specific project
+apilot collections remove my-project
+```
+
 ### `apilot export --list-collectors`
 
 List all available collectors (language/framework parsers).
 
-```bash
-apilot export --list-collectors
-```
-
 ### `apilot export --list-formatters`
 
 List all available output formatters.
-
-```bash
-apilot export --list-formatters
-```
 
 ## Supported Languages & Frameworks
 
@@ -81,7 +114,177 @@ apilot export --list-formatters
 |--------|-------------|
 | `markdown` | Markdown documentation (simple or detailed) |
 | `curl` | One cURL command per endpoint |
-| `postman` | Postman Collection v2.1 JSON |
+| `postman` | Postman Collection v2.1 JSON or direct API push |
+
+## Postman Settings
+
+| Setting | Description |
+|---------|-------------|
+| `postman.api.key` | Postman API key (required for API push mode) |
+| `postman.export.mode` | Export mode: `CREATE_NEW` (always create new collection) or `UPDATE_EXISTING` (update previously exported collection per project, default: `CREATE_NEW`) |
+
+## Smart Mode Detection
+
+The Postman formatter automatically detects the export mode based on context:
+
+| Condition | Mode | Behavior |
+|-----------|------|----------|
+| API key configured, no `--output` | **api** | Push directly to Postman cloud |
+| `--output` specified | **file** | Write Postman Collection JSON to file |
+| No API key configured | **file** | Output Postman Collection JSON to stdout |
+| `--params '{"mode":"api"}'` | **api** | Explicit push to Postman (overrides auto-detection) |
+| `--params '{"mode":"file"}'` | **file** | Explicit file output (overrides auto-detection) |
+
+This means the simplest command just works:
+
+```bash
+# If postman.api.key is set → pushes to Postman automatically
+apilot export ./backend --formatter postman
+
+# If you want a JSON file instead → use --output
+apilot export ./backend --formatter postman --output collection.json
+```
+
+## Project Name Inference
+
+The project name is automatically inferred from the source directory path using the basename:
+
+- `/Users/tangcent/code/github/java-spring-demo` → `java-spring-demo`
+- `/home/user/repos/api-service` → `api-service`
+- `./my-project` → `my-project`
+
+This project name is used as the key for per-project collection bindings. You can override it via the `projectName` param:
+
+```bash
+apilot export ./backend --formatter postman --params '{"mode":"api","projectName":"my-custom-name"}'
+```
+
+## Postman Export Modes
+
+### CREATE_NEW (default)
+
+Always creates a new collection in Postman. Each export produces a new collection with a fresh UID.
+
+### UPDATE_EXISTING
+
+Remembers which collection and workspace each project maps to. On first export, creates a new collection and saves the binding (including workspace). On subsequent exports, updates the same collection in-place — no duplicates.
+
+The project name is derived from the source directory basename (e.g. `/code/my-service` → `my-service`).
+
+Bindings are stored in `~/.config/apilot/postman_collections.json` and can be managed with:
+
+```bash
+apilot collections          # list all bindings
+apilot collections remove my-project  # remove a binding
+```
+
+## Per-Project Workspace & Collection
+
+Workspace and collection bindings are stored **per-project**, not globally. This means:
+
+- Each project can export to a different workspace and collection
+- When using `UPDATE_EXISTING` mode, the workspace is remembered alongside the collection
+- No global workspace configuration is needed — the first export determines the workspace
+
+To specify a workspace for the first export of a project:
+
+```bash
+# Create collection in a specific workspace (workspace is remembered for future exports)
+apilot export ./backend --formatter postman --params '{"mode":"api","workspaceId":"ws-xxxx"}'
+```
+
+## Smart Postman Export Workflow
+
+When the user asks to export APIs to Postman, follow this workflow:
+
+### Step 1: Check for Postman API key
+
+Run `apilot get postman.api.key` to check if a key is already configured.
+
+- **If key exists**: Proceed to Step 2.
+- **If key is missing**: Ask the user:
+  > "No Postman API key found. Would you like to provide one, or export as a JSON file instead?"
+  >
+  > Options:
+  > 1. **Provide API key** — I'll save it with `apilot set postman.api.key <key>` so you can push directly to Postman. Get your key at: https://go.postman.co/settings/api-keys
+  > 2. **Export as JSON file** — I'll generate a `.postman_collection.json` file you can import manually.
+
+### Step 2: Check export mode
+
+Run `apilot get postman.export.mode` to check the current export mode.
+
+- **If UPDATE_EXISTING**: The export will automatically update the previously created collection for this project (if one exists). No further configuration needed.
+- **If CREATE_NEW or not set**: Each export creates a new collection. Ask the user:
+  > "Would you like to use UPDATE_EXISTING mode so the same collection is updated on each export?"
+  >
+  > Options:
+  > 1. **Yes, set UPDATE_EXISTING** — I'll save it with `apilot set postman.export.mode UPDATE_EXISTING`. Future exports will update the same collection.
+  > 2. **No, keep CREATE_NEW** — Each export creates a new collection (useful for versioned snapshots).
+
+### Step 3: Check for existing project binding
+
+Run `apilot collections` to see if this project already has a binding.
+
+- **If binding exists**: The export will update the existing collection in the remembered workspace. No further configuration needed.
+- **If no binding**: Ask the user:
+  > "Would you like to create the collection in a specific Postman workspace?"
+  >
+  > Options:
+  > 1. **Specify workspace** — Provide the workspace ID and it will be remembered for this project: `apilot export <path> --formatter postman --params '{"workspaceId":"ws-xxxx"}'`
+  > 2. **Use personal workspace** — The collection will be created in your default personal workspace
+
+### Step 4: Run the export
+
+```bash
+apilot export <source-path> --formatter postman
+```
+
+The formatter automatically pushes to Postman API when the API key is configured. If you need a JSON file instead, use `--output`.
+
+If the user wants to override defaults for this run:
+
+```bash
+# Push to a specific workspace (workspace is remembered for this project)
+apilot export <source-path> --formatter postman --params '{"workspaceId":"ws-xxxx"}'
+
+# Update a specific collection (overrides UPDATE_EXISTING binding)
+apilot export <source-path> --formatter postman --params '{"collectionUid":"12345-xxxx"}'
+
+# Custom collection name
+apilot export <source-path> --formatter postman --params '{"collectionName":"My API"}'
+
+# Force file output (Postman Collection JSON) instead of API push
+apilot export <source-path> --formatter postman --output collection.json
+```
+
+### Step 5: Report the result
+
+On success, the output will be JSON like:
+
+```json
+{
+  "collectionId": "...",
+  "collectionUid": "...",
+  "collectionUrl": "https://go.postman.co/collection/...",
+  "action": "created"
+}
+```
+
+or
+
+```json
+{
+  "collectionId": "...",
+  "collectionUid": "...",
+  "collectionUrl": "https://go.postman.co/collection/...",
+  "action": "updated"
+}
+```
+
+Tell the user:
+- Whether the collection was **created** or **updated**
+- The URL to open it in Postman
+- If using UPDATE_EXISTING mode, the binding (including workspace) is automatically saved — no manual configuration needed
 
 ## Common Workflows
 
@@ -91,7 +294,35 @@ apilot export --list-formatters
 apilot export ./spring-boot-app --formatter markdown --format detailed --output API.md
 ```
 
-### Create Postman collection from Express.js app
+### Push APIs directly to Postman (one-time setup)
+
+```bash
+apilot set postman.api.key PMAK-xxxx
+apilot set postman.export.mode UPDATE_EXISTING
+apilot export ./backend --formatter postman
+```
+
+### Push to a specific workspace (workspace is remembered per-project)
+
+```bash
+# First export: specify workspace, it's remembered for this project
+apilot export ./backend --formatter postman --params '{"workspaceId":"ws-xxxx"}'
+
+# Subsequent exports: workspace is automatically used from the saved binding
+apilot export ./backend --formatter postman
+```
+
+### Update an existing Postman collection automatically
+
+```bash
+# First export creates the collection and remembers the binding
+apilot export ./backend --formatter postman
+
+# Subsequent exports update the same collection (with UPDATE_EXISTING mode)
+apilot export ./backend --formatter postman
+```
+
+### Export to Postman JSON file (manual import)
 
 ```bash
 apilot export ./express-app --formatter postman --output api.postman_collection.json
@@ -106,8 +337,17 @@ apilot export ./my-api --formatter curl > api-reference.sh
 ### Export specific collector
 
 ```bash
-# Force Java collector even if auto-detection might choose differently
-apilot export ./mixed-project --collector java --formatter postman --output java-apis.json
+apilot export ./mixed-project --collector java --formatter postman --params '{"mode":"api"}'
+```
+
+### Manage collection bindings
+
+```bash
+# See which projects are bound to which collections
+apilot collections
+
+# Remove a stale binding
+apilot collections remove old-project
 ```
 
 ## Tips
@@ -115,6 +355,9 @@ apilot export ./mixed-project --collector java --formatter postman --output java
 - APilot auto-detects the language and framework — you rarely need `--collector`
 - Use `--format detailed` with markdown formatter for comprehensive docs including request/response examples
 - The tool works on source code, not running services — no server startup required
+- Set `postman.export.mode` to `UPDATE_EXISTING` to avoid creating duplicate collections on every export
+- Project-to-collection bindings (including workspace) are stored automatically per-project — no need to manually configure collection UIDs or workspace IDs
+- The project name is auto-inferred from the source directory basename
 - Output to stdout by default — redirect or use `--output` to save to file
 
 ## Plugin System


### PR DESCRIPTION
## Changes

- Remove global postman.workspace.id setting — workspace and collection bindings are now stored per-project
- Smart mode detection — auto-push to Postman API when API key is configured, auto-file when --output is specified
- resolveMode() — intelligently chooses between api/file modes based on context
- resolveProjectName() — infers project name from source path basename
- CollectionStore interface — persistent per-project binding storage with management commands
- Sensitive key masking — apilot get postman.api.key returns masked value
- SKILL.md v0.4.0 — updated workflow documentation