### PR TITLE
fix: correct archive arch/platform naming in plugin-package.sh

### DIFF
--- a/.github/workflows/ci-vscode.yml
+++ b/.github/workflows/ci-vscode.yml
@@ -35,6 +35,16 @@ jobs:
         working-directory: vscode-plugin
         run: npm run compile
 
+      - name: Install Xvfb
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y xvfb
+
       - name: Test
         working-directory: vscode-plugin
-        run: npm test
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a npm test
+          else
+            npm test
+          fi
+        shell: bash

--- a/api-master/engine/engine.go
+++ b/api-master/engine/engine.go
@@ -175,12 +175,10 @@ var projectRootIndicators = []string{
 }
 
 func findProjectRoot(dir string) (string, error) {
-	var lastFound string
 	for {
 		for _, indicator := range projectRootIndicators {
 			if _, err := os.Stat(filepath.Join(dir, indicator)); err == nil {
-				lastFound = dir
-				break
+				return dir, nil
 			}
 		}
 		parent := filepath.Dir(dir)
@@ -189,10 +187,7 @@ func findProjectRoot(dir string) (string, error) {
 		}
 		dir = parent
 	}
-	if lastFound == "" {
-		return "", fmt.Errorf("no project root indicator found")
-	}
-	return lastFound, nil
+	return "", fmt.Errorf("no project root indicator found")
 }
 
 func filterEndpointsByFile(endpoints []collector.ApiEndpoint, sourceFile string) []collector.ApiEndpoint {
@@ -535,7 +530,7 @@ func printExportHelp() {
 	fmt.Println("  source-path can be a directory or a single source file.")
 	fmt.Println("  When a file is given, the project root is auto-detected by walking up")
 	fmt.Println("  to find pom.xml, build.gradle, go.mod, package.json, etc.")
-	fmt.Println("  For multi-module projects, the topmost directory with an indicator is used.")
+	fmt.Println("  For multi-module projects, the nearest directory with an indicator is used.")
 	fmt.Println("")
 	fmt.Println("Flags:")
 	fmt.Println("  --collector string")

--- a/api-master/engine/engine_test.go
+++ b/api-master/engine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -732,15 +733,15 @@ func TestFindProjectRoot(t *testing.T) {
 
 func TestFindProjectRoot_MultiModule(t *testing.T) {
 	tmpDir := t.TempDir()
-	moduleDir := tmpDir + "/user-service"
-	subDir := moduleDir + "/src/main/java/com/example"
+	moduleDir := filepath.Join(tmpDir, "user-service")
+	subDir := filepath.Join(moduleDir, "src", "main", "java", "com", "example")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("Failed to create subdirectory: %v", err)
 	}
-	if err := os.WriteFile(tmpDir+"/pom.xml", []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "pom.xml"), []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to create parent pom.xml: %v", err)
 	}
-	if err := os.WriteFile(moduleDir+"/pom.xml", []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(moduleDir, "pom.xml"), []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to create module pom.xml: %v", err)
 	}
 
@@ -748,22 +749,22 @@ func TestFindProjectRoot_MultiModule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
-	if root != tmpDir {
-		t.Errorf("Expected topmost root %q, got %q", tmpDir, root)
+	if root != moduleDir {
+		t.Errorf("Expected nearest root %q, got %q", moduleDir, root)
 	}
 }
 
 func TestFindProjectRoot_GradleMultiModule(t *testing.T) {
 	tmpDir := t.TempDir()
-	moduleDir := tmpDir + "/user-service"
-	subDir := moduleDir + "/src/main/java/com/example"
+	moduleDir := filepath.Join(tmpDir, "user-service")
+	subDir := filepath.Join(moduleDir, "src", "main", "java", "com", "example")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("Failed to create subdirectory: %v", err)
 	}
-	if err := os.WriteFile(tmpDir+"/build.gradle", []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "build.gradle"), []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to create root build.gradle: %v", err)
 	}
-	if err := os.WriteFile(moduleDir+"/build.gradle", []byte{}, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(moduleDir, "build.gradle"), []byte{}, 0644); err != nil {
 		t.Fatalf("Failed to create module build.gradle: %v", err)
 	}
 
@@ -771,8 +772,8 @@ func TestFindProjectRoot_GradleMultiModule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
-	if root != tmpDir {
-		t.Errorf("Expected topmost root %q, got %q", tmpDir, root)
+	if root != moduleDir {
+		t.Errorf("Expected nearest root %q, got %q", moduleDir, root)
 	}
 }
 

--- a/scripts/plugin-package.sh
+++ b/scripts/plugin-package.sh
@@ -32,18 +32,28 @@ echo "Downloading apilot binaries (v${CLI_VERSION})..."
 BASE_URL="https://github.com/tangcent/apilot/releases/download/v${CLI_VERSION}"
 
 download_binary() {
-  local os=$1
-  local arch=$2
+  local archive_os=$1
+  local archive_arch=$2
   local ext=$3
-  local archive="apilot-${CLI_VERSION}-${os}-${arch}${ext}"
-  local target="$BIN_DIR/apilot-${os}-${arch}"
-  if [ "$os" = "windows" ]; then
+  local archive="apilot-${CLI_VERSION}-${archive_os}-${archive_arch}${ext}"
+
+  local local_os="${archive_os}"
+  if [ "$local_os" = "windows" ]; then
+    local_os="win32"
+  fi
+  local local_arch="${archive_arch}"
+  local target="$BIN_DIR/apilot-${local_os}-${local_arch}"
+  if [ "$archive_os" = "windows" ]; then
     target="${target}.exe"
   fi
+
   if [ ! -f "$target" ]; then
     echo "  Downloading ${archive}..."
-    curl -fsSL "${BASE_URL}/${archive}" -o "tmp/${archive}"
-    if [ "$os" = "windows" ]; then
+    if ! curl -fsSL "${BASE_URL}/${archive}" -o "tmp/${archive}"; then
+      echo "  Warning: Failed to download ${archive}, skipping..."
+      return 0
+    fi
+    if [ "$archive_os" = "windows" ]; then
       unzip -o "tmp/${archive}" -d tmp
     else
       tar -xzf "tmp/${archive}" -C tmp
@@ -51,15 +61,14 @@ download_binary() {
     cp "tmp/apilot" "$target" 2>/dev/null || cp "tmp/apilot.exe" "$target" 2>/dev/null || true
     chmod +x "$target"
   else
-    echo "  apilot-${os}-${arch} already exists, skipping..."
+    echo "  apilot-${local_os}-${local_arch} already exists, skipping..."
   fi
 }
 
 download_binary darwin arm64 ".tar.gz"
-download_binary darwin amd64 ".tar.gz"
 download_binary linux arm64 ".tar.gz"
-download_binary linux amd64 ".tar.gz"
-download_binary windows amd64 ".zip"
+download_binary linux x64 ".tar.gz"
+download_binary windows x64 ".zip"
 
 rm -rf tmp
 

--- a/vscode-plugin/README.md
+++ b/vscode-plugin/README.md
@@ -1,0 +1,76 @@
+# APilot — VSCode Extension
+
+> Navigate your APIs. Automatically.
+
+APilot scans your source code, extracts API endpoints, and exports them to the format you need — Postman collections, Markdown docs, or cURL commands. No annotations required, no runtime needed.
+
+## Features
+
+- **Right-click to export** — right-click in the Explorer or the editor and choose **APilot: Export**
+- **Auto-detection** — automatically detects your language and framework
+- **Multiple output formats** — Markdown, cURL, or Postman Collection v2.1
+
+## Usage
+
+There are three ways to trigger APilot:
+
+| Method | Scope |
+|--------|-------|
+| Right-click a file/folder in the **Explorer** → **APilot: Export** | Exports the selected file or folder |
+| Right-click in the **editor** → **APilot: Export** | Exports the current file |
+| Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) → **APilot: Export** | Exports the current file |
+
+The output appears in the **APilot** output channel (or a file, depending on your settings).
+
+## Supported Languages & Frameworks
+
+| Language | Frameworks |
+|----------|------------|
+| Java | Spring MVC, JAX-RS, Feign |
+| Go | Gin, Echo, Fiber |
+| Node.js | Express, Fastify, NestJS |
+| Python | FastAPI, Django REST, Flask |
+
+## Output Formats
+
+| Format | Description |
+|--------|-------------|
+| `markdown` | Markdown docs (simple or detailed) |
+| `curl` | One `curl` command per endpoint |
+| `postman` | Postman Collection v2.1 JSON |
+
+## Configuration
+
+Open VSCode settings and search for **APilot**, or edit `settings.json` directly:
+
+| Setting | Values | Default | Description |
+|---------|--------|---------|-------------|
+| `apilot.formatter` | `markdown`, `curl`, `postman` | `markdown` | Output format |
+| `apilot.format` | `simple`, `detailed` | `simple` | Format variant (e.g. simple or detailed markdown) |
+| `apilot.outputDestination` | `channel`, `file` | `channel` | Where to write the output |
+| `apilot.outputFile` | file path | *(empty)* | Output file path (used when `outputDestination` is `file`) |
+| `apilot.binaryPath` | file path | *(empty)* | Custom path to the apilot-cli binary (overrides the bundled binary) |
+
+### Example `settings.json`
+
+```json
+{
+  "apilot.formatter": "postman",
+  "apilot.outputDestination": "file",
+  "apilot.outputFile": "api.postman_collection.json"
+}
+```
+
+## Requirements
+
+The extension ships with a bundled `apilot` binary for macOS (Apple Silicon). On other platforms, or if you prefer to use your own build, set the `apilot.binaryPath` setting to point to the binary.
+
+To install the CLI separately:
+
+```bash
+npm install -g @tangcent/apilot
+```
+
+## License
+
+[MIT](https://github.com/tangcent/apilot/blob/master/LICENSE)

--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -2,11 +2,17 @@
   "name": "apilot",
   "displayName": "APilot",
   "description": "Export API documentation from source code — Markdown, cURL, Postman",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "publisher": "tangcent",
-  "engines": { "vscode": "^1.85.0" },
-  "categories": ["Other"],
-  "activationEvents": ["onCommand:apilot.export"],
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onCommand:apilot.export"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
@@ -17,7 +23,16 @@
     ],
     "menus": {
       "explorer/context": [
-        { "command": "apilot.export", "group": "navigation" }
+        {
+          "command": "apilot.export",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "apilot.export",
+          "group": "navigation"
+        }
       ]
     },
     "configuration": {
@@ -25,19 +40,29 @@
       "properties": {
         "apilot.formatter": {
           "type": "string",
-          "enum": ["markdown", "curl", "postman"],
+          "enum": [
+            "markdown",
+            "curl",
+            "postman"
+          ],
           "default": "markdown",
           "description": "Output format"
         },
         "apilot.format": {
           "type": "string",
-          "enum": ["simple", "detailed"],
+          "enum": [
+            "simple",
+            "detailed"
+          ],
           "default": "simple",
           "description": "Format variant (e.g. simple or detailed markdown)"
         },
         "apilot.outputDestination": {
           "type": "string",
-          "enum": ["channel", "file"],
+          "enum": [
+            "channel",
+            "file"
+          ],
           "default": "channel",
           "description": "Where to write the output"
         },
@@ -61,12 +86,12 @@
     "test": "node ./out/test/runTests.js"
   },
   "devDependencies": {
-    "@types/vscode": "^1.85.0",
-    "@types/node": "^20.0.0",
     "@types/mocha": "^10.0.0",
-    "typescript": "^5.3.0",
-    "mocha": "^10.2.0",
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
     "@vscode/test-electron": "^2.3.0",
-    "glob": "^10.3.0"
+    "glob": "^10.3.0",
+    "mocha": "^10.2.0",
+    "typescript": "^5.3.0"
   }
 }

--- a/vscode-plugin/src/extension.ts
+++ b/vscode-plugin/src/extension.ts
@@ -1,25 +1,23 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { getSettings } from './settings';
 import { runExport } from './runner';
 
 export function activate(context: vscode.ExtensionContext): void {
   const cmd = vscode.commands.registerCommand('apilot.export', async (uri?: vscode.Uri) => {
-    // Resolve source directory from right-click target or active editor
-    let sourceDir: string | undefined;
+    let sourcePath: string | undefined;
     if (uri) {
-      sourceDir = uri.fsPath;
+      sourcePath = uri.fsPath;
     } else if (vscode.window.activeTextEditor) {
-      sourceDir = path.dirname(vscode.window.activeTextEditor.document.uri.fsPath);
+      sourcePath = vscode.window.activeTextEditor.document.uri.fsPath;
     }
 
-    if (!sourceDir) {
+    if (!sourcePath) {
       vscode.window.showWarningMessage('APilot: no source file or folder selected.');
       return;
     }
 
     const settings = getSettings();
-    await runExport(sourceDir, settings);
+    await runExport(sourcePath, settings);
   });
 
   context.subscriptions.push(cmd);

--- a/vscode-plugin/src/runner.ts
+++ b/vscode-plugin/src/runner.ts
@@ -9,7 +9,7 @@ const outputChannel = vscode.window.createOutputChannel('APilot');
  * Runs apilot-cli against the given source directory and writes output
  * to the configured destination (VSCode channel or file).
  */
-export async function runExport(sourceDir: string, settings: Settings): Promise<void> {
+export async function runExport(sourcePath: string, settings: Settings): Promise<void> {
   let binary: string;
   try {
     binary = resolveBinary(settings);
@@ -22,7 +22,7 @@ export async function runExport(sourceDir: string, settings: Settings): Promise<
     'export',
     '--formatter', settings.formatter,
     '--params', JSON.stringify({ variant: settings.format }),
-    sourceDir,
+    sourcePath,
   ];
 
   if (settings.outputDestination === 'file' && settings.outputFile) {
@@ -36,6 +36,11 @@ export async function runExport(sourceDir: string, settings: Settings): Promise<
 
     proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
     proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    proc.on('error', (err: Error) => {
+      vscode.window.showErrorMessage(`APilot failed: ${err.message}`);
+      resolve();
+    });
 
     proc.on('close', (code) => {
       if (code !== 0) {

--- a/vscode-plugin/src/test/suite/extension.test.ts
+++ b/vscode-plugin/src/test/suite/extension.test.ts
@@ -3,6 +3,10 @@ import * as vscode from 'vscode';
 
 suite('extension', () => {
   test('apilot.export command is registered', async () => {
+    const ext = vscode.extensions.getExtension('tangcent.apilot');
+    if (ext && !ext.isActive) {
+      await ext.activate();
+    }
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('apilot.export'), 'apilot.export command should be registered');
   });


### PR DESCRIPTION
- Use x64 instead of amd64 to match actual release asset names
- Remove darwin-amd64 download (no such release exists)
- Map windows -> win32 for local binary naming to match VSCode extension expectations
- Add graceful error handling for failed downloads