### PR TITLE
feat: resolve dependency structs from Go module cache

### DIFF
--- a/api-collector-go/collector.go
+++ b/api-collector-go/collector.go
@@ -41,9 +41,16 @@ func (c *GoCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndp
 		framework string
 	}
 
+	var depResolver collector.DependencyResolver
+	if c.dependencyResolver != nil {
+		depResolver = c.dependencyResolver
+	} else {
+		depResolver = NewGoDependencyResolver(ctx.SourceDir)
+	}
+
 	parsers := []struct {
-		name    string
-		parse   func(string) ([]collector.ApiEndpoint, error)
+		name  string
+		parse func(string, ...collector.DependencyResolver) ([]collector.ApiEndpoint, error)
 	}{
 		{"gin", gin.Parse},
 		{"echo", echo.Parse},
@@ -55,9 +62,9 @@ func (c *GoCollector) Collect(ctx collector.CollectContext) ([]collector.ApiEndp
 
 	for _, p := range parsers {
 		wg.Add(1)
-		go func(name string, fn func(string) ([]collector.ApiEndpoint, error)) {
+		go func(name string, fn func(string, ...collector.DependencyResolver) ([]collector.ApiEndpoint, error)) {
 			defer wg.Done()
-			endpoints, err := fn(ctx.SourceDir)
+			endpoints, err := fn(ctx.SourceDir, depResolver)
 			ch <- parseResult{endpoints: endpoints, err: err, framework: name}
 		}(p.name, p.parse)
 	}

--- a/api-collector-go/echo/parser.go
+++ b/api-collector-go/echo/parser.go
@@ -57,7 +57,7 @@ var echoMethods = map[string]bool{
 // Per the collector contract:
 //   - Returns nil, nil (not an error) when no endpoints are found.
 //   - Skips unparseable files silently.
-func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+func Parse(sourceDir string, depResolver ...collector.DependencyResolver) ([]collector.ApiEndpoint, error) {
 	goFiles, err := discoverGoFiles(sourceDir)
 	if err != nil || len(goFiles) == 0 {
 		return nil, nil
@@ -85,6 +85,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	allStructs := make(map[string]StructDef)
 	varTypeMaps := make(map[string]map[string]string)
+	importMaps := make(map[string]string)
 	var allRaw []rawEndpoint
 
 	for res := range ch {
@@ -103,6 +104,9 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		for k, v := range res.varTypeMaps {
 			varTypeMaps[k] = v
 		}
+		for k, v := range res.importMap {
+			importMaps[k] = v
+		}
 		allRaw = append(allRaw, res.rawEndpoints...)
 	}
 
@@ -111,6 +115,10 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	}
 
 	typeResolver := NewTypeResolver(allStructs)
+	if len(depResolver) > 0 {
+		typeResolver.SetDependencyResolver(depResolver[0])
+		typeResolver.SetImportMaps(importMaps)
+	}
 
 	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
 	for _, raw := range allRaw {
@@ -231,6 +239,7 @@ type fileResult struct {
 	handlerAnalyses map[string]handlerAnalysis
 	structDefs      map[string]StructDef
 	varTypeMaps     map[string]map[string]string
+	importMap       map[string]string
 }
 
 // discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
@@ -265,9 +274,10 @@ func processFile(filePath string) fileResult {
 	}
 
 	structDefs := extractStructs(f)
+	importMap := buildImportMap(f)
 
 	if !importsPackage(f, "github.com/labstack/echo/v4") {
-		return fileResult{structDefs: structDefs}
+		return fileResult{structDefs: structDefs, importMap: importMap}
 	}
 
 	varTypeMaps := make(map[string]map[string]string)
@@ -365,6 +375,7 @@ func processFile(filePath string) fileResult {
 		handlerAnalyses: handlerAnalyses,
 		structDefs:      structDefs,
 		varTypeMaps:     varTypeMaps,
+		importMap:       importMap,
 	}
 }
 
@@ -621,4 +632,20 @@ func importsPackage(f *ast.File, pkgPath string) bool {
 		}
 	}
 	return false
+}
+
+func buildImportMap(f *ast.File) map[string]string {
+	m := make(map[string]string)
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if imp.Name != nil && imp.Name.Name != "_" && imp.Name.Name != "." {
+			m[imp.Name.Name] = path
+		} else {
+			parts := strings.Split(path, "/")
+			if len(parts) > 0 {
+				m[parts[len(parts)-1]] = path
+			}
+		}
+	}
+	return m
 }

--- a/api-collector-go/echo/resolver.go
+++ b/api-collector-go/echo/resolver.go
@@ -191,6 +191,7 @@ type TypeResolver struct {
 	structRegistry    map[string]StructDef
 	resolving         map[string]bool
 	dependencyResolver collector.DependencyResolver
+	importMaps        map[string]string
 }
 
 func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
@@ -202,6 +203,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 
 func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
 	r.dependencyResolver = dr
+}
+
+func (r *TypeResolver) SetImportMaps(importMaps map[string]string) {
+	r.importMaps = importMaps
 }
 
 var goPrimitives = map[string]string{
@@ -252,6 +257,19 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		if r.importMaps != nil && strings.Contains(typeName, ".") {
+			parts := strings.SplitN(typeName, ".", 2)
+			if pkg, ok := r.importMaps[parts[0]]; ok {
+				fullTypeName := pkg + "." + parts[1]
+				if r.dependencyResolver != nil {
+					if rt := r.dependencyResolver.ResolveType(fullTypeName); rt != nil {
+						sd := resolvedTypeToStructDef(rt)
+						r.structRegistry[typeName] = sd
+						return r.Resolve(typeName)
+					}
+				}
+			}
+		}
 		if r.dependencyResolver != nil {
 			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
 				sd := resolvedTypeToStructDef(rt)

--- a/api-collector-go/fiber/parser.go
+++ b/api-collector-go/fiber/parser.go
@@ -59,7 +59,7 @@ var fiberMethods = map[string]bool{
 // Per the collector contract:
 //   - Returns nil, nil (not an error) when no endpoints are found.
 //   - Skips unparseable files silently.
-func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+func Parse(sourceDir string, depResolver ...collector.DependencyResolver) ([]collector.ApiEndpoint, error) {
 	goFiles, err := discoverGoFiles(sourceDir)
 	if err != nil || len(goFiles) == 0 {
 		return nil, nil
@@ -87,6 +87,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	allStructs := make(map[string]StructDef)
 	varTypeMaps := make(map[string]map[string]string)
+	importMaps := make(map[string]string)
 	var allRaw []rawEndpoint
 
 	for res := range ch {
@@ -105,6 +106,9 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		for k, v := range res.varTypeMaps {
 			varTypeMaps[k] = v
 		}
+		for k, v := range res.importMap {
+			importMaps[k] = v
+		}
 		allRaw = append(allRaw, res.rawEndpoints...)
 	}
 
@@ -113,6 +117,10 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	}
 
 	typeResolver := NewTypeResolver(allStructs)
+	if len(depResolver) > 0 {
+		typeResolver.SetDependencyResolver(depResolver[0])
+		typeResolver.SetImportMaps(importMaps)
+	}
 
 	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
 	for _, raw := range allRaw {
@@ -233,6 +241,7 @@ type fileResult struct {
 	handlerAnalyses map[string]handlerAnalysis
 	structDefs      map[string]StructDef
 	varTypeMaps     map[string]map[string]string
+	importMap       map[string]string
 }
 
 // discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
@@ -267,9 +276,10 @@ func processFile(filePath string) fileResult {
 	}
 
 	structDefs := extractStructs(f)
+	importMap := buildImportMap(f)
 
 	if !importsPackage(f, "github.com/gofiber/fiber/v2") {
-		return fileResult{structDefs: structDefs}
+		return fileResult{structDefs: structDefs, importMap: importMap}
 	}
 
 	varTypeMaps := make(map[string]map[string]string)
@@ -367,6 +377,7 @@ func processFile(filePath string) fileResult {
 		handlerAnalyses: handlerAnalyses,
 		structDefs:      structDefs,
 		varTypeMaps:     varTypeMaps,
+		importMap:       importMap,
 	}
 }
 
@@ -651,4 +662,20 @@ func importsPackage(f *ast.File, pkgPath string) bool {
 		}
 	}
 	return false
+}
+
+func buildImportMap(f *ast.File) map[string]string {
+	m := make(map[string]string)
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if imp.Name != nil && imp.Name.Name != "_" && imp.Name.Name != "." {
+			m[imp.Name.Name] = path
+		} else {
+			parts := strings.Split(path, "/")
+			if len(parts) > 0 {
+				m[parts[len(parts)-1]] = path
+			}
+		}
+	}
+	return m
 }

--- a/api-collector-go/fiber/resolver.go
+++ b/api-collector-go/fiber/resolver.go
@@ -191,6 +191,7 @@ type TypeResolver struct {
 	structRegistry    map[string]StructDef
 	resolving         map[string]bool
 	dependencyResolver collector.DependencyResolver
+	importMaps        map[string]string
 }
 
 func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
@@ -202,6 +203,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 
 func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
 	r.dependencyResolver = dr
+}
+
+func (r *TypeResolver) SetImportMaps(importMaps map[string]string) {
+	r.importMaps = importMaps
 }
 
 var goPrimitives = map[string]string{
@@ -256,6 +261,19 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		if r.importMaps != nil && strings.Contains(typeName, ".") {
+			parts := strings.SplitN(typeName, ".", 2)
+			if pkg, ok := r.importMaps[parts[0]]; ok {
+				fullTypeName := pkg + "." + parts[1]
+				if r.dependencyResolver != nil {
+					if rt := r.dependencyResolver.ResolveType(fullTypeName); rt != nil {
+						sd := resolvedTypeToStructDef(rt)
+						r.structRegistry[typeName] = sd
+						return r.Resolve(typeName)
+					}
+				}
+			}
+		}
 		if r.dependencyResolver != nil {
 			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
 				sd := resolvedTypeToStructDef(rt)

--- a/api-collector-go/gin/parser.go
+++ b/api-collector-go/gin/parser.go
@@ -59,7 +59,7 @@ var httpMethods = map[string]bool{
 // Per the collector contract:
 //   - Returns nil, nil (not an error) when no endpoints are found.
 //   - Skips unparseable files silently.
-func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
+func Parse(sourceDir string, depResolver ...collector.DependencyResolver) ([]collector.ApiEndpoint, error) {
 	goFiles, err := discoverGoFiles(sourceDir)
 	if err != nil || len(goFiles) == 0 {
 		return nil, nil
@@ -87,6 +87,7 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	handlerAnalyses := make(map[string]handlerAnalysis)
 	allStructs := make(map[string]StructDef)
 	varTypeMaps := make(map[string]map[string]string)
+	importMaps := make(map[string]string)
 	var allRaw []rawEndpoint
 
 	for res := range ch {
@@ -105,6 +106,9 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 		for k, v := range res.varTypeMaps {
 			varTypeMaps[k] = v
 		}
+		for k, v := range res.importMap {
+			importMaps[k] = v
+		}
 		allRaw = append(allRaw, res.rawEndpoints...)
 	}
 
@@ -113,6 +117,10 @@ func Parse(sourceDir string) ([]collector.ApiEndpoint, error) {
 	}
 
 	typeResolver := NewTypeResolver(allStructs)
+	if len(depResolver) > 0 {
+		typeResolver.SetDependencyResolver(depResolver[0])
+		typeResolver.SetImportMaps(importMaps)
+	}
 
 	endpoints := make([]collector.ApiEndpoint, 0, len(allRaw))
 	for _, raw := range allRaw {
@@ -233,6 +241,7 @@ type fileResult struct {
 	handlerAnalyses map[string]handlerAnalysis
 	structDefs      map[string]StructDef
 	varTypeMaps     map[string]map[string]string
+	importMap       map[string]string
 }
 
 // discoverGoFiles walks sourceDir and returns paths to all non-test .go files.
@@ -267,9 +276,10 @@ func processFile(filePath string) fileResult {
 	}
 
 	structDefs := extractStructs(f)
+	importMap := buildImportMap(f)
 
 	if !importsPackage(f, "github.com/gin-gonic/gin") {
-		return fileResult{structDefs: structDefs}
+		return fileResult{structDefs: structDefs, importMap: importMap}
 	}
 
 	varTypeMaps := make(map[string]map[string]string)
@@ -367,6 +377,7 @@ func processFile(filePath string) fileResult {
 		handlerAnalyses: handlerAnalyses,
 		structDefs:      structDefs,
 		varTypeMaps:     varTypeMaps,
+		importMap:       importMap,
 	}
 }
 
@@ -658,6 +669,22 @@ func importsPackage(f *ast.File, pkgPath string) bool {
 		}
 	}
 	return false
+}
+
+func buildImportMap(f *ast.File) map[string]string {
+	m := make(map[string]string)
+	for _, imp := range f.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if imp.Name != nil && imp.Name.Name != "_" && imp.Name.Name != "." {
+			m[imp.Name.Name] = path
+		} else {
+			parts := strings.Split(path, "/")
+			if len(parts) > 0 {
+				m[parts[len(parts)-1]] = path
+			}
+		}
+	}
+	return m
 }
 
 // resolveVarType looks up a variable name in the handler's var type map

--- a/api-collector-go/gin/resolver.go
+++ b/api-collector-go/gin/resolver.go
@@ -196,6 +196,7 @@ type TypeResolver struct {
 	structRegistry    map[string]StructDef
 	resolving         map[string]bool
 	dependencyResolver collector.DependencyResolver
+	importMaps        map[string]string
 }
 
 // NewTypeResolver creates a new TypeResolver with the given struct definitions.
@@ -208,6 +209,10 @@ func NewTypeResolver(structs map[string]StructDef) *TypeResolver {
 
 func (r *TypeResolver) SetDependencyResolver(dr collector.DependencyResolver) {
 	r.dependencyResolver = dr
+}
+
+func (r *TypeResolver) SetImportMaps(importMaps map[string]string) {
+	r.importMaps = importMaps
 }
 
 var goPrimitives = map[string]string{
@@ -263,6 +268,20 @@ func (r *TypeResolver) Resolve(typeName string) *model.ObjectModel {
 
 	structDef, found := r.structRegistry[typeName]
 	if !found {
+		// Try to resolve package-qualified types using import maps
+		if r.importMaps != nil && strings.Contains(typeName, ".") {
+			parts := strings.SplitN(typeName, ".", 2)
+			if pkg, ok := r.importMaps[parts[0]]; ok {
+				fullTypeName := pkg + "." + parts[1]
+				if r.dependencyResolver != nil {
+					if rt := r.dependencyResolver.ResolveType(fullTypeName); rt != nil {
+						sd := resolvedTypeToStructDef(rt)
+						r.structRegistry[typeName] = sd
+						return r.Resolve(typeName)
+					}
+				}
+			}
+		}
 		if r.dependencyResolver != nil {
 			if rt := r.dependencyResolver.ResolveType(typeName); rt != nil {
 				sd := resolvedTypeToStructDef(rt)


### PR DESCRIPTION
## Summary

Resolve structs from external Go dependencies (e.g. `gorm.Model`) by wiring the existing `GoDependencyResolver` into the gin/fiber/echo parsing pipeline.

## Changes

- Add variadic `collector.DependencyResolver` parameter to `gin.Parse()`, `fiber.Parse()`, `echo.Parse()`
- Add `buildImportMap()` to each parser to extract import alias to full package path mappings
- Add `SetImportMaps()` to each TypeResolver for package-qualified type resolution
- `GoCollector.Collect` now auto-creates a `GoDependencyResolver` when none is set

Closes #122