### PR TITLE
feat: add common DependencyResolver interface across all language collectors

### DIFF
--- a/api-collector-go/collector.go
+++ b/api-collector-go/collector.go
@@ -13,14 +13,19 @@ import (
 )
 
 // GoCollector parses Go source trees for API route registrations.
-type GoCollector struct{}
+type GoCollector struct {
+	dependencyResolver collector.DependencyResolver
+}
 
-// New returns a new GoCollector.
 func New() collector.Collector { return &GoCollector{} }
 
 func (c *GoCollector) Name() string { return "go" }
 
 func (c *GoCollector) SupportedLanguages() []string { return []string{"go"} }
+
+func (c *GoCollector) SetDependencyResolver(dr collector.DependencyResolver) {
+	c.dependencyResolver = dr
+}
 
 // Collect walks the source directory and extracts endpoints from Gin, Echo,
 // and Fiber route registrations.

--- a/api-collector-go/dep_resolver.go
+++ b/api-collector-go/dep_resolver.go
@@ -1,0 +1,287 @@
+package gocollector
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+type GoDependencyResolver struct {
+	mu        sync.Mutex
+	sourceDir string
+	cache     map[string]*collector.ResolvedType
+	misses    map[string]bool
+	moduleDir string
+}
+
+func NewGoDependencyResolver(sourceDir string) *GoDependencyResolver {
+	return &GoDependencyResolver{
+		sourceDir: sourceDir,
+		cache:     make(map[string]*collector.ResolvedType),
+		misses:    make(map[string]bool),
+	}
+}
+
+func (r *GoDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return detectGoDependencies(sourceDir)
+}
+
+func (r *GoDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cached, ok := r.cache[typeName]; ok {
+		return cached
+	}
+
+	if r.misses[typeName] {
+		return nil
+	}
+
+	if r.moduleDir == "" {
+		dir, err := resolveModuleCacheDir(r.sourceDir)
+		if err != nil {
+			r.misses[typeName] = true
+			return nil
+		}
+		r.moduleDir = dir
+	}
+
+	rt := r.resolveFromModuleCache(typeName)
+	if rt != nil {
+		r.cache[typeName] = rt
+		return rt
+	}
+
+	r.misses[typeName] = true
+	return nil
+}
+
+func (r *GoDependencyResolver) resolveFromModuleCache(typeName string) *collector.ResolvedType {
+	pkgPath, typeName := splitGoType(typeName)
+	if pkgPath == "" {
+		return nil
+	}
+
+	pkgDir := filepath.Join(r.moduleDir, filepath.FromSlash(pkgPath))
+	if info, err := os.Stat(pkgDir); err != nil || !info.IsDir() {
+		versions, err := findModuleVersions(r.moduleDir, pkgPath)
+		if err != nil || len(versions) == 0 {
+			return nil
+		}
+		pkgDir = versions[0]
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, pkgDir, nil, parser.ParseComments)
+	if err != nil {
+		return nil
+	}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			rt := extractResolvedTypeFromAST(file, typeName)
+			if rt != nil {
+				return rt
+			}
+		}
+	}
+
+	return nil
+}
+
+func extractResolvedTypeFromAST(file *ast.File, typeName string) *collector.ResolvedType {
+	for _, decl := range file.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != typeName {
+				continue
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				return &collector.ResolvedType{
+					Name: typeName,
+				}
+			}
+
+			rt := &collector.ResolvedType{
+				Name: typeName,
+			}
+
+			if structType.Fields != nil {
+				for _, field := range structType.Fields.List {
+					if len(field.Names) == 0 {
+						embeddedType := extractGoTypeNameFromExpr(field.Type)
+						rt.Fields = append(rt.Fields, collector.ResolvedField{
+							Name:     embeddedType,
+							Type:     embeddedType,
+							Required: true,
+						})
+						continue
+					}
+
+					for _, name := range field.Names {
+						sf := collector.ResolvedField{
+							Name: name.Name,
+							Type: extractGoTypeNameFromExpr(field.Type),
+						}
+
+						if field.Tag != nil {
+							tag := strings.Trim(field.Tag.Value, "`")
+							structTag := reflect.StructTag(tag)
+							if jsonTag, ok := structTag.Lookup("json"); ok {
+								parts := strings.SplitN(jsonTag, ",", 2)
+								if parts[0] != "-" && parts[0] != "" {
+									sf.Name = parts[0]
+								}
+								if len(parts) > 1 && strings.Contains(parts[1], "omitempty") {
+									sf.Required = false
+								} else {
+									sf.Required = true
+								}
+							}
+							if bindingTag, ok := structTag.Lookup("binding"); ok {
+								if strings.Contains(bindingTag, "required") {
+									sf.Required = true
+								}
+							}
+						} else {
+							sf.Required = true
+						}
+
+						rt.Fields = append(rt.Fields, sf)
+					}
+				}
+			}
+
+			return rt
+		}
+	}
+
+	return nil
+}
+
+func extractGoTypeNameFromExpr(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return extractGoTypeNameFromExpr(e.X)
+	case *ast.ArrayType:
+		return "[]" + extractGoTypeNameFromExpr(e.Elt)
+	case *ast.MapType:
+		return "map[" + extractGoTypeNameFromExpr(e.Key) + "]" + extractGoTypeNameFromExpr(e.Value)
+	case *ast.SelectorExpr:
+		if x, ok := e.X.(*ast.Ident); ok {
+			return x.Name + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.InterfaceType:
+		return "interface{}"
+	case *ast.StructType:
+		return "struct{}"
+	}
+	return ""
+}
+
+func splitGoType(typeName string) (pkgPath, name string) {
+	if strings.Contains(typeName, ".") {
+		parts := strings.Split(typeName, ".")
+		name = parts[len(parts)-1]
+		pkgPath = strings.Join(parts[:len(parts)-1], "/")
+		return
+	}
+	return "", typeName
+}
+
+func resolveModuleCacheDir(sourceDir string) (string, error) {
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	cmd.Dir = sourceDir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get GOMODCACHE: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func findModuleVersions(moduleCache string, pkgPath string) ([]string, error) {
+	searchDir := filepath.Join(moduleCache, filepath.FromSlash(pkgPath))
+	var versions []string
+
+	entries, err := os.ReadDir(searchDir)
+	if err != nil {
+		parentDir := filepath.Dir(searchDir)
+		entries, err = os.ReadDir(parentDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() && strings.HasPrefix(entry.Name(), filepath.Base(searchDir)+"@") {
+				versionDir := filepath.Join(parentDir, entry.Name())
+				subEntries, err := os.ReadDir(versionDir)
+				if err != nil {
+					continue
+				}
+				for _, sub := range subEntries {
+					if sub.IsDir() {
+						versions = append(versions, filepath.Join(versionDir, sub.Name()))
+					}
+				}
+			}
+		}
+	} else {
+		for _, entry := range entries {
+			if entry.IsDir() && strings.Contains(entry.Name(), "@") {
+				versions = append(versions, filepath.Join(searchDir, entry.Name()))
+			}
+		}
+	}
+
+	return versions, nil
+}
+
+type goModule struct {
+	Path      string `json:"Path"`
+	Version   string `json:"Version"`
+	Indirect  bool   `json:"Indirect"`
+}
+
+func detectGoDependencies(sourceDir string) ([]collector.Dependency, error) {
+	cmd := exec.Command("go", "list", "-m", "-json", "all")
+	cmd.Dir = sourceDir
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list go modules: %w", err)
+	}
+
+	var deps []collector.Dependency
+	decoder := json.NewDecoder(strings.NewReader(string(output)))
+	for decoder.More() {
+		var mod goModule
+		if err := decoder.Decode(&mod); err != nil {
+			break
+		}
+		deps = append(deps, collector.Dependency{
+			Name:    mod.Path,
+			Version: mod.Version,
+		})
+	}
+
+	return deps, nil
+}

--- a/api-collector-go/echo/resolver.go
+++ b/api-collector-go/echo/resolver.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -187,8 +188,9 @@ func inferTypeFromExpr(expr ast.Expr) string {
 }
 
 type TypeResolver struct {
-	structRegistry map[string]StructDef
-	resolving      map[string]bool
+	structRegistry    map[string]StructDef
+	resolving         map[string]bool
+	dependencyResolver collector.DependencyResolver
 }
 
 func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
@@ -196,6 +198,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 		structRegistry: structs,
 		resolving:      make(map[string]bool),
 	}
+}
+
+func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 var goPrimitives = map[string]string{
@@ -246,6 +252,13 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		if r.dependencyResolver != nil {
+			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
+				sd := resolvedTypeToStructDef(rt)
+				r.structRegistry[typeName] = sd
+				return r.Resolve(typeName)
+			}
+		}
 		return model.SingleModel(typeName)
 	}
 
@@ -307,6 +320,23 @@ func parseMapType(typeName string) (string, string) {
 		}
 	}
 	return "string", "interface{}"
+}
+
+func resolvedTypeToStructDef(rt *collector.ResolvedType) StructDef {
+	sd := StructDef{
+		Name: rt.Name,
+	}
+	for _, f := range rt.Fields {
+		sf := StructField{
+			Name: f.Name,
+			Type: f.Type,
+		}
+		if !f.Required {
+			sf.BindingTag = ""
+		}
+		sd.Fields = append(sd.Fields, sf)
+	}
+	return sd
 }
 
 func resolveVarType(typeName string, handlerKey string, varTypeMaps map[string]map[string]string) string {

--- a/api-collector-go/fiber/resolver.go
+++ b/api-collector-go/fiber/resolver.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -187,8 +188,9 @@ func inferTypeFromExpr(expr ast.Expr) string {
 }
 
 type TypeResolver struct {
-	structRegistry map[string]StructDef
-	resolving      map[string]bool
+	structRegistry    map[string]StructDef
+	resolving         map[string]bool
+	dependencyResolver collector.DependencyResolver
 }
 
 func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
@@ -196,6 +198,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 		structRegistry: structs,
 		resolving:      make(map[string]bool),
 	}
+}
+
+func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 var goPrimitives = map[string]string{
@@ -250,6 +256,13 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		if r.dependencyResolver != nil {
+			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
+				sd := resolvedTypeToStructDef(rt)
+				r.structRegistry[typeName] = sd
+				return r.Resolve(typeName)
+			}
+		}
 		return model.SingleModel(typeName)
 	}
 
@@ -311,6 +324,23 @@ func parseMapType(typeName string) (string, string) {
 		}
 	}
 	return "string", "interface{}"
+}
+
+func resolvedTypeToStructDef(rt *collector.ResolvedType) StructDef {
+	sd := StructDef{
+		Name: rt.Name,
+	}
+	for _, f := range rt.Fields {
+		sf := StructField{
+			Name: f.Name,
+			Type: f.Type,
+		}
+		if !f.Required {
+			sf.BindingTag = ""
+		}
+		sd.Fields = append(sd.Fields, sf)
+	}
+	return sd
 }
 
 func resolveVarType(typeName string, handlerKey string, varTypeMaps map[string]map[string]string) string {

--- a/api-collector-go/gin/resolver.go
+++ b/api-collector-go/gin/resolver.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -192,8 +193,9 @@ func inferTypeFromExpr(expr ast.Expr) string {
 
 // TypeResolver resolves Go type names to ObjectModel schemas.
 type TypeResolver struct {
-	structRegistry map[string]StructDef
-	resolving      map[string]bool
+	structRegistry    map[string]StructDef
+	resolving         map[string]bool
+	dependencyResolver collector.DependencyResolver
 }
 
 // NewTypeResolver creates a new TypeResolver with the given struct definitions.
@@ -202,6 +204,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 		structRegistry: structs,
 		resolving:      make(map[string]bool),
 	}
+}
+
+func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 var goPrimitives = map[string]string{
@@ -257,6 +263,13 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		if r.dependencyResolver != nil {
+			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
+				sd := resolvedTypeToStructDef(rt)
+				r.structRegistry[typeName] = sd
+				return r.Resolve(typeName)
+			}
+		}
 		return model.SingleModel(typeName)
 	}
 
@@ -305,7 +318,7 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 // parseMapType extracts key and value types from "map[K]V".
 func parseMapType(typeName string) (string, string) {
-	inner := typeName[4:] // strip "map["
+	inner := typeName[4:]
 	depth := 1
 	for i, c := range inner {
 		switch c {
@@ -319,4 +332,21 @@ func parseMapType(typeName string) (string, string) {
 		}
 	}
 	return "string", "interface{}"
+}
+
+func resolvedTypeToStructDef(rt *collector.ResolvedType) StructDef {
+	sd := StructDef{
+		Name: rt.Name,
+	}
+	for _, f := range rt.Fields {
+		sf := StructField{
+			Name: f.Name,
+			Type: f.Type,
+		}
+		if !f.Required {
+			sf.BindingTag = ""
+		}
+		sd.Fields = append(sd.Fields, sf)
+	}
+	return sd
 }

--- a/api-collector-go/gin/resolver_test.go
+++ b/api-collector-go/gin/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"testing"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -259,4 +260,75 @@ func TestResolve_CircularReference(t *testing.T) {
 	if !nextField.Model.IsRef() {
 		t.Errorf("Expected ref model for circular reference, got kind=%s", nextField.Model.Kind)
 	}
+}
+
+type mockGoDepResolver struct {
+	types map[string]*collector.ResolvedType
+}
+
+func (m *mockGoDepResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return nil, nil
+}
+
+func (m *mockGoDepResolver) ResolveType(typeName string) *collector.ResolvedType {
+	if rt, ok := m.types[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
+func TestResolve_DependencyResolverFallback(t *testing.T) {
+	localStructs := map[string]StructDef{
+		"LocalDTO": {
+			Name: "LocalDTO",
+			Fields: []StructField{
+				{Name: "ID", Type: "int64", JsonTag: "id"},
+			},
+		},
+	}
+
+	depResolver := &mockGoDepResolver{
+		types: map[string]*collector.ResolvedType{
+			"ExternalDTO": {
+				Name: "ExternalDTO",
+				Fields: []collector.ResolvedField{
+					{Name: "code", Type: "string", Required: true},
+					{Name: "value", Type: "int", Required: false},
+				},
+			},
+		},
+	}
+
+	r := NewTypeResolver(localStructs)
+	r.SetDependencyResolver(depResolver)
+
+	t.Run("local struct resolved normally", func(t *testing.T) {
+		result := r.Resolve("LocalDTO")
+		if !result.IsObject() {
+			t.Fatalf("Expected object, got %s", result.Kind)
+		}
+		if result.TypeName != "LocalDTO" {
+			t.Errorf("Expected typeName 'LocalDTO', got '%s'", result.TypeName)
+		}
+	})
+
+	t.Run("external struct resolved via dependency resolver", func(t *testing.T) {
+		result := r.Resolve("ExternalDTO")
+		if !result.IsObject() {
+			t.Fatalf("Expected object, got %s", result.Kind)
+		}
+		if result.TypeName != "ExternalDTO" {
+			t.Errorf("Expected typeName 'ExternalDTO', got '%s'", result.TypeName)
+		}
+		if len(result.Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+		}
+	})
+
+	t.Run("unknown type still returns single", func(t *testing.T) {
+		result := r.Resolve("CompletelyUnknown")
+		if !result.IsSingle() {
+			t.Errorf("Expected single for unknown type, got %s", result.Kind)
+		}
+	})
 }

--- a/api-collector-java/feign/parser.go
+++ b/api-collector-java/feign/parser.go
@@ -4,6 +4,7 @@ package feign
 import (
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
@@ -11,6 +12,7 @@ import (
 // Parser extracts Feign client endpoints from parsed Java classes.
 type Parser struct {
 	dependencyResolver resolver.DependencyResolver
+	collectorDepResolver collector.DependencyResolver
 }
 
 // NewParser creates a new Feign client parser.
@@ -22,6 +24,10 @@ func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
 	p.dependencyResolver = dr
 }
 
+func (p *Parser) SetCollectorDependencyResolver(cdr collector.DependencyResolver) {
+	p.collectorDepResolver = cdr
+}
+
 // ExtractClients extracts Feign clients from parse results.
 // It supports both Spring Cloud OpenFeign (Spring MVC annotations) and
 // Netflix Feign (@RequestLine annotations).
@@ -30,6 +36,8 @@ func (p *Parser) ExtractClients(results []parser.ParseResult) []FeignClient {
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
 	if p.dependencyResolver != nil {
 		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	} else if p.collectorDepResolver != nil {
+		typeResolver.SetCollectorDependencyResolver(p.collectorDepResolver)
 	}
 
 	var clients []FeignClient

--- a/api-collector-java/jaxrs/parser.go
+++ b/api-collector-java/jaxrs/parser.go
@@ -5,12 +5,14 @@ import (
 	"path"
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
 type Parser struct {
 	dependencyResolver resolver.DependencyResolver
+	collectorDepResolver collector.DependencyResolver
 }
 
 // NewParser creates a new JAX-RS parser.
@@ -22,12 +24,18 @@ func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
 	p.dependencyResolver = dr
 }
 
+func (p *Parser) SetCollectorDependencyResolver(cdr collector.DependencyResolver) {
+	p.collectorDepResolver = cdr
+}
+
 // ExtractResources extracts JAX-RS resources from parse results.
 func (p *Parser) ExtractResources(results []parser.ParseResult) []Resource {
 	classRegistry := buildClassRegistry(results)
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
 	if p.dependencyResolver != nil {
 		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	} else if p.collectorDepResolver != nil {
+		typeResolver.SetCollectorDependencyResolver(p.collectorDepResolver)
 	}
 
 	var resources []Resource

--- a/api-collector-java/maven/dep_resolver.go
+++ b/api-collector-java/maven/dep_resolver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 )
 
@@ -114,6 +115,57 @@ func (r *MavenDependencyResolver) fetchSource(className string) (string, error) 
 	}
 
 	return source, nil
+}
+
+func (r *MavenDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	deps, err := detectDependencies(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []collector.Dependency
+	for _, d := range deps {
+		result = append(result, collector.Dependency{
+			Name:    d.ArtifactID,
+			Version: d.Version,
+		})
+	}
+	return result, nil
+}
+
+func (r *MavenDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
+	class := r.ResolveClass(typeName)
+	if class == nil {
+		return nil
+	}
+
+	rt := &collector.ResolvedType{
+		Name:               class.Name,
+		TypeParameters:     class.TypeParameters,
+		SuperClass:         class.SuperClass,
+		SuperClassTypeArgs: class.SuperClassTypeArgs,
+		IsInterface:        class.IsInterface,
+		Interfaces:         class.Interfaces,
+	}
+
+	for _, f := range class.Fields {
+		if f.IsStatic || f.IsFinal {
+			continue
+		}
+		required := true
+		for _, ann := range f.Annotations {
+			if ann.Name == "Nullable" || ann.Name == "Null" {
+				required = false
+			}
+		}
+		rt.Fields = append(rt.Fields, collector.ResolvedField{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: required,
+		})
+	}
+
+	return rt
 }
 
 func extractSourceFromMarkdown(raw string) (string, error) {

--- a/api-collector-java/resolver/resolver.go
+++ b/api-collector-java/resolver/resolver.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	model "github.com/tangcent/apilot/api-model"
 )
@@ -68,6 +69,47 @@ func NewTypeResolver(classes []parser.Class) *TypeResolver {
 
 func (r *TypeResolver) SetDependencyResolver(dr DependencyResolver) {
 	r.dependencyResolver = dr
+}
+
+func (r *TypeResolver) SetCollectorDependencyResolver(cdr collector.DependencyResolver) {
+	r.dependencyResolver = &collectorDependencyAdapter{resolver: cdr}
+}
+
+type collectorDependencyAdapter struct {
+	resolver collector.DependencyResolver
+}
+
+func (a *collectorDependencyAdapter) ResolveClass(className string) *parser.Class {
+	rt := a.resolver.ResolveType(className)
+	if rt == nil {
+		return nil
+	}
+	return resolvedTypeToClass(rt)
+}
+
+func resolvedTypeToClass(rt *collector.ResolvedType) *parser.Class {
+	class := &parser.Class{
+		Name:               rt.Name,
+		TypeParameters:     rt.TypeParameters,
+		SuperClass:         rt.SuperClass,
+		SuperClassTypeArgs: rt.SuperClassTypeArgs,
+		IsInterface:        rt.IsInterface,
+		Interfaces:         rt.Interfaces,
+	}
+
+	for _, f := range rt.Fields {
+		var annotations []parser.Annotation
+		if !f.Required {
+			annotations = append(annotations, parser.Annotation{Name: "Nullable"})
+		}
+		class.Fields = append(class.Fields, parser.Field{
+			Name:        f.Name,
+			Type:        f.Type,
+			Annotations: annotations,
+		})
+	}
+
+	return class
 }
 
 func (r *TypeResolver) Resolve(rawType string, typeBindings map[string]string) *model.ObjectModel {

--- a/api-collector-java/resolver/resolver_test.go
+++ b/api-collector-java/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"testing"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	model "github.com/tangcent/apilot/api-model"
 )
@@ -721,6 +722,21 @@ func (m *mockDependencyResolver) ResolveClass(className string) *parser.Class {
 	return nil
 }
 
+type mockCollectorDependencyResolver struct {
+	types map[string]*collector.ResolvedType
+}
+
+func (m *mockCollectorDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return nil, nil
+}
+
+func (m *mockCollectorDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
+	if rt, ok := m.types[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
 func TestResolve_DependencyResolverFallback(t *testing.T) {
 	localClasses := []parser.Class{
 		{
@@ -835,5 +851,89 @@ func TestResolve_NoDependencyResolver(t *testing.T) {
 	}
 	if result.TypeName != "UnknownType" {
 		t.Errorf("Expected typeName 'UnknownType', got '%s'", result.TypeName)
+	}
+}
+
+func TestResolve_CollectorDependencyResolverFallback(t *testing.T) {
+	localClasses := []parser.Class{
+		{
+			Name: "LocalDTO",
+			Fields: []parser.Field{
+				{Name: "id", Type: "Long"},
+			},
+		},
+	}
+
+	cdr := &mockCollectorDependencyResolver{
+		types: map[string]*collector.ResolvedType{
+			"ExternalDTO": {
+				Name: "ExternalDTO",
+				Fields: []collector.ResolvedField{
+					{Name: "code", Type: "String", Required: true},
+					{Name: "value", Type: "int", Required: false},
+				},
+			},
+		},
+	}
+
+	r := NewTypeResolver(localClasses)
+	r.SetCollectorDependencyResolver(cdr)
+
+	t.Run("local class resolved normally", func(t *testing.T) {
+		result := r.Resolve("LocalDTO", nil)
+		if result.Kind != model.KindObject {
+			t.Fatalf("Expected KindObject, got %s", result.Kind)
+		}
+		if result.TypeName != "LocalDTO" {
+			t.Errorf("Expected typeName 'LocalDTO', got '%s'", result.TypeName)
+		}
+	})
+
+	t.Run("external class resolved via collector dependency resolver", func(t *testing.T) {
+		result := r.Resolve("ExternalDTO", nil)
+		if result.Kind != model.KindObject {
+			t.Fatalf("Expected KindObject, got %s", result.Kind)
+		}
+		if result.TypeName != "ExternalDTO" {
+			t.Errorf("Expected typeName 'ExternalDTO', got '%s'", result.TypeName)
+		}
+		if len(result.Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+		}
+		codeField := result.Fields["code"]
+		if codeField == nil || codeField.Model.TypeName != model.JsonTypeString {
+			t.Errorf("Expected code field typeName 'string', got '%v'", codeField)
+		}
+	})
+
+	t.Run("unknown type still returns SingleModel", func(t *testing.T) {
+		result := r.Resolve("CompletelyUnknown", nil)
+		if result.Kind != model.KindSingle {
+			t.Fatalf("Expected KindSingle, got %s", result.Kind)
+		}
+	})
+}
+
+func TestResolve_CollectorDependencyResolverPreferredOverNone(t *testing.T) {
+	cdr := &mockCollectorDependencyResolver{
+		types: map[string]*collector.ResolvedType{
+			"DepClass": {
+				Name: "DepClass",
+				Fields: []collector.ResolvedField{
+					{Name: "name", Type: "String", Required: true},
+				},
+			},
+		},
+	}
+
+	r := NewTypeResolver(nil)
+	r.SetCollectorDependencyResolver(cdr)
+
+	result := r.Resolve("DepClass", nil)
+	if result.Kind != model.KindObject {
+		t.Fatalf("Expected KindObject, got %s", result.Kind)
+	}
+	if result.TypeName != "DepClass" {
+		t.Errorf("Expected typeName 'DepClass', got '%s'", result.TypeName)
 	}
 }

--- a/api-collector-java/springmvc/parser.go
+++ b/api-collector-java/springmvc/parser.go
@@ -4,12 +4,14 @@ import (
 	"path"
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	"github.com/tangcent/apilot/api-collector-java/parser"
 	"github.com/tangcent/apilot/api-collector-java/resolver"
 )
 
 type Parser struct {
 	dependencyResolver resolver.DependencyResolver
+	collectorDepResolver collector.DependencyResolver
 }
 
 func NewParser() *Parser {
@@ -20,11 +22,17 @@ func (p *Parser) SetDependencyResolver(dr resolver.DependencyResolver) {
 	p.dependencyResolver = dr
 }
 
+func (p *Parser) SetCollectorDependencyResolver(cdr collector.DependencyResolver) {
+	p.collectorDepResolver = cdr
+}
+
 func (p *Parser) ExtractControllers(results []parser.ParseResult) []Controller {
 	classRegistry := buildClassRegistry(results)
 	typeResolver := resolver.NewTypeResolver(flattenClasses(results))
 	if p.dependencyResolver != nil {
 		typeResolver.SetDependencyResolver(p.dependencyResolver)
+	} else if p.collectorDepResolver != nil {
+		typeResolver.SetCollectorDependencyResolver(p.collectorDepResolver)
 	}
 
 	var controllers []Controller

--- a/api-collector-node/collector.go
+++ b/api-collector-node/collector.go
@@ -13,14 +13,19 @@ import (
 )
 
 // NodeCollector parses TypeScript/JavaScript source trees for API route definitions.
-type NodeCollector struct{}
+type NodeCollector struct {
+	dependencyResolver collector.DependencyResolver
+}
 
-// New returns a new NodeCollector.
 func New() collector.Collector { return &NodeCollector{} }
 
 func (c *NodeCollector) Name() string { return "node" }
 
 func (c *NodeCollector) SupportedLanguages() []string { return []string{"typescript", "javascript"} }
+
+func (c *NodeCollector) SetDependencyResolver(dr collector.DependencyResolver) {
+	c.dependencyResolver = dr
+}
 
 // Collect walks the source directory and extracts endpoints from Express, Fastify, and NestJS sources.
 // Each framework parser is invoked concurrently. Results are merged into a
@@ -37,7 +42,12 @@ func (c *NodeCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEn
 		name  string
 		parse func(string) ([]collector.ApiEndpoint, error)
 	}{
-		{"express", express.Parse},
+		{"express", func(dir string) ([]collector.ApiEndpoint, error) {
+			if c.dependencyResolver != nil {
+				return express.ParseWithDependencyResolver(dir, c.dependencyResolver)
+			}
+			return express.Parse(dir)
+		}},
 		{"fastify", fastify.Parse},
 		{"nestjs", nestjs.Parse},
 	}

--- a/api-collector-node/dep_resolver.go
+++ b/api-collector-node/dep_resolver.go
@@ -1,0 +1,226 @@
+package nodecollector
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	collector "github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-collector-node/express"
+)
+
+type NodeDependencyResolver struct {
+	mu       sync.Mutex
+	sourceDir string
+	registry *express.TSTypeRegistry
+	cache    map[string]*collector.ResolvedType
+	misses   map[string]bool
+	loaded   bool
+}
+
+func NewNodeDependencyResolver(sourceDir string) *NodeDependencyResolver {
+	return &NodeDependencyResolver{
+		sourceDir: sourceDir,
+		registry:  express.NewTSTypeRegistry(),
+		cache:     make(map[string]*collector.ResolvedType),
+		misses:    make(map[string]bool),
+	}
+}
+
+func (r *NodeDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return detectNodeDependencies(sourceDir)
+}
+
+func (r *NodeDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cached, ok := r.cache[typeName]; ok {
+		return cached
+	}
+
+	if r.misses[typeName] {
+		return nil
+	}
+
+	if !r.loaded {
+		r.loadFromNodeModules()
+		r.loaded = true
+	}
+
+	rt := r.resolveFromRegistry(typeName)
+	if rt != nil {
+		r.cache[typeName] = rt
+		return rt
+	}
+
+	r.misses[typeName] = true
+	return nil
+}
+
+func (r *NodeDependencyResolver) loadFromNodeModules() {
+	nodeModulesDir := filepath.Join(r.sourceDir, "node_modules")
+	info, err := os.Stat(nodeModulesDir)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	entries, err := os.ReadDir(nodeModulesDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pkgDir := filepath.Join(nodeModulesDir, entry.Name())
+		if strings.HasPrefix(entry.Name(), "@") {
+			scopedEntries, err := os.ReadDir(pkgDir)
+			if err != nil {
+				continue
+			}
+			for _, scoped := range scopedEntries {
+				if scoped.IsDir() {
+					r.loadPackageTypes(filepath.Join(pkgDir, scoped.Name()))
+				}
+			}
+		} else {
+			r.loadPackageTypes(pkgDir)
+		}
+	}
+}
+
+func (r *NodeDependencyResolver) loadPackageTypes(pkgDir string) {
+	dtsFiles := findDTSFiles(pkgDir)
+	if len(dtsFiles) == 0 {
+		return
+	}
+
+	for _, f := range dtsFiles {
+		reg, err := express.ExtractTypesFromFile(f)
+		if err != nil {
+			continue
+		}
+		r.registry.Merge(reg)
+	}
+}
+
+func (r *NodeDependencyResolver) resolveFromRegistry(typeName string) *collector.ResolvedType {
+	baseName := typeName
+	if idx := strings.Index(typeName, "<"); idx != -1 {
+		baseName = typeName[:idx]
+	}
+
+	if iface, found := r.registry.Interfaces[baseName]; found {
+		return tsInterfaceToResolvedType(iface)
+	}
+
+	if alias, found := r.registry.TypeAliases[baseName]; found {
+		return tsTypeAliasToResolvedType(alias)
+	}
+
+	return nil
+}
+
+func tsInterfaceToResolvedType(iface *express.TSInterface) *collector.ResolvedType {
+	rt := &collector.ResolvedType{
+		Name:           iface.Name,
+		TypeParameters: iface.TypeParameters,
+		IsInterface:    true,
+	}
+
+	for _, f := range iface.Fields {
+		rt.Fields = append(rt.Fields, collector.ResolvedField{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: f.Required,
+		})
+	}
+
+	return rt
+}
+
+func tsTypeAliasToResolvedType(alias *express.TSTypeAlias) *collector.ResolvedType {
+	return &collector.ResolvedType{
+		Name:           alias.Name,
+		TypeParameters: alias.TypeParameters,
+		IsInterface:    false,
+	}
+}
+
+func findDTSFiles(dir string) []string {
+	var files []string
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == "node_modules" || name == ".git" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".d.ts") && !strings.HasSuffix(path, ".d.ts.map") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files
+}
+
+type packageJSON struct {
+	Name        string            `json:"name"`
+	Version     string            `json:"version"`
+	Dependencies map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+	PeerDependencies map[string]string `json:"peerDependencies"`
+}
+
+func detectNodeDependencies(sourceDir string) ([]collector.Dependency, error) {
+	pkgPath := filepath.Join(sourceDir, "package.json")
+	data, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return nil, nil
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil, fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	seen := make(map[string]bool)
+	var deps []collector.Dependency
+
+	addDep := func(name, version string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		cleanVersion := strings.TrimPrefix(version, "^")
+		cleanVersion = strings.TrimPrefix(cleanVersion, "~")
+		cleanVersion = strings.TrimPrefix(cleanVersion, ">=")
+		cleanVersion = strings.TrimPrefix(cleanVersion, "<=")
+		deps = append(deps, collector.Dependency{
+			Name:    name,
+			Version: cleanVersion,
+		})
+	}
+
+	for name, version := range pkg.Dependencies {
+		addDep(name, version)
+	}
+	for name, version := range pkg.DevDependencies {
+		addDep(name, version)
+	}
+	for name, version := range pkg.PeerDependencies {
+		addDep(name, version)
+	}
+
+	return deps, nil
+}

--- a/api-collector-node/express/parser.go
+++ b/api-collector-node/express/parser.go
@@ -89,6 +89,231 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	return allEndpoints, nil
 }
 
+func ParseWithDependencyResolver(sourceDir string, depResolver collector.DependencyResolver) ([]collector.ApiEndpoint, error) {
+	allFiles, err := discoverSourceFiles(sourceDir)
+	if err != nil || len(allFiles) == 0 {
+		return nil, nil
+	}
+
+	var tsFiles []string
+	var jsFiles []string
+	for _, f := range allFiles {
+		if strings.HasSuffix(f, ".ts") || strings.HasSuffix(f, ".tsx") {
+			tsFiles = append(tsFiles, f)
+		} else {
+			jsFiles = append(jsFiles, f)
+		}
+	}
+
+	typeRegistry := NewTSTypeRegistry()
+	if len(tsFiles) > 0 {
+		reg, err := ParseTSTypes(sourceDir)
+		if err == nil && reg != nil {
+			typeRegistry = reg
+		}
+	}
+
+	ctx := &parseContext{
+		typeRegistry:    typeRegistry,
+		dependencyResolver: depResolver,
+	}
+
+	ch := make(chan fileResult, len(allFiles))
+	var wg sync.WaitGroup
+
+	for _, path := range jsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := ctx.processJSFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	for _, path := range tsFiles {
+		wg.Add(1)
+		go func(filePath string) {
+			defer wg.Done()
+			res := ctx.processTSFile(filePath)
+			ch <- res
+		}(path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var allEndpoints []collector.ApiEndpoint
+	for res := range ch {
+		if res.err != nil {
+			continue
+		}
+		allEndpoints = append(allEndpoints, res.endpoints...)
+	}
+
+	if len(allEndpoints) == 0 {
+		return nil, nil
+	}
+
+	return allEndpoints, nil
+}
+
+type parseContext struct {
+	typeRegistry       *TSTypeRegistry
+	dependencyResolver collector.DependencyResolver
+}
+
+func (ctx *parseContext) processJSFile(filePath string) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(javascript.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := ctx.extractEndpoints(rootNode, source)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func (ctx *parseContext) processTSFile(filePath string) fileResult {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileResult{err: fmt.Errorf("failed to read file: %w", err)}
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(typescript.LanguageTypescript())
+	if err := p.SetLanguage(lang); err != nil {
+		return fileResult{err: fmt.Errorf("failed to set language: %w", err)}
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return fileResult{}
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	endpoints := ctx.extractEndpoints(rootNode, source)
+
+	return fileResult{endpoints: endpoints}
+}
+
+func (ctx *parseContext) extractEndpoints(rootNode *tree_sitter.Node, source []byte) []collector.ApiEndpoint {
+	var endpoints []collector.ApiEndpoint
+	var lastComment string
+
+	for i := uint(0); i < rootNode.ChildCount(); i++ {
+		child := rootNode.Child(i)
+
+		if child.Kind() == "comment" {
+			commentText := child.Utf8Text(source)
+			if isJSDocComment(commentText) {
+				lastComment = cleanJSDocComment(commentText)
+			} else {
+				lastComment = ""
+			}
+			continue
+		}
+
+		if child.Kind() == "expression_statement" {
+			ep := ctx.extractFromExpressionStatement(child, source, lastComment)
+			if ep != nil {
+				endpoints = append(endpoints, *ep)
+			}
+			lastComment = ""
+		} else {
+			lastComment = ""
+		}
+	}
+
+	return endpoints
+}
+
+func (ctx *parseContext) extractFromExpressionStatement(node *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
+		if child.Kind() == "call_expression" {
+			return ctx.extractFromCallExpression(child, source, description)
+		}
+	}
+	return nil
+}
+
+func (ctx *parseContext) extractFromCallExpression(callNode *tree_sitter.Node, source []byte, description string) *collector.ApiEndpoint {
+	method, isRoute := extractMethodInfo(callNode, source)
+	if !isRoute {
+		return nil
+	}
+
+	path, handlerName := extractCallArguments(callNode, source)
+	if path == "" {
+		return nil
+	}
+
+	standardPath := convertExpressPath(path)
+
+	ep := &collector.ApiEndpoint{
+		Name:        handlerName,
+		Path:        standardPath,
+		Method:      strings.ToUpper(method),
+		Protocol:    "http",
+		Description: description,
+	}
+
+	pathParams := extractPathParams(standardPath)
+	if len(pathParams) > 0 {
+		var params []collector.ApiParameter
+		for _, p := range pathParams {
+			params = append(params, collector.ApiParameter{
+				Name:     p.name,
+				In:       "path",
+				Required: true,
+				Type:     "text",
+			})
+		}
+		ep.Parameters = params
+	}
+
+	if ctx.typeRegistry != nil {
+		handlerInfo := AnalyzeExpressHandler(callNode, source)
+		if handlerInfo != nil {
+			reqBody, resBody := ResolveHandlerTypesWithDepResolver(handlerInfo, ctx.typeRegistry, ctx.dependencyResolver)
+			if reqBody != nil && !reqBody.IsNull() {
+				ep.RequestBody = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      reqBody,
+				}
+			}
+			if resBody != nil && !resBody.IsNull() {
+				ep.Response = &collector.ApiBody{
+					MediaType: "application/json",
+					Body:      resBody,
+				}
+			}
+		}
+	}
+
+	return ep
+}
+
 type fileResult struct {
 	endpoints []collector.ApiEndpoint
 	err       error

--- a/api-collector-node/express/resolver.go
+++ b/api-collector-node/express/resolver.go
@@ -3,6 +3,7 @@ package express
 import (
 	"strings"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -51,8 +52,9 @@ var tsCollectionTypes = map[string]bool{
 }
 
 type TSTypeResolver struct {
-	registry   *TSTypeRegistry
-	resolving  map[string]bool
+	registry           *TSTypeRegistry
+	resolving          map[string]bool
+	dependencyResolver collector.DependencyResolver
 }
 
 func NewTSTypeResolver(registry *TSTypeRegistry) *TSTypeResolver {
@@ -60,6 +62,10 @@ func NewTSTypeResolver(registry *TSTypeRegistry) *TSTypeResolver {
 		registry:  registry,
 		resolving: make(map[string]bool),
 	}
+}
+
+func (r *TSTypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 func (r *TSTypeResolver) Resolve(rawType string, typeBindings map[string]string) *model.ObjectModel {
@@ -119,6 +125,26 @@ func (r *TSTypeResolver) Resolve(rawType string, typeBindings map[string]string)
 
 	if alias, found := r.registry.TypeAliases[baseName]; found {
 		return r.resolveTypeAlias(alias, typeArgs, typeBindings)
+	}
+
+	if r.dependencyResolver != nil {
+		if rt := r.dependencyResolver.ResolveType(baseName); rt != nil {
+			if iface, ok := r.registry.Interfaces[baseName]; !ok {
+				iface = &TSInterface{
+					Name:           rt.Name,
+					TypeParameters: rt.TypeParameters,
+				}
+				for _, f := range rt.Fields {
+					iface.Fields = append(iface.Fields, TSField{
+						Name:     f.Name,
+						Type:     f.Type,
+						Required: f.Required,
+					})
+				}
+				r.registry.Interfaces[baseName] = iface
+			}
+			return r.Resolve(rawType, typeBindings)
+		}
 	}
 
 	return model.SingleModel(rawType)
@@ -362,7 +388,14 @@ func parseTSTypeArgs(rawType string) (string, []string) {
 }
 
 func ResolveHandlerTypes(handlerInfo *ExpressHandlerInfo, registry *TSTypeRegistry) (reqBody *model.ObjectModel, resBody *model.ObjectModel) {
+	return ResolveHandlerTypesWithDepResolver(handlerInfo, registry, nil)
+}
+
+func ResolveHandlerTypesWithDepResolver(handlerInfo *ExpressHandlerInfo, registry *TSTypeRegistry, depResolver collector.DependencyResolver) (reqBody *model.ObjectModel, resBody *model.ObjectModel) {
 	resolver := NewTSTypeResolver(registry)
+	if depResolver != nil {
+		resolver.SetDependencyResolver(depResolver)
+	}
 
 	if handlerInfo.ReqBodyType != "" {
 		reqBody = resolver.Resolve(handlerInfo.ReqBodyType, nil)

--- a/api-collector-node/express/resolver_test.go
+++ b/api-collector-node/express/resolver_test.go
@@ -3,6 +3,7 @@ package express
 import (
 	"testing"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -456,6 +457,100 @@ func TestResolveHandlerTypes(t *testing.T) {
 	} else {
 		if _, ok := resBody.Fields["id"]; !ok {
 			t.Error("resBody should have 'id' field")
+		}
+	}
+}
+
+type mockDepResolver struct {
+	types map[string]*collector.ResolvedType
+}
+
+func (m *mockDepResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return nil, nil
+}
+
+func (m *mockDepResolver) ResolveType(typeName string) *collector.ResolvedType {
+	if rt, ok := m.types[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
+func TestTSTypeResolver_DependencyResolverFallback(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	resolver := NewTSTypeResolver(registry)
+
+	depResolver := &mockDepResolver{
+		types: map[string]*collector.ResolvedType{
+			"ExternalDTO": {
+				Name: "ExternalDTO",
+				Fields: []collector.ResolvedField{
+					{Name: "code", Type: "string", Required: true},
+					{Name: "value", Type: "number", Required: false},
+				},
+			},
+		},
+	}
+	resolver.SetDependencyResolver(depResolver)
+
+	t.Run("unknown type resolved via dependency resolver", func(t *testing.T) {
+		result := resolver.Resolve("ExternalDTO", nil)
+		if !result.IsObject() {
+			t.Fatalf("Expected object, got %s", result.Kind)
+		}
+		if result.TypeName != "ExternalDTO" {
+			t.Errorf("Expected typeName 'ExternalDTO', got '%s'", result.TypeName)
+		}
+		if len(result.Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+		}
+	})
+
+	t.Run("completely unknown type still returns single", func(t *testing.T) {
+		result := resolver.Resolve("CompletelyUnknown", nil)
+		if !result.IsSingle() {
+			t.Errorf("Expected single for unknown type, got %s", result.Kind)
+		}
+	})
+}
+
+func TestResolveHandlerTypesWithDepResolver(t *testing.T) {
+	registry := NewTSTypeRegistry()
+	registry.Interfaces["CreateUserRequest"] = &TSInterface{
+		Name: "CreateUserRequest",
+		Fields: []TSField{
+			{Name: "name", Type: "string", Required: true},
+		},
+	}
+
+	depResolver := &mockDepResolver{
+		types: map[string]*collector.ResolvedType{
+			"UserResponse": {
+				Name: "UserResponse",
+				Fields: []collector.ResolvedField{
+					{Name: "id", Type: "number", Required: true},
+					{Name: "name", Type: "string", Required: true},
+				},
+			},
+		},
+	}
+
+	handlerInfo := &ExpressHandlerInfo{
+		ReqBodyType: "CreateUserRequest",
+		ResBodyType: "UserResponse",
+	}
+
+	reqBody, resBody := ResolveHandlerTypesWithDepResolver(handlerInfo, registry, depResolver)
+
+	if reqBody == nil || !reqBody.IsObject() {
+		t.Errorf("reqBody should be object, got %v", reqBody)
+	}
+
+	if resBody == nil || !resBody.IsObject() {
+		t.Errorf("resBody should be object, got %v", resBody)
+	} else {
+		if _, ok := resBody.Fields["id"]; !ok {
+			t.Error("resBody should have 'id' field from dependency resolver")
 		}
 	}
 }

--- a/api-collector-node/express/tsparser.go
+++ b/api-collector-node/express/tsparser.go
@@ -24,7 +24,7 @@ func ParseTSTypes(sourceDir string) (*TSTypeRegistry, error) {
 		wg.Add(1)
 		go func(filePath string) {
 			defer wg.Done()
-			registry, err := extractTypesFromFile(filePath)
+			registry, err := ExtractTypesFromFile(filePath)
 			if err != nil {
 				ch <- NewTSTypeRegistry()
 				return
@@ -63,7 +63,7 @@ func discoverTSFiles(sourceDir string) ([]string, error) {
 	return tsFiles, nil
 }
 
-func extractTypesFromFile(filePath string) (*TSTypeRegistry, error) {
+func ExtractTypesFromFile(filePath string) (*TSTypeRegistry, error) {
 	source, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)

--- a/api-collector-python/collector.go
+++ b/api-collector-python/collector.go
@@ -13,14 +13,19 @@ import (
 )
 
 // PythonCollector parses Python source trees for API route definitions.
-type PythonCollector struct{}
+type PythonCollector struct {
+	dependencyResolver collector.DependencyResolver
+}
 
-// New returns a new PythonCollector.
 func New() collector.Collector { return &PythonCollector{} }
 
 func (c *PythonCollector) Name() string { return "python" }
 
 func (c *PythonCollector) SupportedLanguages() []string { return []string{"python"} }
+
+func (c *PythonCollector) SetDependencyResolver(dr collector.DependencyResolver) {
+	c.dependencyResolver = dr
+}
 
 // Collect walks the source directory and extracts endpoints from FastAPI, Django REST, and Flask sources.
 // Each framework parser is invoked concurrently. Results are merged into a

--- a/api-collector-python/dep_resolver.go
+++ b/api-collector-python/dep_resolver.go
@@ -1,0 +1,224 @@
+package pycollector
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	collector "github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-collector-python/fastapi"
+)
+
+type PythonDependencyResolver struct {
+	mu        sync.Mutex
+	sourceDir string
+	cache     map[string]*collector.ResolvedType
+	misses    map[string]bool
+	loaded    bool
+}
+
+func NewPythonDependencyResolver(sourceDir string) *PythonDependencyResolver {
+	return &PythonDependencyResolver{
+		sourceDir: sourceDir,
+		cache:     make(map[string]*collector.ResolvedType),
+		misses:    make(map[string]bool),
+	}
+}
+
+func (r *PythonDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return detectPythonDependencies(sourceDir)
+}
+
+func (r *PythonDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cached, ok := r.cache[typeName]; ok {
+		return cached
+	}
+
+	if r.misses[typeName] {
+		return nil
+	}
+
+	if !r.loaded {
+		r.loadFromSitePackages()
+		r.loaded = true
+	}
+
+	rt := r.resolveFromCache(typeName)
+	if rt != nil {
+		return rt
+	}
+
+	r.misses[typeName] = true
+	return nil
+}
+
+func (r *PythonDependencyResolver) loadFromSitePackages() {
+	sitePackagesDir, err := findSitePackages()
+	if err != nil || sitePackagesDir == "" {
+		return
+	}
+
+	entries, err := os.ReadDir(sitePackagesDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pkgDir := filepath.Join(sitePackagesDir, entry.Name())
+		if strings.HasPrefix(entry.Name(), "_") || strings.HasSuffix(entry.Name(), ".dist-info") {
+			continue
+		}
+
+		r.loadPackageTypes(pkgDir)
+	}
+}
+
+func (r *PythonDependencyResolver) loadPackageTypes(pkgDir string) {
+	pyFiles := findPyFiles(pkgDir)
+	if len(pyFiles) == 0 {
+		return
+	}
+
+	for _, f := range pyFiles {
+		models, err := fastapi.ExtractPydanticModelsFromFile(f)
+		if err != nil {
+			continue
+		}
+		for name, md := range models {
+			rt := pydanticModelToResolvedType(md)
+			r.cache[name] = rt
+		}
+	}
+}
+
+func (r *PythonDependencyResolver) resolveFromCache(typeName string) *collector.ResolvedType {
+	if rt, ok := r.cache[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
+func pydanticModelToResolvedType(md fastapi.PydanticModel) *collector.ResolvedType {
+	rt := &collector.ResolvedType{
+		Name:           md.Name,
+		IsInterface:    false,
+	}
+
+	for _, embedded := range md.EmbeddedTypes {
+		rt.Interfaces = append(rt.Interfaces, embedded)
+	}
+
+	for _, f := range md.Fields {
+		rt.Fields = append(rt.Fields, collector.ResolvedField{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: f.Required,
+		})
+	}
+
+	return rt
+}
+
+func findPyFiles(dir string) []string {
+	var files []string
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == "__pycache__" || name == ".git" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".py") && !strings.HasSuffix(path, "__init__.py") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files
+}
+
+func findSitePackages() (string, error) {
+	cmd := exec.Command("python3", "-c", "import site; print(site.getsitepackages()[0])")
+	output, err := cmd.Output()
+	if err != nil {
+		cmd = exec.Command("python", "-c", "import site; print(site.getsitepackages()[0])")
+		output, err = cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to find site-packages: %w", err)
+		}
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+type pipPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func detectPythonDependencies(sourceDir string) ([]collector.Dependency, error) {
+	reqFile := filepath.Join(sourceDir, "requirements.txt")
+	data, err := os.ReadFile(reqFile)
+	if err != nil {
+		return nil, nil
+	}
+
+	var deps []collector.Dependency
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+			continue
+		}
+
+		name, version := parseRequirementLine(line)
+		deps = append(deps, collector.Dependency{
+			Name:    name,
+			Version: version,
+		})
+	}
+
+	return deps, nil
+}
+
+func parseRequirementLine(line string) (name, version string) {
+	ops := []string{"==", ">=", "<=", "~=", "!=", "~>", "==="}
+	for _, op := range ops {
+		if idx := strings.Index(line, op); idx != -1 {
+			name = strings.TrimSpace(line[:idx])
+			rest := strings.TrimSpace(line[idx+len(op):])
+			if commaIdx := strings.Index(rest, ","); commaIdx != -1 {
+				version = strings.TrimSpace(rest[:commaIdx])
+			} else {
+				version = rest
+			}
+			return
+		}
+	}
+
+	if idx := strings.Index(line, ">"); idx != -1 {
+		name = strings.TrimSpace(line[:idx])
+		version = strings.TrimSpace(line[idx+1:])
+		return
+	}
+	if idx := strings.Index(line, "<"); idx != -1 {
+		name = strings.TrimSpace(line[:idx])
+		version = strings.TrimSpace(line[idx+1:])
+		return
+	}
+
+	name = strings.TrimSpace(line)
+	return
+}

--- a/api-collector-python/fastapi/resolver.go
+++ b/api-collector-python/fastapi/resolver.go
@@ -1,10 +1,14 @@
 package fastapi
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	python "github.com/tree-sitter/tree-sitter-python/bindings/go"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -79,6 +83,30 @@ func ExtractPydanticModels(rootNode *tree_sitter.Node, source []byte) map[string
 	}
 
 	return models
+}
+
+func ExtractPydanticModelsFromFile(filePath string) (map[string]PydanticModel, error) {
+	source, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	p := tree_sitter.NewParser()
+	defer p.Close()
+
+	lang := tree_sitter.NewLanguage(python.Language())
+	if err := p.SetLanguage(lang); err != nil {
+		return nil, fmt.Errorf("failed to set language: %w", err)
+	}
+
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		return nil, nil
+	}
+	defer tree.Close()
+
+	rootNode := tree.RootNode()
+	return ExtractPydanticModels(rootNode, source), nil
 }
 
 type classInfo struct {
@@ -317,8 +345,9 @@ func extractFieldTypeInfoFromArgs(argList *tree_sitter.Node, source []byte, call
 }
 
 type PythonTypeResolver struct {
-	modelRegistry map[string]PydanticModel
-	resolving     map[string]bool
+	modelRegistry     map[string]PydanticModel
+	resolving         map[string]bool
+	dependencyResolver collector.DependencyResolver
 }
 
 func NewPythonTypeResolver(models map[string]PydanticModel) *PythonTypeResolver {
@@ -326,6 +355,10 @@ func NewPythonTypeResolver(models map[string]PydanticModel) *PythonTypeResolver 
 		modelRegistry: models,
 		resolving:     make(map[string]bool),
 	}
+}
+
+func (r *PythonTypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
+	r.dependencyResolver = dr
 }
 
 func (r *PythonTypeResolver) Resolve(typeText string) *model.ObjectModel {
@@ -447,7 +480,32 @@ func (r *PythonTypeResolver) Resolve(typeText string) *model.ObjectModel {
 		}
 	}
 
+	if r.dependencyResolver != nil {
+		if rt := r.dependencyResolver.ResolveType(baseName); rt != nil {
+			md := resolvedTypeToPydanticModel(rt)
+			r.modelRegistry[baseName] = md
+			return r.Resolve(typeText)
+		}
+	}
+
 	return model.SingleModel(typeText)
+}
+
+func resolvedTypeToPydanticModel(rt *collector.ResolvedType) PydanticModel {
+	md := PydanticModel{
+		Name: rt.Name,
+	}
+	for _, f := range rt.Fields {
+		md.Fields = append(md.Fields, PydanticField{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: f.Required,
+		})
+	}
+	for _, iface := range rt.Interfaces {
+		md.EmbeddedTypes = append(md.EmbeddedTypes, iface)
+	}
+	return md
 }
 
 func (r *PythonTypeResolver) resolveFieldModel(f PydanticField) *model.FieldModel {

--- a/api-collector-python/fastapi/resolver_test.go
+++ b/api-collector-python/fastapi/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	python "github.com/tree-sitter/tree-sitter-python/bindings/go"
 
+	collector "github.com/tangcent/apilot/api-collector"
 	model "github.com/tangcent/apilot/api-model"
 )
 
@@ -428,4 +429,75 @@ func createTestParser(t *testing.T) *tree_sitter.Parser {
 		t.Fatalf("failed to set language: %v", err)
 	}
 	return p
+}
+
+type mockPyDepResolver struct {
+	types map[string]*collector.ResolvedType
+}
+
+func (m *mockPyDepResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return nil, nil
+}
+
+func (m *mockPyDepResolver) ResolveType(typeName string) *collector.ResolvedType {
+	if rt, ok := m.types[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
+func TestPythonTypeResolver_DependencyResolverFallback(t *testing.T) {
+	localModels := map[string]PydanticModel{
+		"LocalDTO": {
+			Name: "LocalDTO",
+			Fields: []PydanticField{
+				{Name: "id", Type: "int", Required: true},
+			},
+		},
+	}
+
+	depResolver := &mockPyDepResolver{
+		types: map[string]*collector.ResolvedType{
+			"ExternalDTO": {
+				Name: "ExternalDTO",
+				Fields: []collector.ResolvedField{
+					{Name: "code", Type: "str", Required: true},
+					{Name: "value", Type: "int", Required: false},
+				},
+			},
+		},
+	}
+
+	r := NewPythonTypeResolver(localModels)
+	r.SetDependencyResolver(depResolver)
+
+	t.Run("local model resolved normally", func(t *testing.T) {
+		result := r.Resolve("LocalDTO")
+		if !result.IsObject() {
+			t.Fatalf("Expected object, got %s", result.Kind)
+		}
+		if result.TypeName != "LocalDTO" {
+			t.Errorf("Expected typeName 'LocalDTO', got '%s'", result.TypeName)
+		}
+	})
+
+	t.Run("external model resolved via dependency resolver", func(t *testing.T) {
+		result := r.Resolve("ExternalDTO")
+		if !result.IsObject() {
+			t.Fatalf("Expected object, got %s", result.Kind)
+		}
+		if result.TypeName != "ExternalDTO" {
+			t.Errorf("Expected typeName 'ExternalDTO', got '%s'", result.TypeName)
+		}
+		if len(result.Fields) != 2 {
+			t.Fatalf("Expected 2 fields, got %d", len(result.Fields))
+		}
+	})
+
+	t.Run("unknown type still returns single", func(t *testing.T) {
+		result := r.Resolve("CompletelyUnknown")
+		if !result.IsSingle() {
+			t.Errorf("Expected single for unknown type, got %s", result.Kind)
+		}
+	})
 }

--- a/api-collector/dependency.go
+++ b/api-collector/dependency.go
@@ -1,0 +1,28 @@
+package collector
+
+type Dependency struct {
+	Name    string
+	Version string
+}
+
+type ResolvedField struct {
+	Name     string
+	Type     string
+	Required bool
+}
+
+type ResolvedType struct {
+	Name               string
+	Fields             []ResolvedField
+	TypeParameters     []string
+	SuperClass         string
+	SuperClassTypeArgs []string
+	IsInterface        bool
+	Interfaces         []string
+}
+
+type DependencyResolver interface {
+	DetectDependencies(sourceDir string) ([]Dependency, error)
+
+	ResolveType(typeName string) *ResolvedType
+}

--- a/api-collector/dependency_test.go
+++ b/api-collector/dependency_test.go
@@ -1,0 +1,113 @@
+package collector
+
+import (
+	"testing"
+)
+
+type mockDependencyResolver struct {
+	types map[string]*ResolvedType
+	deps  []Dependency
+}
+
+func (m *mockDependencyResolver) DetectDependencies(sourceDir string) ([]Dependency, error) {
+	return m.deps, nil
+}
+
+func (m *mockDependencyResolver) ResolveType(typeName string) *ResolvedType {
+	if rt, ok := m.types[typeName]; ok {
+		return rt
+	}
+	return nil
+}
+
+func TestDependencyResolver_Interface(t *testing.T) {
+	resolver := &mockDependencyResolver{
+		types: map[string]*ResolvedType{
+			"User": {
+				Name: "User",
+				Fields: []ResolvedField{
+					{Name: "id", Type: "int", Required: true},
+					{Name: "name", Type: "string", Required: true},
+					{Name: "email", Type: "string", Required: false},
+				},
+			},
+		},
+		deps: []Dependency{
+			{Name: "mylib", Version: "1.0.0"},
+		},
+	}
+
+	var _ DependencyResolver = resolver
+
+	deps, err := resolver.DetectDependencies("/tmp")
+	if err != nil {
+		t.Fatalf("DetectDependencies returned error: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Name != "mylib" || deps[0].Version != "1.0.0" {
+		t.Errorf("unexpected dependency: %+v", deps[0])
+	}
+
+	rt := resolver.ResolveType("User")
+	if rt == nil {
+		t.Fatal("expected resolved type, got nil")
+	}
+	if rt.Name != "User" {
+		t.Errorf("expected name=User, got %s", rt.Name)
+	}
+	if len(rt.Fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(rt.Fields))
+	}
+	if rt.Fields[0].Name != "id" || !rt.Fields[0].Required {
+		t.Errorf("unexpected field[0]: %+v", rt.Fields[0])
+	}
+	if rt.Fields[2].Name != "email" || rt.Fields[2].Required {
+		t.Errorf("expected email not required, got %+v", rt.Fields[2])
+	}
+
+	if resolver.ResolveType("Unknown") != nil {
+		t.Error("expected nil for unknown type")
+	}
+}
+
+func TestResolvedType_Fields(t *testing.T) {
+	rt := &ResolvedType{
+		Name:           "Page",
+		TypeParameters: []string{"T"},
+		SuperClass:     "BasePage",
+		IsInterface:    false,
+		Interfaces:     []string{"Serializable"},
+		Fields: []ResolvedField{
+			{Name: "content", Type: "List<T>", Required: true},
+			{Name: "total", Type: "int", Required: true},
+		},
+	}
+
+	if len(rt.TypeParameters) != 1 || rt.TypeParameters[0] != "T" {
+		t.Errorf("unexpected type parameters: %v", rt.TypeParameters)
+	}
+	if rt.SuperClass != "BasePage" {
+		t.Errorf("unexpected super class: %s", rt.SuperClass)
+	}
+	if len(rt.Interfaces) != 1 || rt.Interfaces[0] != "Serializable" {
+		t.Errorf("unexpected interfaces: %v", rt.Interfaces)
+	}
+	if !rt.Fields[0].Required {
+		t.Error("expected content to be required")
+	}
+}
+
+func TestDependency_Fields(t *testing.T) {
+	dep := Dependency{
+		Name:    "com.example:my-lib",
+		Version: "2.1.0",
+	}
+	if dep.Name != "com.example:my-lib" {
+		t.Errorf("unexpected name: %s", dep.Name)
+	}
+	if dep.Version != "2.1.0" {
+		t.Errorf("unexpected version: %s", dep.Version)
+	}
+}


### PR DESCRIPTION
Implements a common DependencyResolver interface across all language collectors (Java, Node.js, Go, Python) to resolve classes/types from dependencies. Closes #119