### PR TITLE
feat: add pip dependency resolver for Python site-packages model resolution

### DIFF
--- a/api-collector-python/dep_resolver.go
+++ b/api-collector-python/dep_resolver.go
@@ -1,224 +1,24 @@
 package pycollector
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"sync"
-
 	collector "github.com/tangcent/apilot/api-collector"
-	"github.com/tangcent/apilot/api-collector-python/fastapi"
+	"github.com/tangcent/apilot/api-collector-python/pip"
 )
 
 type PythonDependencyResolver struct {
-	mu        sync.Mutex
-	sourceDir string
-	cache     map[string]*collector.ResolvedType
-	misses    map[string]bool
-	loaded    bool
+	delegate *pip.PipTypeResolver
 }
 
 func NewPythonDependencyResolver(sourceDir string) *PythonDependencyResolver {
 	return &PythonDependencyResolver{
-		sourceDir: sourceDir,
-		cache:     make(map[string]*collector.ResolvedType),
-		misses:    make(map[string]bool),
+		delegate: pip.NewPipTypeResolver(sourceDir),
 	}
 }
 
 func (r *PythonDependencyResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
-	return detectPythonDependencies(sourceDir)
+	return r.delegate.DetectDependencies(sourceDir)
 }
 
 func (r *PythonDependencyResolver) ResolveType(typeName string) *collector.ResolvedType {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if cached, ok := r.cache[typeName]; ok {
-		return cached
-	}
-
-	if r.misses[typeName] {
-		return nil
-	}
-
-	if !r.loaded {
-		r.loadFromSitePackages()
-		r.loaded = true
-	}
-
-	rt := r.resolveFromCache(typeName)
-	if rt != nil {
-		return rt
-	}
-
-	r.misses[typeName] = true
-	return nil
-}
-
-func (r *PythonDependencyResolver) loadFromSitePackages() {
-	sitePackagesDir, err := findSitePackages()
-	if err != nil || sitePackagesDir == "" {
-		return
-	}
-
-	entries, err := os.ReadDir(sitePackagesDir)
-	if err != nil {
-		return
-	}
-
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-
-		pkgDir := filepath.Join(sitePackagesDir, entry.Name())
-		if strings.HasPrefix(entry.Name(), "_") || strings.HasSuffix(entry.Name(), ".dist-info") {
-			continue
-		}
-
-		r.loadPackageTypes(pkgDir)
-	}
-}
-
-func (r *PythonDependencyResolver) loadPackageTypes(pkgDir string) {
-	pyFiles := findPyFiles(pkgDir)
-	if len(pyFiles) == 0 {
-		return
-	}
-
-	for _, f := range pyFiles {
-		models, err := fastapi.ExtractPydanticModelsFromFile(f)
-		if err != nil {
-			continue
-		}
-		for name, md := range models {
-			rt := pydanticModelToResolvedType(md)
-			r.cache[name] = rt
-		}
-	}
-}
-
-func (r *PythonDependencyResolver) resolveFromCache(typeName string) *collector.ResolvedType {
-	if rt, ok := r.cache[typeName]; ok {
-		return rt
-	}
-	return nil
-}
-
-func pydanticModelToResolvedType(md fastapi.PydanticModel) *collector.ResolvedType {
-	rt := &collector.ResolvedType{
-		Name:           md.Name,
-		IsInterface:    false,
-	}
-
-	for _, embedded := range md.EmbeddedTypes {
-		rt.Interfaces = append(rt.Interfaces, embedded)
-	}
-
-	for _, f := range md.Fields {
-		rt.Fields = append(rt.Fields, collector.ResolvedField{
-			Name:     f.Name,
-			Type:     f.Type,
-			Required: f.Required,
-		})
-	}
-
-	return rt
-}
-
-func findPyFiles(dir string) []string {
-	var files []string
-	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-		if info.IsDir() {
-			name := info.Name()
-			if name == "__pycache__" || name == ".git" || strings.HasPrefix(name, ".") {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if strings.HasSuffix(path, ".py") && !strings.HasSuffix(path, "__init__.py") {
-			files = append(files, path)
-		}
-		return nil
-	})
-	return files
-}
-
-func findSitePackages() (string, error) {
-	cmd := exec.Command("python3", "-c", "import site; print(site.getsitepackages()[0])")
-	output, err := cmd.Output()
-	if err != nil {
-		cmd = exec.Command("python", "-c", "import site; print(site.getsitepackages()[0])")
-		output, err = cmd.Output()
-		if err != nil {
-			return "", fmt.Errorf("failed to find site-packages: %w", err)
-		}
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
-type pipPackage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
-func detectPythonDependencies(sourceDir string) ([]collector.Dependency, error) {
-	reqFile := filepath.Join(sourceDir, "requirements.txt")
-	data, err := os.ReadFile(reqFile)
-	if err != nil {
-		return nil, nil
-	}
-
-	var deps []collector.Dependency
-	lines := strings.Split(string(data), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
-			continue
-		}
-
-		name, version := parseRequirementLine(line)
-		deps = append(deps, collector.Dependency{
-			Name:    name,
-			Version: version,
-		})
-	}
-
-	return deps, nil
-}
-
-func parseRequirementLine(line string) (name, version string) {
-	ops := []string{"==", ">=", "<=", "~=", "!=", "~>", "==="}
-	for _, op := range ops {
-		if idx := strings.Index(line, op); idx != -1 {
-			name = strings.TrimSpace(line[:idx])
-			rest := strings.TrimSpace(line[idx+len(op):])
-			if commaIdx := strings.Index(rest, ","); commaIdx != -1 {
-				version = strings.TrimSpace(rest[:commaIdx])
-			} else {
-				version = rest
-			}
-			return
-		}
-	}
-
-	if idx := strings.Index(line, ">"); idx != -1 {
-		name = strings.TrimSpace(line[:idx])
-		version = strings.TrimSpace(line[idx+1:])
-		return
-	}
-	if idx := strings.Index(line, "<"); idx != -1 {
-		name = strings.TrimSpace(line[:idx])
-		version = strings.TrimSpace(line[idx+1:])
-		return
-	}
-
-	name = strings.TrimSpace(line)
-	return
+	return r.delegate.ResolveType(typeName)
 }

--- a/api-collector-python/pip/resolver.go
+++ b/api-collector-python/pip/resolver.go
@@ -1,0 +1,595 @@
+package pip
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	collector "github.com/tangcent/apilot/api-collector"
+	"github.com/tangcent/apilot/api-collector-python/fastapi"
+)
+
+type PipTypeResolver struct {
+	mu         sync.Mutex
+	sourceDir  string
+	cache      map[string]*collector.ResolvedType
+	misses     map[string]bool
+	deps       []string
+	loadedPkgs map[string]bool
+	depsParsed bool
+}
+
+func NewPipTypeResolver(sourceDir string) *PipTypeResolver {
+	return &PipTypeResolver{
+		sourceDir:  sourceDir,
+		cache:      make(map[string]*collector.ResolvedType),
+		misses:     make(map[string]bool),
+		loadedPkgs: make(map[string]bool),
+	}
+}
+
+func (r *PipTypeResolver) DetectDependencies(sourceDir string) ([]collector.Dependency, error) {
+	return DetectPipDependencies(sourceDir)
+}
+
+func (r *PipTypeResolver) ResolveType(typeName string) *collector.ResolvedType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cached, ok := r.cache[typeName]; ok {
+		return cached
+	}
+
+	if r.misses[typeName] {
+		return nil
+	}
+
+	if !r.depsParsed {
+		r.parseDependencies()
+		r.depsParsed = true
+	}
+
+	r.loadAllDependencyTypes()
+
+	if rt, ok := r.cache[typeName]; ok {
+		return rt
+	}
+
+	r.misses[typeName] = true
+	return nil
+}
+
+func (r *PipTypeResolver) parseDependencies() {
+	deps, err := DetectPipDependencies(r.sourceDir)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		normalized := normalizePackageName(dep.Name)
+		if !seen[normalized] {
+			seen[normalized] = true
+			r.deps = append(r.deps, normalized)
+		}
+	}
+}
+
+func (r *PipTypeResolver) loadAllDependencyTypes() {
+	sitePackagesDir, err := FindSitePackages(r.sourceDir)
+	if err != nil || sitePackagesDir == "" {
+		return
+	}
+
+	for _, dep := range r.deps {
+		if r.loadedPkgs[dep] {
+			continue
+		}
+		r.loadedPkgs[dep] = true
+		r.loadPackageTypes(sitePackagesDir, dep)
+	}
+}
+
+func (r *PipTypeResolver) loadPackageTypes(sitePackagesDir string, pkgName string) {
+	pkgDir := FindPackageDir(sitePackagesDir, pkgName)
+	if pkgDir == "" {
+		return
+	}
+
+	pyFiles := FindPyFiles(pkgDir)
+	for _, f := range pyFiles {
+		models, err := fastapi.ExtractPydanticModelsFromFile(f)
+		if err != nil {
+			continue
+		}
+		for name, md := range models {
+			rt := pydanticModelToResolvedType(md)
+			r.cache[name] = rt
+		}
+	}
+}
+
+func pydanticModelToResolvedType(md fastapi.PydanticModel) *collector.ResolvedType {
+	rt := &collector.ResolvedType{
+		Name:        md.Name,
+		IsInterface: false,
+	}
+
+	for _, embedded := range md.EmbeddedTypes {
+		rt.Interfaces = append(rt.Interfaces, embedded)
+	}
+
+	for _, f := range md.Fields {
+		rt.Fields = append(rt.Fields, collector.ResolvedField{
+			Name:     f.Name,
+			Type:     f.Type,
+			Required: f.Required,
+		})
+	}
+
+	return rt
+}
+
+func DetectPipDependencies(sourceDir string) ([]collector.Dependency, error) {
+	if deps, err := detectFromRequirementsTxt(sourceDir); err == nil && len(deps) > 0 {
+		return deps, nil
+	}
+
+	if deps, err := detectFromPyprojectToml(sourceDir); err == nil && len(deps) > 0 {
+		return deps, nil
+	}
+
+	if deps, err := detectFromPipfile(sourceDir); err == nil && len(deps) > 0 {
+		return deps, nil
+	}
+
+	return nil, nil
+}
+
+func detectFromRequirementsTxt(sourceDir string) ([]collector.Dependency, error) {
+	reqFile := filepath.Join(sourceDir, "requirements.txt")
+	data, err := os.ReadFile(reqFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var deps []collector.Dependency
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+			continue
+		}
+
+		name, version := parseRequirementLine(line)
+		if name != "" {
+			deps = append(deps, collector.Dependency{
+				Name:    name,
+				Version: version,
+			})
+		}
+	}
+
+	return deps, nil
+}
+
+func detectFromPyprojectToml(sourceDir string) ([]collector.Dependency, error) {
+	pyprojectFile := filepath.Join(sourceDir, "pyproject.toml")
+	data, err := os.ReadFile(pyprojectFile)
+	if err != nil {
+		return nil, err
+	}
+
+	content := string(data)
+	var deps []collector.Dependency
+	seen := make(map[string]bool)
+
+	inDeps := false
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "dependencies") && strings.Contains(line, "=") {
+			inDeps = true
+			if strings.Contains(line, "[") {
+				parseInlineArray(line, &deps, seen)
+			}
+			continue
+		}
+
+		if inDeps {
+			if line == "]" || (!strings.HasPrefix(line, "\"") && !strings.HasPrefix(line, "'") && !strings.HasPrefix(line, "-") && line != "" && !strings.HasPrefix(line, "#")) {
+				if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+					continue
+				}
+				inDeps = false
+				continue
+			}
+
+			dep := strings.Trim(line, " \t\"',")
+			dep = strings.TrimSuffix(dep, ",")
+			if dep == "" || strings.HasPrefix(dep, "#") {
+				continue
+			}
+
+			name, version := parseRequirementLine(dep)
+			if name != "" && !seen[normalizePackageName(name)] {
+				seen[normalizePackageName(name)] = true
+				deps = append(deps, collector.Dependency{
+					Name:    name,
+					Version: version,
+				})
+			}
+		}
+	}
+
+	scanner = bufio.NewScanner(strings.NewReader(content))
+	inOptionalDeps := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "[project.optional-dependencies]") || (strings.Contains(line, "optional-dependencies") && strings.Contains(line, "=")) {
+			inOptionalDeps = true
+			continue
+		}
+
+		if inOptionalDeps {
+			if strings.HasPrefix(line, "[") && !strings.Contains(line, "optional-dependencies") {
+				inOptionalDeps = false
+				continue
+			}
+
+			dep := strings.Trim(line, " \t\"',")
+			dep = strings.TrimSuffix(dep, ",")
+			if dep == "" || strings.HasPrefix(dep, "#") {
+				continue
+			}
+
+			if strings.Contains(dep, "=") || strings.Contains(dep, ">") || strings.Contains(dep, "<") || strings.Contains(dep, "~") || strings.Contains(dep, "!") {
+				name, version := parseRequirementLine(dep)
+				if name != "" && !seen[normalizePackageName(name)] {
+					seen[normalizePackageName(name)] = true
+					deps = append(deps, collector.Dependency{
+						Name:    name,
+						Version: version,
+					})
+				}
+			}
+		}
+	}
+
+	return deps, nil
+}
+
+func parseInlineArray(line string, deps *[]collector.Dependency, seen map[string]bool) {
+	startIdx := strings.Index(line, "[")
+	endIdx := strings.LastIndex(line, "]")
+	if startIdx == -1 || endIdx == -1 || endIdx <= startIdx {
+		return
+	}
+
+	inner := line[startIdx+1 : endIdx]
+	items := strings.Split(inner, ",")
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		item = strings.Trim(item, "\"'")
+		if item == "" {
+			continue
+		}
+		name, version := parseRequirementLine(item)
+		if name != "" && !seen[normalizePackageName(name)] {
+			seen[normalizePackageName(name)] = true
+			*deps = append(*deps, collector.Dependency{
+				Name:    name,
+				Version: version,
+			})
+		}
+	}
+}
+
+func detectFromPipfile(sourceDir string) ([]collector.Dependency, error) {
+	pipfile := filepath.Join(sourceDir, "Pipfile")
+	data, err := os.ReadFile(pipfile)
+	if err != nil {
+		return nil, err
+	}
+
+	content := string(data)
+	var deps []collector.Dependency
+	seen := make(map[string]bool)
+
+	inPackages := false
+	inDevPackages := false
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "[packages]" {
+			inPackages = true
+			inDevPackages = false
+			continue
+		}
+		if line == "[dev-packages]" {
+			inDevPackages = true
+			inPackages = false
+			continue
+		}
+		if strings.HasPrefix(line, "[") && line != "[packages]" && line != "[dev-packages]" {
+			inPackages = false
+			inDevPackages = false
+			continue
+		}
+
+		if inPackages || inDevPackages {
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			name, version := parsePipfileLine(line)
+			if name != "" && !seen[normalizePackageName(name)] {
+				seen[normalizePackageName(name)] = true
+				deps = append(deps, collector.Dependency{
+					Name:    name,
+					Version: version,
+				})
+			}
+		}
+	}
+
+	return deps, nil
+}
+
+func parsePipfileLine(line string) (name, version string) {
+	eqIdx := strings.Index(line, "=")
+	if eqIdx == -1 {
+		name = strings.TrimSpace(line)
+		return name, ""
+	}
+
+	name = strings.TrimSpace(line[:eqIdx])
+	value := strings.TrimSpace(line[eqIdx+1:])
+
+	var rawVersion string
+	if strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'") {
+		rawVersion = strings.Trim(value, "\"'")
+	} else if strings.HasPrefix(value, "{") {
+		rawVersion = extractVersionFromPipfileDict(value)
+	}
+
+	if rawVersion == "*" || rawVersion == "" {
+		return name, ""
+	}
+
+	_, version = parseRequirementLine(rawVersion)
+	return name, version
+}
+
+func extractVersionFromPipfileDict(dictStr string) string {
+	versionKey := "version"
+	idx := strings.Index(dictStr, versionKey)
+	if idx == -1 {
+		return ""
+	}
+
+	afterKey := dictStr[idx+len(versionKey):]
+	afterKey = strings.TrimSpace(afterKey)
+	if !strings.HasPrefix(afterKey, "=") {
+		return ""
+	}
+	afterKey = strings.TrimPrefix(afterKey, "=")
+	afterKey = strings.TrimSpace(afterKey)
+
+	if strings.HasPrefix(afterKey, "\"") || strings.HasPrefix(afterKey, "'") {
+		quote := string(afterKey[0])
+		endIdx := strings.Index(afterKey[1:], quote)
+		if endIdx != -1 {
+			return afterKey[1 : endIdx+1]
+		}
+	}
+
+	commaIdx := strings.Index(afterKey, ",")
+	braceIdx := strings.Index(afterKey, "}")
+	endIdx := len(afterKey)
+	if commaIdx != -1 && commaIdx < endIdx {
+		endIdx = commaIdx
+	}
+	if braceIdx != -1 && braceIdx < endIdx {
+		endIdx = braceIdx
+	}
+
+	return strings.TrimSpace(strings.Trim(afterKey[:endIdx], "\"'"))
+}
+
+func parseRequirementLine(line string) (name, version string) {
+	ops := []string{"==", ">=", "<=", "~=", "!=", "~>", "==="}
+	for _, op := range ops {
+		if idx := strings.Index(line, op); idx != -1 {
+			name = strings.TrimSpace(line[:idx])
+			rest := strings.TrimSpace(line[idx+len(op):])
+			if commaIdx := strings.Index(rest, ","); commaIdx != -1 {
+				version = strings.TrimSpace(rest[:commaIdx])
+			} else {
+				version = rest
+			}
+			return
+		}
+	}
+
+	if idx := strings.Index(line, ">"); idx != -1 {
+		name = strings.TrimSpace(line[:idx])
+		version = strings.TrimSpace(line[idx+1:])
+		return
+	}
+	if idx := strings.Index(line, "<"); idx != -1 {
+		name = strings.TrimSpace(line[:idx])
+		version = strings.TrimSpace(line[idx+1:])
+		return
+	}
+
+	name = strings.TrimSpace(line)
+	return
+}
+
+func normalizePackageName(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, ".", "_")
+	return name
+}
+
+func FindSitePackages(sourceDir string) (string, error) {
+	venvSitePkg := findVenvSitePackages(sourceDir)
+	if venvSitePkg != "" {
+		return venvSitePkg, nil
+	}
+
+	condaSitePkg := findCondaSitePackages()
+	if condaSitePkg != "" {
+		return condaSitePkg, nil
+	}
+
+	return findSystemSitePackages()
+}
+
+func findVenvSitePackages(sourceDir string) string {
+	venvDirs := []string{
+		filepath.Join(sourceDir, ".venv"),
+		filepath.Join(sourceDir, "venv"),
+		filepath.Join(sourceDir, "env"),
+	}
+
+	for _, venvDir := range venvDirs {
+		sitePkg := filepath.Join(venvDir, "lib")
+		if info, err := os.Stat(sitePkg); err == nil && info.IsDir() {
+			entries, err := os.ReadDir(sitePkg)
+			if err != nil {
+				continue
+			}
+			for _, entry := range entries {
+				if entry.IsDir() && strings.HasPrefix(entry.Name(), "python") {
+					candidate := filepath.Join(sitePkg, entry.Name(), "site-packages")
+					if dirExists(candidate) {
+						return candidate
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func findCondaSitePackages() string {
+	condaPrefix := os.Getenv("CONDA_PREFIX")
+	if condaPrefix != "" {
+		sitePkg := filepath.Join(condaPrefix, "lib")
+		if info, err := os.Stat(sitePkg); err == nil && info.IsDir() {
+			entries, err := os.ReadDir(sitePkg)
+			if err != nil {
+				return ""
+			}
+			for _, entry := range entries {
+				if entry.IsDir() && strings.HasPrefix(entry.Name(), "python") {
+					candidate := filepath.Join(sitePkg, entry.Name(), "site-packages")
+					if dirExists(candidate) {
+						return candidate
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func findSystemSitePackages() (string, error) {
+	for _, cmdName := range []string{"python3", "python"} {
+		cmd := exec.Command(cmdName, "-c", "import site; print(site.getsitepackages()[0])")
+		output, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		dir := strings.TrimSpace(string(output))
+		if dirExists(dir) {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find site-packages directory")
+}
+
+func FindPackageDir(sitePackagesDir string, pkgName string) string {
+	normalized := normalizePackageName(pkgName)
+
+	entries, err := os.ReadDir(sitePackagesDir)
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		entryNormalized := normalizePackageName(entry.Name())
+
+		if entryNormalized == normalized {
+			return filepath.Join(sitePackagesDir, entry.Name())
+		}
+
+		if strings.HasPrefix(entryNormalized, normalized+"_") {
+			return filepath.Join(sitePackagesDir, entry.Name())
+		}
+
+		if entryNormalized == normalized+"-dist" {
+			return filepath.Join(sitePackagesDir, entry.Name())
+		}
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		entryName := entry.Name()
+		if strings.HasPrefix(entryName, normalized) && strings.Contains(entryName, "-") {
+			parts := strings.SplitN(entryName, "-", 2)
+			if normalizePackageName(parts[0]) == normalized {
+				return filepath.Join(sitePackagesDir, entryName)
+			}
+		}
+	}
+
+	return ""
+}
+
+func FindPyFiles(dir string) []string {
+	var files []string
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			name := info.Name()
+			if name == "__pycache__" || name == ".git" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".py") && !strings.HasSuffix(path, "__init__.py") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/api-collector-python/pip/resolver_test.go
+++ b/api-collector-python/pip/resolver_test.go
@@ -1,0 +1,426 @@
+package pip
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	collector "github.com/tangcent/apilot/api-collector"
+)
+
+func TestDetectPipDependencies_RequirementsTxt(t *testing.T) {
+	dir := t.TempDir()
+
+	reqContent := "flask==2.3.0\n# comment\nrequests>=2.28.0\nnumpy\n-r other.txt\n"
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(reqContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := DetectPipDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 dependencies, got %d", len(deps))
+	}
+
+	if deps[0].Name != "flask" || deps[0].Version != "2.3.0" {
+		t.Errorf("deps[0] = {%s, %s}, want {flask, 2.3.0}", deps[0].Name, deps[0].Version)
+	}
+	if deps[1].Name != "requests" || deps[1].Version != "2.28.0" {
+		t.Errorf("deps[1] = {%s, %s}, want {requests, 2.28.0}", deps[1].Name, deps[1].Version)
+	}
+	if deps[2].Name != "numpy" || deps[2].Version != "" {
+		t.Errorf("deps[2] = {%s, %s}, want {numpy, }", deps[2].Name, deps[2].Version)
+	}
+}
+
+func TestDetectPipDependencies_PyprojectToml(t *testing.T) {
+	dir := t.TempDir()
+
+	pyprojectContent := `[build-system]
+requires = ["setuptools"]
+
+[project]
+name = "myapp"
+dependencies = [
+    "flask==2.3.0",
+    "requests>=2.28.0",
+    "numpy",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+`
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte(pyprojectContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := DetectPipDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) < 3 {
+		t.Fatalf("expected at least 3 dependencies, got %d", len(deps))
+	}
+
+	names := make(map[string]string)
+	for _, dep := range deps {
+		names[dep.Name] = dep.Version
+	}
+
+	if v, ok := names["flask"]; !ok || v != "2.3.0" {
+		t.Errorf("flask version = %q, want 2.3.0", v)
+	}
+	if v, ok := names["requests"]; !ok || v != "2.28.0" {
+		t.Errorf("requests version = %q, want 2.28.0", v)
+	}
+	if _, ok := names["numpy"]; !ok {
+		t.Error("expected numpy dependency")
+	}
+}
+
+func TestDetectPipDependencies_Pipfile(t *testing.T) {
+	dir := t.TempDir()
+
+	pipfileContent := `[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "==2.3.0"
+requests = ">=2.28.0"
+numpy = "*"
+
+[dev-packages]
+pytest = ">=7.0"
+
+[requires]
+python_version = "3.11"
+`
+	if err := os.WriteFile(filepath.Join(dir, "Pipfile"), []byte(pipfileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := DetectPipDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) < 3 {
+		t.Fatalf("expected at least 3 dependencies, got %d", len(deps))
+	}
+
+	names := make(map[string]string)
+	for _, dep := range deps {
+		names[dep.Name] = dep.Version
+	}
+
+	if v, ok := names["flask"]; !ok || v != "2.3.0" {
+		t.Errorf("flask version = %q, want 2.3.0", v)
+	}
+	if v, ok := names["requests"]; !ok || v != "2.28.0" {
+		t.Errorf("requests version = %q, want 2.28.0", v)
+	}
+	if _, ok := names["numpy"]; !ok {
+		t.Error("expected numpy dependency")
+	}
+}
+
+func TestDetectPipDependencies_NoFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	deps, err := DetectPipDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps != nil {
+		t.Errorf("expected nil deps, got %v", deps)
+	}
+}
+
+func TestDetectPipDependencies_RequirementsTxtPriority(t *testing.T) {
+	dir := t.TempDir()
+
+	reqContent := "flask==1.0.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(reqContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pipfileContent := `[packages]
+flask = "==2.0.0"
+`
+	if err := os.WriteFile(filepath.Join(dir, "Pipfile"), []byte(pipfileContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := DetectPipDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Version != "1.0.0" {
+		t.Errorf("expected requirements.txt version 1.0.0 to take priority, got %s", deps[0].Version)
+	}
+}
+
+func TestParseRequirementLine(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantName    string
+		wantVersion string
+	}{
+		{"flask==2.3.0", "flask", "2.3.0"},
+		{"requests>=2.28.0", "requests", "2.28.0"},
+		{"numpy<=1.25.0", "numpy", "1.25.0"},
+		{"django~=4.2", "django", "4.2"},
+		{"package!=1.0", "package", "1.0"},
+		{"numpy", "numpy", ""},
+		{"scipy>1.0", "scipy", "1.0"},
+		{"pandas<2.0", "pandas", "2.0"},
+		{"my-pkg==1.0,>=0.5", "my-pkg", "1.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			name, version := parseRequirementLine(tt.input)
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if version != tt.wantVersion {
+				t.Errorf("version = %q, want %q", version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestNormalizePackageName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Flask", "flask"},
+		{"my-package", "my_package"},
+		{"my.package", "my_package"},
+		{"My-Package", "my_package"},
+		{"requests", "requests"},
+		{"  flask  ", "flask"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizePackageName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizePackageName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindVenvSitePackages(t *testing.T) {
+	dir := t.TempDir()
+
+	venvDir := filepath.Join(dir, ".venv", "lib", "python3.11", "site-packages")
+	if err := os.MkdirAll(venvDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := findVenvSitePackages(dir)
+	if result != venvDir {
+		t.Errorf("findVenvSitePackages() = %q, want %q", result, venvDir)
+	}
+}
+
+func TestFindVenvSitePackages_VenvDir(t *testing.T) {
+	dir := t.TempDir()
+
+	venvDir := filepath.Join(dir, "venv", "lib", "python3.12", "site-packages")
+	if err := os.MkdirAll(venvDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := findVenvSitePackages(dir)
+	if result != venvDir {
+		t.Errorf("findVenvSitePackages() = %q, want %q", result, venvDir)
+	}
+}
+
+func TestFindVenvSitePackages_NoVenv(t *testing.T) {
+	dir := t.TempDir()
+
+	result := findVenvSitePackages(dir)
+	if result != "" {
+		t.Errorf("findVenvSitePackages() = %q, want empty string", result)
+	}
+}
+
+func TestFindPackageDir(t *testing.T) {
+	dir := t.TempDir()
+	sitePackages := filepath.Join(dir, "site-packages")
+	if err := os.MkdirAll(filepath.Join(sitePackages, "flask"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sitePackages, "my_package"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sitePackages, "requests-2.28.0.dist-info"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		pkgName string
+		want    string
+	}{
+		{"flask", filepath.Join(sitePackages, "flask")},
+		{"my-package", filepath.Join(sitePackages, "my_package")},
+		{"nonexistent", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pkgName, func(t *testing.T) {
+			got := FindPackageDir(sitePackages, tt.pkgName)
+			if got != tt.want {
+				t.Errorf("FindPackageDir(%q) = %q, want %q", tt.pkgName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindPyFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(dir, "__pycache__"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "model.py"), []byte("class Foo: pass"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "__init__.py"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "__pycache__", "cached.pyc"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := FindPyFiles(dir)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 .py file, got %d", len(files))
+	}
+	if filepath.Base(files[0]) != "model.py" {
+		t.Errorf("expected model.py, got %s", files[0])
+	}
+}
+
+func TestPipTypeResolver_Interface(t *testing.T) {
+	resolver := NewPipTypeResolver("/tmp")
+	var _ collector.DependencyResolver = resolver
+}
+
+func TestPipTypeResolver_DetectDependencies(t *testing.T) {
+	dir := t.TempDir()
+
+	reqContent := "flask==2.3.0\nrequests>=2.28.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(reqContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := NewPipTypeResolver(dir)
+	deps, err := resolver.DetectDependencies(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 dependencies, got %d", len(deps))
+	}
+}
+
+func TestPipTypeResolver_ResolveType_Miss(t *testing.T) {
+	dir := t.TempDir()
+
+	resolver := NewPipTypeResolver(dir)
+	rt := resolver.ResolveType("NonExistentModel")
+	if rt != nil {
+		t.Errorf("expected nil for non-existent type, got %v", rt)
+	}
+}
+
+func TestPipTypeResolver_ResolveType_CacheMiss(t *testing.T) {
+	dir := t.TempDir()
+
+	resolver := NewPipTypeResolver(dir)
+
+	rt1 := resolver.ResolveType("NonExistentModel")
+	if rt1 != nil {
+		t.Errorf("expected nil, got %v", rt1)
+	}
+
+	rt2 := resolver.ResolveType("NonExistentModel")
+	if rt2 != nil {
+		t.Errorf("expected nil on second call, got %v", rt2)
+	}
+}
+
+func TestDetectFromRequirementsTxt_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := detectFromRequirementsTxt(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 0 {
+		t.Errorf("expected 0 deps for empty file, got %d", len(deps))
+	}
+}
+
+func TestDetectFromRequirementsTxt_CommentsAndFlags(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "# This is a comment\n-r base.txt\n--index-url https://pypi.org/simple\nflask==2.3.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := detectFromRequirementsTxt(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Name != "flask" {
+		t.Errorf("expected flask, got %s", deps[0].Name)
+	}
+}
+
+func TestDetectFromPipfile_DictVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `[packages]
+mylib = {version = ">=1.0", index = "pypi"}
+`
+	if err := os.WriteFile(filepath.Join(dir, "Pipfile"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps, err := detectFromPipfile(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(deps))
+	}
+	if deps[0].Name != "mylib" {
+		t.Errorf("expected mylib, got %s", deps[0].Name)
+	}
+	if deps[0].Version != "1.0" {
+		t.Errorf("expected 1.0, got %s", deps[0].Version)
+	}
+}


### PR DESCRIPTION
Closes #123

## Summary

Resolve Pydantic models from Python dependency packages in site-packages, addressing the issue where the type resolver falls back to model.SingleModel(typeText) when encountering models defined in installed packages.

## Changes

- New file: api-collector-python/pip/resolver.go - PipTypeResolver implementing collector.DependencyResolver
  - DetectDependencies(): Supports requirements.txt, pyproject.toml, and Pipfile
  - ResolveType(): Resolves Pydantic models from dependency packages in site-packages
  - FindSitePackages(): Detects venv (.venv/, venv/, env/), conda (CONDA_PREFIX), system Python
  - FindPackageDir(): Locates package directories with normalized name matching
  - Reuses ExtractPydanticModels() from fastapi/resolver.go

- Refactored: api-collector-python/dep_resolver.go - Delegates to pip.PipTypeResolver

- New file: api-collector-python/pip/resolver_test.go - Comprehensive test coverage

## Testing

All tests pass across all Python collector packages.
