### PR TITLE
release: cli v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## [0.1.3] - 2026-06-23
+
+### Added
+-  enhance samples with 10+ controllers, generic bases, and complex DTOs
+-  add export dialog for per-export formatter and destination
+-  export spring mvc documentation comments
+-  add pip dependency resolver for Python site-packages model resolution (#123) (#128)
+-  resolve dependency structs from Go module cache (#122) (#127)
+-  resolve types from node_modules .d.ts files for complete API schemas (#126)
+-  add DependencyResolver (#125)
+- feat(java): wire maven-indexer-cli into TypeResolver for dependency class resolution (#124)
+-  support file-level and method-level API export (#118)
+-  per-project Postman workspace/collection binding with smart mode detection (#116)
+
+### Fixed
+-  support swagger2 api params
+-  correct archive arch/platform naming in plugin-package.sh (#129)
+
+### Improved
+- chore: normalize archived java doc spec
+- chore: archive java doc export change
+- chore: mark java doc export verified
+- chore: record java doc export verification
+- ci: fix fork-PR workflow permissions (#131)
+- doc: remove outdated research, POC results, and completed spec docs
+- chore: correct changelog line number comparison
+
+---
+
 ## [0.1.2] - 2026-04-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tangcent/apilot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Navigate your APIs. Scans source code and exports to Markdown, cURL, Postman, and more.",
   "bin": {
     "apilot": "scripts/run.js"


### PR DESCRIPTION
## CLI Release Changes

* feat: enhance samples with 10+ controllers, generic bases, and complex DTOs
* feat: add export dialog for per-export formatter and destination
* fix: support swagger2 api params
* chore: normalize archived java doc spec
* chore: archive java doc export change
* chore: mark java doc export verified
* chore: record java doc export verification
* feat: export spring mvc documentation comments
* ci: fix fork-PR workflow permissions (#131)
* fix: correct archive arch/platform naming in plugin-package.sh (#129)
* feat: add pip dependency resolver for Python site-packages model resolution (#123) (#128)
* feat: resolve dependency structs from Go module cache (#122) (#127)
* feat: resolve types from node_modules .d.ts files for complete API schemas (#126)
* feat: add DependencyResolver (#125)
* feat(java): wire maven-indexer-cli into TypeResolver for dependency class resolution (#124)
* doc: remove outdated research, POC results, and completed spec docs
* feat: support file-level and method-level API export (#118)
* feat: per-project Postman workspace/collection binding with smart mode detection (#116)
* chore: correct changelog line number comparison
