### PR TITLE
feat(java): wire maven-indexer-cli into TypeResolver for dependency class resolution

### DIFF
--- a/api-collector-java/collector.go
+++ b/api-collector-java/collector.go
@@ -28,12 +28,21 @@ func (c *JavaCollector) SupportedLanguages() []string { return []string{"java", 
 // When maven-indexer-cli is available and a build file (pom.xml/build.gradle) is present,
 // it attempts to resolve dependency JARs for improved type analysis.
 func (c *JavaCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndpoint, error) {
+	var depResolver *maven.MavenDependencyResolver
 	if maven.HasBuildFile(ctx.SourceDir) && maven.IsAvailable() {
 		jarPaths, err := maven.Resolve(ctx.SourceDir)
 		if err != nil {
 			log.Printf("[maven] dependency resolution skipped: %v", err)
 		} else if len(jarPaths) > 0 {
 			log.Printf("[maven] resolved %d dependency JARs", len(jarPaths))
+		}
+
+		dr, err := maven.NewMavenDependencyResolver()
+		if err != nil {
+			log.Printf("[maven] dependency class resolver unavailable: %v", err)
+		} else {
+			depResolver = dr
+			defer depResolver.Close()
 		}
 	}
 
@@ -67,6 +76,9 @@ func (c *JavaCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEn
 
 	if frameworks["spring-mvc"] {
 		sm := springmvc.NewParser()
+		if depResolver != nil {
+			sm.SetDependencyResolver(depResolver)
+		}
 		for _, ctrl := range sm.ExtractControllers(results) {
 			for _, ep := range ctrl.Endpoints {
 				endpoints = append(endpoints, springmvcEndpointToAPI(ep, ctrl.Name))
@@ -76,6 +88,9 @@ func (c *JavaCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEn
 
 	if frameworks["jaxrs"] {
 		jr := jaxrs.NewParser()
+		if depResolver != nil {
+			jr.SetDependencyResolver(depResolver)
+		}
 		for _, res := range jr.ExtractResources(results) {
 			for _, ep := range res.Endpoints {
 				endpoints = append(endpoints, jaxrsEndpointToAPI(ep, res.Name))
@@ -85,6 +100,9 @@ func (c *JavaCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEn
 
 	if frameworks["feign"] {
 		fg := feign.NewParser()
+		if depResolver != nil {
+			fg.SetDependencyResolver(depResolver)
+		}
 		for _, client := range fg.ExtractClients(results) {
 			for _, ep := range client.Endpoints {
 				endpoints = append(endpoints, feignEndpointToAPI(ep, client.Name))

--- a/api-collector-java/feign/parser.go
+++ b/api-collector-java/feign/parser.go
@@ -9,11 +9,17 @@ import (
 )
 
 // Parser extracts Feign client endpoints from parsed Java classes.
-type Parser struct{}
+type Parser struct {
+	dependencyResolver resolver.DependencyResolver
+}
 
 // NewParser creates a new Feign client parser.
 func NewParser() *Parser {
 	return &Parser{}
+}
+
+func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
+	p.dependencyResolver = dr
 }
 
 // ExtractClients extracts Feign clients from parse results.
@@ -22,6 +28,9 @@ func NewParser() *Parser {
 func (p *Parser) ExtractClients(results []parser.ParseResult) []FeignClient {
 	classRegistry := buildClassRegistry(results)
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
+	if p.dependencyResolver != nil {
+		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	}
 
 	var clients []FeignClient
 	for _, result := range results {

--- a/api-collector-java/jaxrs/parser.go
+++ b/api-collector-java/jaxrs/parser.go
@@ -9,18 +9,26 @@ import (
 	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
-// Parser extracts JAX-RS endpoints from parsed Java classes.
-type Parser struct{}
+type Parser struct {
+	dependencyResolver resolver.DependencyResolver
+}
 
 // NewParser creates a new JAX-RS parser.
 func NewParser() *Parser {
 	return &Parser{}
 }
 
+func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
+	p.dependencyResolver = dr
+}
+
 // ExtractResources extracts JAX-RS resources from parse results.
 func (p *Parser) ExtractResources(results []parser.ParseResult) []Resource {
 	classRegistry := buildClassRegistry(results)
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
+	if p.dependencyResolver != nil {
+		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	}
 
 	var resources []Resource
 	for _, result := range results {

--- a/api-collector-java/maven/dep_resolver.go
+++ b/api-collector-java/maven/dep_resolver.go
@@ -1,0 +1,138 @@
+package maven
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/tangcent/apilot/api-collector-java/parser"
+)
+
+type MavenDependencyResolver struct {
+	mu      sync.Mutex
+	parser  *parser.Parser
+	cache   map[string]*parser.Class
+	misses  map[string]bool
+}
+
+func NewMavenDependencyResolver() (*MavenDependencyResolver, error) {
+	if !isCLIAvailable() {
+		return nil, fmt.Errorf("maven-indexer-cli not available")
+	}
+
+	p, err := parser.NewParser(parser.ParserOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create java parser: %w", err)
+	}
+
+	return &MavenDependencyResolver{
+		parser: p,
+		cache:  make(map[string]*parser.Class),
+		misses: make(map[string]bool),
+	}, nil
+}
+
+func (r *MavenDependencyResolver) Close() {
+	if r.parser != nil {
+		r.parser.Close()
+	}
+}
+
+func (r *MavenDependencyResolver) ResolveClass(className string) *parser.Class {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cached, ok := r.cache[className]; ok {
+		return cached
+	}
+
+	if r.misses[className] {
+		return nil
+	}
+
+	class := r.resolveFromCLI(className)
+	if class != nil {
+		r.cache[className] = class
+		return class
+	}
+
+	r.misses[className] = true
+	return nil
+}
+
+func (r *MavenDependencyResolver) resolveFromCLI(className string) *parser.Class {
+	source, err := r.fetchSource(className)
+	if err != nil || source == "" {
+		return nil
+	}
+
+	classes, err := r.parser.ParseSource([]byte(source))
+	if err != nil || len(classes) == 0 {
+		return nil
+	}
+
+	for i := range classes {
+		if classes[i].Name == className {
+			return &classes[i]
+		}
+	}
+
+	if len(classes) > 0 {
+		return &classes[0]
+	}
+
+	return nil
+}
+
+func (r *MavenDependencyResolver) fetchSource(className string) (string, error) {
+	cmd := exec.Command(cliName, "get-class", className, "--json", "--type", "source")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("maven-indexer-cli get-class failed: %w", err)
+	}
+
+	var raw string
+	if err := json.Unmarshal(output, &raw); err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" || strings.HasPrefix(trimmed, "Class") {
+			return "", nil
+		}
+		return trimmed, nil
+	}
+
+	if raw == "" {
+		return "", nil
+	}
+
+	source, err := extractSourceFromMarkdown(raw)
+	if err != nil {
+		log.Printf("[maven-dep] failed to extract source for %s: %v", className, err)
+		return raw, nil
+	}
+
+	return source, nil
+}
+
+func extractSourceFromMarkdown(raw string) (string, error) {
+	codeBlockStart := "```java\n"
+	codeBlockEnd := "```"
+
+	startIdx := strings.Index(raw, codeBlockStart)
+	if startIdx == -1 {
+		return raw, nil
+	}
+
+	afterStart := startIdx + len(codeBlockStart)
+	remaining := raw[afterStart:]
+
+	endIdx := strings.Index(remaining, codeBlockEnd)
+	if endIdx == -1 {
+		return remaining, nil
+	}
+
+	source := remaining[:endIdx]
+	return strings.TrimSuffix(source, "\n"), nil
+}

--- a/api-collector-java/maven/dep_resolver_test.go
+++ b/api-collector-java/maven/dep_resolver_test.go
@@ -1,0 +1,85 @@
+package maven
+
+import (
+	"testing"
+)
+
+func TestExtractSourceFromMarkdown(t *testing.T) {
+	t.Run("extracts java code block", func(t *testing.T) {
+		input := "### Class: com.example.Result\nArtifact: com.example:lib:1.0\n\n```java\npackage com.example;\n\npublic class Result {\n    private int code;\n}\n```\n"
+		expected := "package com.example;\n\npublic class Result {\n    private int code;\n}"
+		result, err := extractSourceFromMarkdown(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != expected {
+			t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("returns raw if no code block", func(t *testing.T) {
+		input := "public class Foo { }"
+		result, err := extractSourceFromMarkdown(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != input {
+			t.Errorf("expected raw input returned, got:\n%s", result)
+		}
+	})
+
+	t.Run("handles unclosed code block", func(t *testing.T) {
+		input := "```java\npublic class Foo { }"
+		expected := "public class Foo { }"
+		result, err := extractSourceFromMarkdown(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != expected {
+			t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+		}
+	})
+
+	t.Run("handles empty code block", func(t *testing.T) {
+		input := "```java\n```"
+		expected := ""
+		result, err := extractSourceFromMarkdown(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != expected {
+			t.Errorf("expected empty string, got:\n%s", result)
+		}
+	})
+
+	t.Run("handles code block with generics", func(t *testing.T) {
+		input := "```java\npublic class Result<T> {\n    private T data;\n}\n```"
+		expected := "public class Result<T> {\n    private T data;\n}"
+		result, err := extractSourceFromMarkdown(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != expected {
+			t.Errorf("expected:\n%s\ngot:\n%s", expected, result)
+		}
+	})
+}
+
+func TestMavenDependencyResolver_New(t *testing.T) {
+	resolver, err := NewMavenDependencyResolver()
+	if isCLIAvailable() {
+		if err != nil {
+			t.Errorf("Expected no error when CLI available, got: %v", err)
+		}
+		if resolver == nil {
+			t.Error("Expected non-nil resolver when CLI available")
+		}
+		if resolver != nil {
+			resolver.Close()
+		}
+	} else {
+		if err == nil {
+			t.Error("Expected error when CLI unavailable")
+		}
+	}
+}

--- a/api-collector-java/parser/parser.go
+++ b/api-collector-java/parser/parser.go
@@ -92,6 +92,19 @@ func (p *Parser) ParseFile(path string) (*ParseResult, error) {
 	return result, nil
 }
 
+func (p *Parser) ParseSource(source []byte) ([]Class, error) {
+	p.mu.Lock()
+	tree := p.parser.Parse(source, nil)
+	p.mu.Unlock()
+
+	if tree == nil {
+		return nil, fmt.Errorf("failed to parse source")
+	}
+	defer tree.Close()
+
+	return extractAllClasses(tree, source)
+}
+
 // ParseDirectory parses all Java files in a directory sequentially.
 func (p *Parser) ParseDirectory(dir string) ([]ParseResult, error) {
 	p.logger.Info("Parsing directory: %s", dir)

--- a/api-collector-java/parser/parser_test.go
+++ b/api-collector-java/parser/parser_test.go
@@ -255,3 +255,67 @@ func TestParser_ConcurrentAccess(t *testing.T) {
 		}
 	}
 }
+
+func TestParser_ParseSource(t *testing.T) {
+	p, err := NewParser(ParserOptions{LogLevel: LogLevelError})
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+	defer p.Close()
+
+	t.Run("parses simple class", func(t *testing.T) {
+		source := []byte(`package com.example;
+
+public class User {
+    private Long id;
+    private String name;
+}`)
+		classes, err := p.ParseSource(source)
+		if err != nil {
+			t.Fatalf("Failed to parse source: %v", err)
+		}
+		if len(classes) != 1 {
+			t.Fatalf("Expected 1 class, got %d", len(classes))
+		}
+		if classes[0].Name != "User" {
+			t.Errorf("Expected class name 'User', got '%s'", classes[0].Name)
+		}
+		if classes[0].Package != "com.example" {
+			t.Errorf("Expected package 'com.example', got '%s'", classes[0].Package)
+		}
+		if len(classes[0].Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(classes[0].Fields))
+		}
+	})
+
+	t.Run("parses generic class", func(t *testing.T) {
+		source := []byte(`public class Result<T> {
+    private int code;
+    private T data;
+}`)
+		classes, err := p.ParseSource(source)
+		if err != nil {
+			t.Fatalf("Failed to parse source: %v", err)
+		}
+		if len(classes) != 1 {
+			t.Fatalf("Expected 1 class, got %d", len(classes))
+		}
+		if classes[0].Name != "Result" {
+			t.Errorf("Expected class name 'Result', got '%s'", classes[0].Name)
+		}
+		if len(classes[0].TypeParameters) != 1 || classes[0].TypeParameters[0] != "T" {
+			t.Errorf("Expected type parameter 'T', got %v", classes[0].TypeParameters)
+		}
+	})
+
+	t.Run("returns empty classes for empty source", func(t *testing.T) {
+		source := []byte("")
+		classes, err := p.ParseSource(source)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(classes) != 0 {
+			t.Errorf("Expected 0 classes for empty source, got %d", len(classes))
+		}
+	})
+}

--- a/api-collector-java/resolver/resolver.go
+++ b/api-collector-java/resolver/resolver.go
@@ -39,10 +39,15 @@ var mapTypes = map[string]bool{
 	"TreeMap":       true,
 }
 
+type DependencyResolver interface {
+	ResolveClass(className string) *parser.Class
+}
+
 type TypeResolver struct {
-	classRegistry map[string]parser.Class
-	allTypeParams map[string]bool
-	resolving     map[string]bool
+	classRegistry     map[string]parser.Class
+	allTypeParams     map[string]bool
+	resolving         map[string]bool
+	dependencyResolver DependencyResolver
 }
 
 func NewTypeResolver(classes []parser.Class) *TypeResolver {
@@ -59,6 +64,10 @@ func NewTypeResolver(classes []parser.Class) *TypeResolver {
 		allTypeParams: allTypeParams,
 		resolving:     make(map[string]bool),
 	}
+}
+
+func (r *TypeResolver) SetDependencyResolver(dr DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *model.ObjectModel {
@@ -166,6 +175,16 @@ func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *
 			Kind:     model.KindObject,
 			TypeName: baseName,
 			Fields:   fields,
+		}
+	}
+
+	if r.dependencyResolver != nil {
+		if depClass := r.dependencyResolver.ResolveClass(baseName); depClass != nil {
+			r.classRegistry[baseName] = *depClass
+			for _, tp := range depClass.TypeParameters {
+				r.allTypeParams[tp] = true
+			}
+			return r.Resolve(rawType, typeBindings)
 		}
 	}
 

--- a/api-collector-java/resolver/resolver_test.go
+++ b/api-collector-java/resolver/resolver_test.go
@@ -709,3 +709,131 @@ func TestResolve_FieldOverrideInSubclass(t *testing.T) {
 		t.Errorf("Expected name typeName 'string', got '%s'", nameField.Model.TypeName)
 	}
 }
+
+type mockDependencyResolver struct {
+	classes map[string]parser.Class
+}
+
+func (m *mockDependencyResolver) ResolveClass(className string) *parser.Class {
+	if c, ok := m.classes[className]; ok {
+		return &c
+	}
+	return nil
+}
+
+func TestResolve_DependencyResolverFallback(t *testing.T) {
+	localClasses := []parser.Class{
+		{
+			Name: "LocalDTO",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+	}
+
+	depClasses := map[string]parser.Class{
+		"ExternalDTO": {
+			Name: "ExternalDTO",
+			Fields: []parser.Field{
+				{Name: "code", Type: "String"},
+				{Name: "value", Type: "int"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(localClasses)
+	r.SetDependencyResolver(&mockDependencyResolver{classes: depClasses})
+
+	t.Run("local class resolved normally", func(t *testing.T) {
+		result := r.Resolve("LocalDTO", nil)
+		if result.Kind != model.KindObject {
+			t.Fatalf("Expected KindObject, got %s", result.Kind)
+		}
+		if result.TypeName != "LocalDTO" {
+			t.Errorf("Expected typeName 'LocalDTO', got '%s'", result.TypeName)
+		}
+	})
+
+	t.Run("external class resolved via dependency resolver", func(t *testing.T) {
+		result := r.Resolve("ExternalDTO", nil)
+		if result.Kind != model.KindObject {
+			t.Fatalf("Expected KindObject, got %s", result.Kind)
+		}
+		if result.TypeName != "ExternalDTO" {
+			t.Errorf("Expected typeName 'ExternalDTO', got '%s'", result.TypeName)
+		}
+		if len(result.Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+		}
+		codeField := result.Fields["code"]
+		if codeField == nil || codeField.Model.TypeName != model.JsonTypeString {
+			t.Errorf("Expected code field typeName 'string', got '%v'", codeField)
+		}
+	})
+
+	t.Run("unknown type still returns SingleModel", func(t *testing.T) {
+		result := r.Resolve("CompletelyUnknown", nil)
+		if result.Kind != model.KindSingle {
+			t.Fatalf("Expected KindSingle, got %s", result.Kind)
+		}
+		if result.TypeName != "CompletelyUnknown" {
+			t.Errorf("Expected typeName 'CompletelyUnknown', got '%s'", result.TypeName)
+		}
+	})
+
+	t.Run("resolved class is cached in registry", func(t *testing.T) {
+		r.Resolve("ExternalDTO", nil)
+		if _, found := r.classRegistry["ExternalDTO"]; !found {
+			t.Error("Expected ExternalDTO to be cached in classRegistry after resolution")
+		}
+	})
+}
+
+func TestResolve_DependencyResolverWithGenerics(t *testing.T) {
+	depClasses := map[string]parser.Class{
+		"Result": {
+			Name:           "Result",
+			TypeParameters: []string{"T"},
+			Fields: []parser.Field{
+				{Name: "code", Type: "int"},
+				{Name: "data", Type: "T"},
+			},
+		},
+		"User": {
+			Name: "User",
+			Fields: []parser.Field{
+				{Name: "name", Type: "String"},
+			},
+		},
+	}
+
+	r := NewTypeResolver(nil)
+	r.SetDependencyResolver(&mockDependencyResolver{classes: depClasses})
+
+	result := r.Resolve("Result<User>", nil)
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+
+	dataField := result.Fields["data"]
+	if dataField == nil {
+		t.Fatal("Expected 'data' field")
+	}
+	if dataField.Model.Kind != model.KindObject {
+		t.Errorf("Expected data KindObject, got %s", dataField.Model.Kind)
+	}
+	if dataField.Model.TypeName != "User" {
+		t.Errorf("Expected data typeName 'User', got '%s'", dataField.Model.TypeName)
+	}
+}
+
+func TestResolve_NoDependencyResolver(t *testing.T) {
+	r := NewTypeResolver(nil)
+	result := r.Resolve("UnknownType", nil)
+	if result.Kind != model.KindSingle {
+		t.Fatalf("Expected KindSingle, got %s", result.Kind)
+	}
+	if result.TypeName != "UnknownType" {
+		t.Errorf("Expected typeName 'UnknownType', got '%s'", result.TypeName)
+	}
+}

--- a/api-collector-java/springmvc/parser.go
+++ b/api-collector-java/springmvc/parser.go
@@ -8,15 +8,24 @@ import (
 	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
-type Parser struct{}
+type Parser struct {
+	dependencyResolver resolver.DependencyResolver
+}
 
 func NewParser() *Parser {
 	return &Parser{}
 }
 
+func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
+	p.dependencyResolver = dr
+}
+
 func (p *Parser) ExtractControllers(results []parser.ParseResult) []Controller {
 	classRegistry := buildClassRegistry(results)
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
+	if p.dependencyResolver != nil {
+		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	}
 
 	var controllers []Controller
 


### PR DESCRIPTION
Resolves #120

When a type is not found in the local class registry, the TypeResolver now falls back to resolving the class from Maven dependencies via maven-indexer-cli.

**Changes:**
- Add DependencyResolver interface to resolver package
- Add MavenDependencyResolver in maven package using maven-indexer-cli get-class --type source
- Add ParseSource method to parser for parsing Java source from byte slice
- Add dependency resolver fallback in TypeResolver.Resolve()
- Wire MavenDependencyResolver through Spring MVC, JAX-RS, Feign parsers
- Add caching and miss-tracking in MavenDependencyResolver
- Add tests for all new functionality