### PR TITLE
ci: fix fork-PR workflow permissions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: 'Auto Label PR'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
 
 permissions:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Comment on target issue
         if: steps.check_issue.outputs.has_issue == 'true'
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -74,6 +75,7 @@ jobs:
 
       - name: Comment on PR
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,7 +1,7 @@
 name: Update Release PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - main
@@ -22,12 +22,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Fetch PR head
+        run: |
+          git fetch origin refs/pull/${{ github.event.pull_request.number }}/head:pr-head
+          git checkout pr-head
 
       - name: Determine release type
         id: release_type
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="$BRANCH_NAME"
           if [[ "$BRANCH" == cli-release/* ]]; then
             echo "type=cli" >> $GITHUB_OUTPUT
             echo "label=cli-release" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `PR Build and Comment` workflow is failing on fork PRs (e.g. #130 from `echo-layker/apilot`) with:

```
Resource not accessible by integration
```

**Root cause:** For PRs triggered on the `pull_request` event from a **fork**, GitHub forces the `GITHUB_TOKEN` to **read-only** regardless of the `permissions:` block. The failing run shows `Issues: read`, `PullRequests: read`, so every write step (comments, labels, PR-body updates) fails.

## Fix

Mirrors the fix already shipped in easy-yapi — [`9bbcd67`](https://github.com/tangcent/easy-yapi/commit/9bbcd67df130a7347a18cf446c64cbcc80f041d1) + [`24c004f`](https://github.com/tangcent/easy-yapi/commit/24c004f20795fadd41c6e428ce4b20b3c919c29b) — tailored per workflow depending on whether it executes PR-supplied code:

| Workflow | Change | Why |
|---|---|---|
| `pr-package.yml` | `continue-on-error` on both comment steps | Runs `go build` on PR code → **must stay on `pull_request`** (switching to `pull_request_target` + checking out PR head would run untrusted code with a write token). Build/artifact upload still runs; only the impossible-on-fork comments are skipped. |
| `auto-label.yml` | `pull_request` → `pull_request_target` | `github-script` API calls only, no PR code. Gets a write token so labels work on fork PRs. |
| `pr-release.yml` | `pull_request` → `pull_request_target`, explicit PR-head fetch, branch name moved to `env` | No build of PR code, safe to elevate. `pull_request_target` checks out the base branch by default, so fetch PR head explicitly (`pull/N/head` — `N` is a controlled integer). Branch name is attacker-controlled, so move it to `env: BRANCH_NAME` to prevent script injection. |

No source code changes — CI config only.